### PR TITLE
java version 17 for sonar-test-scan

### DIFF
--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
           overwrite-settings: false


### PR DESCRIPTION
fix: java version 17 for sonar-test-scan

Got a warning from SonarScan and a message from [Slack](https://liquibase.slack.com/archives/C53DX4S4W/p1696351856930289)
Warning: The last analysis has a warning.[See details](https://sonarcloud.io/project/issues)