### PR TITLE
DAT-15708 Incorrect Installation Path for Liquibase APT Package on Github Action Runners

### DIFF
--- a/.github/package-deb-pom.xml
+++ b/.github/package-deb-pom.xml
@@ -56,7 +56,7 @@
 							<type>directory</type>
 							<mapper>
 								<type>perm</type>
-								<prefix>/opt/liquibase</prefix>
+								<prefix>/usr/bin</prefix>
 								<filemode>755</filemode>
 							</mapper>
 						</data>

--- a/src/liquibase/deb/control/postinst
+++ b/src/liquibase/deb/control/postinst
@@ -1,26 +1,4 @@
 #!/bin/bash
 
 # Define LIQUIBASE_HOME
-LIQUIBASE_HOME="/opt/liquibase"
-
-# Iterate through all user home directories
-for user_home in /home/*; do
-    if [ -d "$user_home" ]; then
-        user=$(basename "$user_home")
-        profile_file="$user_home/.profile"
-        
-        # Check if the .profile file exists for the user
-        if [ -f "$profile_file" ]; then
-            echo "Adding LIQUIBASE_HOME to .profile for user: $user"
-            if grep -q "$LIQUIBASE_HOME" "$profile_file"; then
-                echo "LIQUIBASE_HOME already in PATH for user: $user"
-            else
-                echo "export LIQUIBASE_HOME=$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
-                echo "export PATH=\$PATH:\$LIQUIBASE_HOME" | sudo tee -a "$profile_file"
-                . "$profile_file"
-            fi
-        else
-            echo "No .profile found for user: $user"
-        fi
-    fi
-done
+LIQUIBASE_HOME="/usr/bin"

--- a/src/liquibase/deb/control/postrm
+++ b/src/liquibase/deb/control/postrm
@@ -1,22 +1,5 @@
 #!/bin/bash
 
-# Define LIQUIBASE_HOME
-LIQUIBASE_HOME="/opt/liquibase"
+# unset LIQUIBASE_HOME
+unset LIQUIBASE_HOME
 
-# Iterate through all user home directories
-for user_home in /home/*; do
-    if [ -d "$user_home" ]; then
-        user=$(basename "$user_home")
-        profile_file="$user_home/.profile"
-        
-        # Check if the .profile file exists for the user
-        if [ -f "$profile_file" ]; then
-            echo "Removing LIQUIBASE_HOME from .profile for user: $user"
-            sed -i '/LIQUIBASE_HOME=/d' "$profile_file"
-            sed -i '/export PATH=\$PATH:\$LIQUIBASE_HOME/d' "$profile_file"
-            . "$profile_file"
-        else
-            echo "No .profile found for user: $user"
-        fi
-    fi
-done


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-15708

- refactor(package-deb-pom.xml): update prefix in mapper to /usr/bin for better installation location
- refactor(postinst): update LIQUIBASE_HOME to /usr/bin for better installation location and remove unnecessary code for updating user profiles
- refactor(postrm): unset LIQUIBASE_HOME and remove unnecessary code for updating user profiles