### PR TITLE
chore(workflows): update test report paths in GitHub workflows

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -171,7 +171,7 @@ jobs:
           name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
           path: |
             **/target/surefire-reports
-            **/target/jacoco.exec
+            **/target/site/jacoco/jacoco.xml
 
   sonar-pr:
     needs: [ unit-test ]

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -232,7 +232,7 @@ jobs:
           name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
           path: |
             **/target/surefire-reports
-            **/target/jacoco.exec
+            **/target/site/jacoco/jacoco.xml
 
   sonar-pr:
     needs: [ unit-test ]

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           github_token: ${{secrets.BOT_TOKEN}}
           workflow: test.yml
-          name: ${{ env.artifact_id }}-artifacts
+          name: test-reports-jdk-17-ubuntu-latest
           repo: ${{ github.repository }}
           path: ./target
           if_no_artifact_found: warn

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           github_token: ${{secrets.BOT_TOKEN}}
           workflow: test.yml
-          name: ${{ env.artifact_id }}-artifacts
+          name: test-reports-jdk-17-ubuntu-latest
           repo: ${{ github.repository }}
           path: ./target
           if_no_artifact_found: warn


### PR DESCRIPTION
- In os-extension-test.yml and pro-extension-test.yml, change the path for jacoco.xml from **/target/jacoco.exec to **/target/site/jacoco/jacoco.xml. This is done to correctly locate the Jacoco code coverage report.
- In sonar-pull-request.yml and sonar-push.yml, update the name of the test report artifact to test-reports-jdk-17-ubuntu-latest. This is done to ensure consistency in the naming of the test report artifacts across workflows.