### PR TITLE
DAT-14457 Pro Extensions are failing to release due to build-logic bugs

### DIFF
--- a/.github/upload_asset.sh
+++ b/.github/upload_asset.sh
@@ -39,14 +39,12 @@ upload_asset() {
 
 declare -a StringArray=(".jar" ".jar.asc" ".jar.md5" ".jar.sha1" \
  ".pom" ".pom.asc" ".pom.md5" ".pom.sha1" \
- ".zip" \
  "-javadoc.jar" "-javadoc.jar.asc" "-javadoc.jar.md5" "-javadoc.jar.sha1" \
  "-sources.jar" "-sources.jar.asc" "-sources.jar.md5" "-sources.jar.sha1" )
 
 for val in "${StringArray[@]}"; do
     FILE=$ASSET_DIR/$ASSET_NAME_PREFIX$VERSION$val
-    # Skip if zip files do not exist (some extensions do not generate examples in zip format)
-    if [[ ! -f "$FILE" && "$FILE" != *".zip" ]]; then
+    if [[ ! -f "$FILE" ]]; then
         echo "$FILE does not exist."
         exit 1
     fi
@@ -58,5 +56,3 @@ for val in "${StringArray[@]}"; do
     MIME=$(file -b --mime-type $FILE)
     upload_asset $FILE $SIZE $MIME
 done
-
-

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   sonar:
-    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@v0.3.1
     secrets: inherit
               
   create-release:

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Get Reusable Script Files
         run: |
-          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/main/.github/get_draft_release.sh
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/main/.github/sign_artifact.sh
-          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/main/.github/upload_asset.sh
+          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.1/.github/get_draft_release.sh
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.1/.github/sign_artifact.sh
+          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.1/.github/upload_asset.sh
           chmod +x $PWD/.github/get_draft_release.sh
           chmod +x $PWD/.github/sign_artifact.sh
           chmod +x $PWD/.github/upload_asset.sh

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -78,5 +78,5 @@ jobs:
 
   sonar-pr:
     needs: [ unit-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.2.4
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.3.1
     secrets: inherit

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -97,5 +97,5 @@ jobs:
 
   sonar-pr:
     needs: [ unit-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.2.4
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.3.1
     secrets: inherit


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-14457

chore(upload_asset.sh): remove unnecessary check for zip files
chore(create-release.yml): update sonar-push.yml version to v0.3.1
chore(extension-attach-artifact-release.yml): update build-logic version to v0.3.1
chore(os-extension-test.yml): update sonar-pull-request.yml version to v0.3.1
chore(pro-extension-test.yml): update sonar-pull-request.yml version to v0.3.1