### PR TITLE
Update lth-docker.yml to not require pro license key

### DIFF
--- a/.github/workflows/lth-docker.yml
+++ b/.github/workflows/lth-docker.yml
@@ -5,7 +5,7 @@ on:
     secrets:
         PRO_LICENSE_KEY:
             description: 'Liquibase Pro license key'
-            required: true
+            required: false
 env:
   LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
 


### PR DESCRIPTION
do not require a pro license key