### PR TITLE
DAT-15783 DevOps :: run nightly builds for extensions against core master-snapshot

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ on:
   
 jobs:
   sonar:
-    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@v0.3.9
+    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@v0.4.1
     secrets: inherit
               
   create-release:

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -31,9 +31,9 @@ jobs:
 
       - name: Get Reusable Script Files
         run: |
-          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/.github/get_draft_release.sh
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/.github/sign_artifact.sh
-          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/.github/upload_asset.sh
+          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/.github/get_draft_release.sh
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/.github/sign_artifact.sh
+          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/.github/upload_asset.sh
           chmod +x $PWD/.github/get_draft_release.sh
           chmod +x $PWD/.github/sign_artifact.sh
           chmod +x $PWD/.github/upload_asset.sh

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -68,5 +68,5 @@ jobs:
 
   maven-release:
     needs: release
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.3.9
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.4.1
     secrets: inherit

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -89,5 +89,5 @@ jobs:
 
   sonar-pr:
     needs: [ unit-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.3.9
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.4.1
     secrets: inherit

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -54,10 +54,10 @@ jobs:
             # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
             mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
             mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/src/${{ inputs.artifactId }}/deb/control/control
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/src/${{ inputs.artifactId }}/deb/control/postinst
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-            curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.3.9/.github/package-deb-pom.xml
+            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/src/${{ inputs.artifactId }}/deb/control/control
+            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/src/${{ inputs.artifactId }}/deb/control/postinst
+            curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+            curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.4.1/.github/package-deb-pom.xml
 
         - name: Set up Maven
           uses: stCarolas/setup-maven@v4.5

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -14,7 +14,7 @@ on:
         default: '["ubuntu-latest", "windows-latest"]'
         type: string
       nigthly:
-        description: 'Specifies a nightly build against liquibase master-SNAPSHOT'
+        description: 'Specifies nightly builds against liquibase master-SNAPSHOT'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: '["ubuntu-latest", "windows-latest"]'
         type: string
+      nigthly:
+        description: 'Specifies a nightly build agains liquibase master-SNAPSHOT'
+        required: false
+        default: false
+        type: boolean
     secrets:
       SONAR_TOKEN:
         description: 'SONAR_TOKEN from the caller workflow'
@@ -47,6 +52,10 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: Set latest liquibase version
+        if: ${{ inputs.nigthly }} 
+        run: mvn versions:set-property -Dproperty=liquibase.version -DnewVersion=master-SNAPSHOT
 
       - name: Build and Package
         run: mvn -B dependency:go-offline clean package -DskipTests=true
@@ -109,5 +118,5 @@ jobs:
 
   sonar-pr:
     needs: [ unit-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.3.9
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.4.1
     secrets: inherit

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -14,7 +14,7 @@ on:
         default: '["ubuntu-latest", "windows-latest"]'
         type: string
       nigthly:
-        description: 'Specifies a nightly build agains liquibase master-SNAPSHOT'
+        description: 'Specifies a nightly build against liquibase master-SNAPSHOT'
         required: false
         default: false
         type: boolean


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-15783

chore(create-release.yml): update sonar-push.yml version to v0.4.1 for improved functionality
chore(extension-attach-artifact-release.yml): update script file versions to v0.4.1 for improved functionality
chore(extension-release-published.yml): update extension-release-prepare.yml version to v0.4.1 for improved functionality
chore(os-extension-test.yml): update sonar-pull-request.yml version to v0.4.1 for improved functionality
chore(package-deb.yml): update build-logic versions to v0.4.1 for improved functionality
chore(pro-extension-test.yml): set latest liquibase version to master-SNAPSHOT if nightly build is specified