### PR TITLE
DAT-15655 Release-drafter for extensions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+
+name-template: 'Liquibase v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skipReleaseNotes'
+categories:
+  - title: ':green_book: Notable Changes'
+    labels: 
+      - 'notableChanges'
+  - title: '🚀 New Features'
+    labels:
+      - 'TypeEnhancement'
+      - 'TypeTest'
+  - title: '🐛 Bug Fixes 🛠'
+    labels:
+      - 'TypeBug'
+  - title: '💥 Breaking Changes'
+    labels: 
+      - 'breakingChanges'
+  - title: '💥 API Breaking Changes'
+    labels: 
+      - 'APIBreakingChanges'
+  - title: '🤖 Security Driver and Other Updates'
+    collapse-after: 5
+    labels:
+      - 'sdou'
+      - 'dependencies'
+  - title: '👏 New Contributors'
+    labels:
+      - 'newContributors'
+       
+  
+change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'patch'
+      - 'bugfix'
+      - 'sdou'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$REPOSITORY-$RESOLVED_VERSION


### PR DESCRIPTION
feat(release-drafter.yml): add configuration file for release drafter

The release-drafter.yml file is added to the .github directory. This file contains the configuration for the release drafter tool. It specifies the name and tag templates for the releases, as well as the categories for the release notes. The categories include notable changes, new features, bug fixes, breaking changes, API breaking changes, security driver and other updates, and new contributors. The change template is also defined to format the individual changes in the release notes. The version resolver is set up to determine the release type based on labels. Finally, a template is provided to format the full changelog with links to the GitHub repository.