### PR TITLE
bugfix:  add pro license key to env

### DIFF
--- a/.github/workflows/lth-docker.yml
+++ b/.github/workflows/lth-docker.yml
@@ -6,6 +6,8 @@ on:
         PRO_LICENSE_KEY:
             description: 'Liquibase Pro license key'
             required: true
+env:
+  LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
 
 jobs:
   liquibase-test-harness:


### PR DESCRIPTION
liquibase pro license key is required as an env var