### PR TITLE
fix(postinst): check if LIQUIBASE_HOME is already in PATH before addi…

### DIFF
--- a/src/liquibase/deb/control/postinst
+++ b/src/liquibase/deb/control/postinst
@@ -12,9 +12,13 @@ for user_home in /home/*; do
         # Check if the .profile file exists for the user
         if [ -f "$profile_file" ]; then
             echo "Adding LIQUIBASE_HOME to .profile for user: $user"
-            echo "export LIQUIBASE_HOME=$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
-            echo "export PATH=\$PATH:\$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
-            . "$profile_file"
+            if grep -q "$LIQUIBASE_HOME" "$profile_file"; then
+                echo "LIQUIBASE_HOME already in PATH for user: $user"
+            else
+                echo "export LIQUIBASE_HOME=$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
+                echo "export PATH=\$PATH:\$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
+                . "$profile_file"
+            fi
         else
             echo "No .profile found for user: $user"
         fi


### PR DESCRIPTION
…ng it to .profile file to avoid duplication

The changes were made to the postinst file in the src/liquibase/deb/control directory. The script checks if the LIQUIBASE_HOME environment variable is already present in the .profile file for each user's home directory. If it is not present, the script adds the LIQUIBASE_HOME variable and appends it to the PATH variable in the .profile file. This change was made to prevent duplication of the LIQUIBASE_HOME variable in the .profile file.