### PR TITLE
adding workflow_dispatch to test ci-reports

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test-report:


### PR DESCRIPTION
Need to test the installation of liquibase-sdk-maven plugin for the failures encountered in ci-report generation :https://github.com/liquibase/build-logic/actions/runs/6276419011