### PR TITLE
DAT-16593 Downgrade upload/download artifacts for extensions

### DIFF
--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Save Release files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: release-files
           path: |

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Download release files
         id: download-release-files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: release-files
 

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -195,7 +195,7 @@ jobs:
           
 
     - name: Archive published_drafts.txt
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: published_drafts
         path: published_drafts.txt
@@ -242,7 +242,7 @@ jobs:
           done
 
       - name: Archive closed_nexus_repos.txt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: closed_nexus_repos
           path: closed_nexus_repos.txt

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -126,14 +126,14 @@ jobs:
         run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts
           path: |
             target/*
 
       - name: Save Event File
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -165,7 +165,7 @@ jobs:
         with:
           maven-version: ${{ env.MAVEN_VERSION }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ${{needs.build.outputs.artifact_id}}-artifacts
           path: ./target
@@ -193,7 +193,7 @@ jobs:
 
       - name: Archive Test Results - ${{ matrix.os }}
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
           path: |

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -143,14 +143,14 @@ jobs:
         run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts
           path: |
             target/*
 
       - name: Save Event File
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -225,7 +225,7 @@ jobs:
               }
             ]
             
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ${{needs.build.outputs.artifact_id}}-artifacts
           path: ./target
@@ -253,7 +253,7 @@ jobs:
 
       - name: Archive Test Results - ${{ matrix.os }}
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
           path: |

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -95,7 +95,7 @@ jobs:
         run: echo "artifact_id=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Download unit tests report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: test-reports-jdk-17-ubuntu-latest
 

--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -121,70 +121,70 @@ jobs:
             ]
 
       - name: Download unit tests report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-jacoco-test-results
           path: ${{ inputs.sonarRootPath }}/unit-tests
 
       - name: Download mssql integration tests report
         if: contains(inputs.dbPlatforms, 'mssql')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
             name: liquibase-integration-jacoco-test-results-mssql
             path: ${{ inputs.sonarRootPath }}/integration-tests/mssql
 
       - name: Download mysql integration tests report
         if: contains(inputs.dbPlatforms, 'mysql')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
             name: liquibase-integration-jacoco-test-results-mysql
             path: ${{ inputs.sonarRootPath }}/integration-tests/mysql
 
       - name: Download oracle integration tests report
         if: contains(inputs.dbPlatforms, 'oracle')
-        uses: actions/download-artifact@v4        
+        uses: actions/download-artifact@v3     
         with:
           name: liquibase-integration-jacoco-test-results-oracle
           path: ${{ inputs.sonarRootPath }}/integration-tests/oracle
 
       - name: Download postgresql integration tests report
         if: contains(inputs.dbPlatforms, 'postgresql')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-postgresql
           path: ${{ inputs.sonarRootPath }}/integration-tests/postgresql
 
       - name: Download h2 integration tests report
         if: contains(inputs.dbPlatforms, 'h2')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-h2
           path: ${{ inputs.sonarRootPath }}/integration-tests/h2
 
       - name: Download hsqldb integration tests report
         if: contains(inputs.dbPlatforms, 'hsqldb')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-hsqldb
           path: ${{ inputs.sonarRootPath }}/integration-tests/hsqldb
 
       - name: Download mariadb integration tests report
         if: contains(inputs.dbPlatforms, 'mariadb')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-mariadb
           path: ${{ inputs.sonarRootPath }}/integration-tests/mariadb
 
       - name: Download sqlite integration tests report
         if: contains(inputs.dbPlatforms, 'sqlite')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-sqlite
           path: ${{ inputs.sonarRootPath }}/integration-tests/sqlite
 
       - name: Download firebird integration tests report
         if: contains(inputs.dbPlatforms, 'firebird')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: liquibase-integration-jacoco-test-results-firebird
           path: ${{ inputs.sonarRootPath }}/integration-tests/firebird


### PR DESCRIPTION
chore(workflows): update actions/upload-artifact and actions/download-artifact versions to v3

The actions/upload-artifact and actions/download-artifact versions have been updated from v4 to v3 in the following workflow files:
- .github/workflows/extension-release-prepare.yml
- .github/workflows/extension-release-rollback.yml
- .github/workflows/os-extension-automated-release.yml
- .github/workflows/os-extension-test.yml
- .github/workflows/pro-extension-test.yml
- .github/workflows/sonar-pull-request.yml
- .github/workflows/sonar-test-scan.yml

This update was done to ensure compatibility with the latest versions of the actions and to take advantage of any bug fixes or improvements introduced in the new versions.