### PR TITLE
DAT-11513      DevOps :: Enable OIDC for Github / AWS Integration

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -39,6 +39,9 @@ jobs:
   upload_packages:
       name: Upload ${{ inputs.artifactId }} linux packages
       runs-on: ubuntu-22.04
+      permissions:
+        id-token: write
+        contents: read
       steps:
         - uses: actions/checkout@v4
 
@@ -81,8 +84,7 @@ jobs:
         - name: Configure AWS credentials
           uses: aws-actions/configure-aws-credentials@v4
           with:
-            aws-access-key-id: ${{ secrets.AWS_PROD_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.AWS_PROD_SECRET_ACCESS_KEY }}
+            role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
             aws-region: us-east-1
 
         - name: Download ${{ inputs.artifactId }} Release


### PR DESCRIPTION
fix(package-linux.yml): update AWS credentials configuration to use GitHub OIDC role for improved security

feat(package-linux.yml): add permissions for id-token and contents to allow write access and read access respectively