### PR TITLE
DAT-16972 SDKMAN Distribution

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,7 +11,7 @@ on:
   
 jobs:
   sonar:
-    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@v0.6.6
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -84,9 +84,9 @@ jobs:
             
       - name: Get Reusable Script Files
         run: |
-          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.5/.github/get_draft_release.sh
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.5/.github/sign_artifact.sh
-          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.5/.github/upload_asset.sh
+          curl -o $PWD/.github/get_draft_release.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.6/.github/get_draft_release.sh
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.6/.github/sign_artifact.sh
+          curl -o $PWD/.github/upload_asset.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.6/.github/upload_asset.sh
           chmod +x $PWD/.github/get_draft_release.sh
           chmod +x $PWD/.github/sign_artifact.sh
           chmod +x $PWD/.github/upload_asset.sh
@@ -175,7 +175,7 @@ jobs:
       - name: Get upload_zip.sh Script File
         if: inputs.zip == 'true'
         run: |
-          curl -o $PWD/.github/upload_zip.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.5/.github/upload_zip.sh
+          curl -o $PWD/.github/upload_zip.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.6/.github/upload_zip.sh
           chmod +x $PWD/.github/upload_zip.sh
   
       - name: Attach Zip File to Draft Release

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -107,7 +107,7 @@ jobs:
   release-rollback:
     needs: prepare-release
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@v0.6.6
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   maven-release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.6.6
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -251,7 +251,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.6.6
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,147 +3,156 @@ on:
   workflow_call:
     inputs:
       groupId:
-        description: 'Value from the groupId field in pom.xml. i.e. org.liquibase'
+        description: "Value from the groupId field in pom.xml. i.e. org.liquibase"
         required: true
         type: string
       artifactId:
-        description: 'Value from the artifactId field in pom.xml. i.e. liquibase'
+        description: "Value from the artifactId field in pom.xml. i.e. liquibase"
         required: true
         type: string
       version:
-        description: 'Value from the version field in pom.xml. i.e 4.23.0'
+        description: "Value from the version field in pom.xml. i.e 4.23.0"
         type: string
     secrets:
       GPG_SECRET:
-        description: 'GPG_SECRET from the caller workflow'
+        description: "GPG_SECRET from the caller workflow"
         required: true
       GPG_PASSPHRASE:
-        description: 'GPG_PASSPHRASE from the caller workflow'
+        description: "GPG_PASSPHRASE from the caller workflow"
         required: true
       GPG_SECRET_KEY_ID:
-        description: 'GPG_SECRET_KEY_ID from the caller workflow'
+        description: "GPG_SECRET_KEY_ID from the caller workflow"
         required: true
 
 env:
-  MAVEN_VERSION: '3.9.5'
+  MAVEN_VERSION: "3.9.5"
 
 jobs:
+  upload_packages:
+    name: Upload ${{ inputs.artifactId }} packages
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
 
-  upload_linux_packages:
-      name: Upload ${{ inputs.artifactId }} linux packages
-      runs-on: ubuntu-22.04
-      permissions:
-        id-token: write
-        contents: read
-      steps:
-        - uses: actions/checkout@v4
+      # - name: Set up Java
+      #   uses: actions/setup-java@v4
+      #   with:
+      #     java-version: "17"
+      #     distribution: "temurin"
+      #     cache: "maven"
 
-        - name: Set up Java
-          uses: actions/setup-java@v4
-          with:
-            java-version: '17'
-            distribution: 'temurin'
-            cache: 'maven'
+      # - name: Set up Maven
+      #   uses: stCarolas/setup-maven@v4.5
+      #   with:
+      #     maven-version: ${{ env.MAVEN_VERSION }}
 
-        - name: Set up Maven
-          uses: stCarolas/setup-maven@v4.5
-          with:
-            maven-version: ${{ env.MAVEN_VERSION }}
+      # - name: Set up Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: 3.1.4
 
-        - name: Set up Ruby
-          uses: ruby/setup-ruby@v1
-          with:
-            ruby-version: 3.1.4
+      # - name: Get Reusable Files
+      #   run: |
+      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+      #     chmod +x $PWD/.github/sign_artifact.sh
 
-        - name: Get Reusable Files
-          run: |
-            # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-            mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-            mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-            curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-            curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-            curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-            chmod +x $PWD/.github/sign_artifact.sh
+      # - name: Import GPG key
+      #   id: import_gpg
+      #   uses: crazy-max/ghaction-import-gpg@v6
+      #   with:
+      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
+      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-        - name: Import GPG key
-          id: import_gpg
-          uses: crazy-max/ghaction-import-gpg@v6
-          with:
-            gpg_private_key: ${{ secrets.GPG_SECRET }}
-            passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+      #     aws-region: us-east-1
 
-        - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-            aws-region: us-east-1
+      # - name: Download ${{ inputs.artifactId }} Release
+      #   run: |
+      #     mkdir -p $PWD/.github/target
+      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-        - name: Download ${{ inputs.artifactId }} Release
-          run: |
-            mkdir -p $PWD/.github/target
-            # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-            wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      # - name: Build ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-        - name: Build ${{ inputs.artifactId }} deb package
-          run: |
-            mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      # - name: Install deb-s3 gem
+      #   run: gem install deb-s3
 
-        - name: Install deb-s3 gem
-          run: gem install deb-s3
+      # - name: Upload ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     sudo apt install pinentry-tty
+      #     echo "2" | sudo update-alternatives --config pinentry
+      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+      #     export GPG_TTY=$(tty)
+      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-        - name: Upload ${{ inputs.artifactId }} deb package
-          run: |
-            sudo apt install pinentry-tty
-            echo "2" | sudo update-alternatives --config pinentry
-            echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-            export GPG_TTY=$(tty)
-            echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-            deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Convert deb to rpm
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y alien
+      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-        - name: Convert deb to rpm
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y alien
-            sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Upload ${{ inputs.artifactId }} rpm package
+      #   run: |
+      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+      #     mkdir createrepo_folder
+      #     cd createrepo_folder
+      #     git clone https://github.com/rpm-software-management/createrepo_c
+      #     cd createrepo_c
+      #     mkdir build
+      #     cd build
+      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+      #     make -j
+      #     cp src/createrepo_c  /opt/createrepo
+      #     cd ../../..
+      #     mkdir -p $PWD/yum/noarch
+      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+      #     /opt/createrepo -h
+      #     /opt/createrepo -dp $PWD/yum/noarch
+      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-        - name: Upload ${{ inputs.artifactId }} rpm package
-          run: |
-            sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-            ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-            mkdir createrepo_folder
-            cd createrepo_folder
-            git clone https://github.com/rpm-software-management/createrepo_c
-            cd createrepo_c
-            mkdir build
-            cd build
-            cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-            make -j
-            cp src/createrepo_c  /opt/createrepo
-            cd ../../..
-            mkdir -p $PWD/yum/noarch
-            aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-            /opt/createrepo -h
-            /opt/createrepo -dp $PWD/yum/noarch
-            ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-            mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-            aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   # Will set the following for the first time, then we can the line
+      #   continue-on-error: true
+      #   with:
+      #     token: ${{ secrets.BOT_TOKEN }}
+      #     no_fork: true
+      #     formula: liquibase
+      #     tag: "${{ github.event.release.tag_name }}"
+      #     force: true
 
-        - name: Update Homebrew formula for ${{ inputs.artifactId }}
-          uses: dawidd6/action-homebrew-bump-formula@v3
-          # Will set the following for the first time, then we can the line
-          continue-on-error: true
-          with:
-            token: ${{ secrets.BOT_TOKEN }}
-            no_fork: true
-            formula: liquibase
-            tag: "${{ github.event.release.tag_name }}"
-            force: true
+      - name: Update SDKMAN version for ${{ inputs.artifactId }}
+        run: |
+          wget https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
+          mkdir -p liquibase-${{ inputs.version }}/bin/internal
+          unzip liquibase-${{ inputs.version }}.zip
+          mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
+          mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
+          cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
+          ls -ltr
+          # TODO sendzip to sdkman
 
-  upload_windows_package:
-    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
-          
+  # upload_windows_package:
+  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+  #   secrets: inherit
+  #   with:
+  #     version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Set up Java
-      #   uses: actions/setup-java@v4
-      #   with:
-      #     java-version: "17"
-      #     distribution: "temurin"
-      #     cache: "maven"
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
-      # - name: Set up Maven
-      #   uses: stCarolas/setup-maven@v4.5
-      #   with:
-      #     maven-version: ${{ env.MAVEN_VERSION }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
 
-      # - name: Set up Ruby
-      #   uses: ruby/setup-ruby@v1
-      #   with:
-      #     ruby-version: 3.1.4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.4
 
-      # - name: Get Reusable Files
-      #   run: |
-      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-      #     chmod +x $PWD/.github/sign_artifact.sh
+      - name: Get Reusable Files
+        run: |
+          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+          chmod +x $PWD/.github/sign_artifact.sh
 
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: crazy-max/ghaction-import-gpg@v6
-      #   with:
-      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
-      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_SECRET }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+          aws-region: us-east-1
 
-      # - name: Download ${{ inputs.artifactId }} Release
-      #   run: |
-      #     mkdir -p $PWD/.github/target
-      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      - name: Download ${{ inputs.artifactId }} Release
+        run: |
+          mkdir -p $PWD/.github/target
+          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      # - name: Build ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      - name: Build ${{ inputs.artifactId }} deb package
+        run: |
+          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      # - name: Install deb-s3 gem
-      #   run: gem install deb-s3
+      - name: Install deb-s3 gem
+        run: gem install deb-s3
 
-      # - name: Upload ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     sudo apt install pinentry-tty
-      #     echo "2" | sudo update-alternatives --config pinentry
-      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-      #     export GPG_TTY=$(tty)
-      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Upload ${{ inputs.artifactId }} deb package
+        run: |
+          sudo apt install pinentry-tty
+          echo "2" | sudo update-alternatives --config pinentry
+          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+          export GPG_TTY=$(tty)
+          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Convert deb to rpm
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y alien
-      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Convert deb to rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alien
+          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Upload ${{ inputs.artifactId }} rpm package
-      #   run: |
-      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-      #     mkdir createrepo_folder
-      #     cd createrepo_folder
-      #     git clone https://github.com/rpm-software-management/createrepo_c
-      #     cd createrepo_c
-      #     mkdir build
-      #     cd build
-      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-      #     make -j
-      #     cp src/createrepo_c  /opt/createrepo
-      #     cd ../../..
-      #     mkdir -p $PWD/yum/noarch
-      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-      #     /opt/createrepo -h
-      #     /opt/createrepo -dp $PWD/yum/noarch
-      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      - name: Upload ${{ inputs.artifactId }} rpm package
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          mkdir createrepo_folder
+          cd createrepo_folder
+          git clone https://github.com/rpm-software-management/createrepo_c
+          cd createrepo_c
+          mkdir build
+          cd build
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          make -j
+          cp src/createrepo_c  /opt/createrepo
+          cd ../../..
+          mkdir -p $PWD/yum/noarch
+          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+          /opt/createrepo -h
+          /opt/createrepo -dp $PWD/yum/noarch
+          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   # Will set the following for the first time, then we can the line
-      #   continue-on-error: true
-      #   with:
-      #     token: ${{ secrets.BOT_TOKEN }}
-      #     no_fork: true
-      #     formula: liquibase
-      #     tag: "${{ github.event.release.tag_name }}"
-      #     force: true
+      - name: Update Homebrew formula for ${{ inputs.artifactId }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        # Will set the following for the first time, then we can the line
+        continue-on-error: true
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          no_fork: true
+          formula: liquibase
+          tag: "${{ github.event.release.tag_name }}"
+          force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -188,9 +188,8 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-
-  # upload_windows_package:
-  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-  #   secrets: inherit
-  #   with:
-  #     version: ${{ inputs.version }}
+  upload_windows_package:
+    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -154,7 +154,7 @@ jobs:
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -v -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
+          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  https://artifactory.datical.net/artifactory/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
 
 
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "maven"
+      # - name: Set up Java
+      #   uses: actions/setup-java@v4
+      #   with:
+      #     java-version: "17"
+      #     distribution: "temurin"
+      #     cache: "maven"
 
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: ${{ env.MAVEN_VERSION }}
+      # - name: Set up Maven
+      #   uses: stCarolas/setup-maven@v4.5
+      #   with:
+      #     maven-version: ${{ env.MAVEN_VERSION }}
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1.4
+      # - name: Set up Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: 3.1.4
 
-      - name: Get Reusable Files
-        run: |
-          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-          chmod +x $PWD/.github/sign_artifact.sh
+      # - name: Get Reusable Files
+      #   run: |
+      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+      #     chmod +x $PWD/.github/sign_artifact.sh
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # - name: Import GPG key
+      #   id: import_gpg
+      #   uses: crazy-max/ghaction-import-gpg@v6
+      #   with:
+      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
+      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-          aws-region: us-east-1
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+      #     aws-region: us-east-1
 
-      - name: Download ${{ inputs.artifactId }} Release
-        run: |
-          mkdir -p $PWD/.github/target
-          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      # - name: Download ${{ inputs.artifactId }} Release
+      #   run: |
+      #     mkdir -p $PWD/.github/target
+      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      - name: Build ${{ inputs.artifactId }} deb package
-        run: |
-          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      # - name: Build ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      - name: Install deb-s3 gem
-        run: gem install deb-s3
+      # - name: Install deb-s3 gem
+      #   run: gem install deb-s3
 
-      - name: Upload ${{ inputs.artifactId }} deb package
-        run: |
-          sudo apt install pinentry-tty
-          echo "2" | sudo update-alternatives --config pinentry
-          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-          export GPG_TTY=$(tty)
-          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Upload ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     sudo apt install pinentry-tty
+      #     echo "2" | sudo update-alternatives --config pinentry
+      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+      #     export GPG_TTY=$(tty)
+      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Convert deb to rpm
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y alien
-          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Convert deb to rpm
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y alien
+      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Upload ${{ inputs.artifactId }} rpm package
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-          mkdir createrepo_folder
-          cd createrepo_folder
-          git clone https://github.com/rpm-software-management/createrepo_c
-          cd createrepo_c
-          mkdir build
-          cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-          make -j
-          cp src/createrepo_c  /opt/createrepo
-          cd ../../..
-          mkdir -p $PWD/yum/noarch
-          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-          /opt/createrepo -h
-          /opt/createrepo -dp $PWD/yum/noarch
-          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      # - name: Upload ${{ inputs.artifactId }} rpm package
+      #   run: |
+      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+      #     mkdir createrepo_folder
+      #     cd createrepo_folder
+      #     git clone https://github.com/rpm-software-management/createrepo_c
+      #     cd createrepo_c
+      #     mkdir build
+      #     cd build
+      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+      #     make -j
+      #     cp src/createrepo_c  /opt/createrepo
+      #     cd ../../..
+      #     mkdir -p $PWD/yum/noarch
+      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+      #     /opt/createrepo -h
+      #     /opt/createrepo -dp $PWD/yum/noarch
+      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      - name: Update Homebrew formula for ${{ inputs.artifactId }}
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        # Will set the following for the first time, then we can the line
-        continue-on-error: true
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          no_fork: true
-          formula: liquibase
-          tag: "${{ github.event.release.tag_name }}"
-          force: true
+      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   # Will set the following for the first time, then we can the line
+      #   continue-on-error: true
+      #   with:
+      #     token: ${{ secrets.BOT_TOKEN }}
+      #     no_fork: true
+      #     formula: liquibase
+      #     tag: "${{ github.event.release.tag_name }}"
+      #     force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -154,34 +154,11 @@ jobs:
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           # Upload the release to Artifactory
           curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
-          # Send the release to SDKMAN
-          curl -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.6.zip"}' \
-          https://vendors.sdkman.io/release
-          # Set the default version for SDKMAN
-          curl -X PUT \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
-          https://vendors.sdkman.io/default
-          # Announce the release to SDKMAN
-          curl -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
-          https://vendors.sdkman.io/announce/struct
 
 
-  upload_windows_package:
-    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
+
+  # upload_windows_package:
+  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+  #   secrets: inherit
+  #   with:
+  #     version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -142,9 +142,10 @@ jobs:
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         run: |
-          wget https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
+          wget -q https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
           mkdir -p liquibase-${{ inputs.version }}/bin/internal
           unzip liquibase-${{ inputs.version }}.zip
+          ls -ltr
           mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -153,7 +153,7 @@ jobs:
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           # Upload the release to Artifactory
-          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL
+          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
           # Send the release to SDKMAN
           curl -X POST \
           -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Set up Java
-      #   uses: actions/setup-java@v4
-      #   with:
-      #     java-version: "17"
-      #     distribution: "temurin"
-      #     cache: "maven"
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
-      # - name: Set up Maven
-      #   uses: stCarolas/setup-maven@v4.5
-      #   with:
-      #     maven-version: ${{ env.MAVEN_VERSION }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
 
-      # - name: Set up Ruby
-      #   uses: ruby/setup-ruby@v1
-      #   with:
-      #     ruby-version: 3.1.4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.4
 
-      # - name: Get Reusable Files
-      #   run: |
-      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-      #     chmod +x $PWD/.github/sign_artifact.sh
+      - name: Get Reusable Files
+        run: |
+          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+          chmod +x $PWD/.github/sign_artifact.sh
 
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: crazy-max/ghaction-import-gpg@v6
-      #   with:
-      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
-      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_SECRET }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+          aws-region: us-east-1
 
-      # - name: Download ${{ inputs.artifactId }} Release
-      #   run: |
-      #     mkdir -p $PWD/.github/target
-      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      - name: Download ${{ inputs.artifactId }} Release
+        run: |
+          mkdir -p $PWD/.github/target
+          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      # - name: Build ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      - name: Build ${{ inputs.artifactId }} deb package
+        run: |
+          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      # - name: Install deb-s3 gem
-      #   run: gem install deb-s3
+      - name: Install deb-s3 gem
+        run: gem install deb-s3
 
-      # - name: Upload ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     sudo apt install pinentry-tty
-      #     echo "2" | sudo update-alternatives --config pinentry
-      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-      #     export GPG_TTY=$(tty)
-      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Upload ${{ inputs.artifactId }} deb package
+        run: |
+          sudo apt install pinentry-tty
+          echo "2" | sudo update-alternatives --config pinentry
+          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+          export GPG_TTY=$(tty)
+          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Convert deb to rpm
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y alien
-      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Convert deb to rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alien
+          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Upload ${{ inputs.artifactId }} rpm package
-      #   run: |
-      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-      #     mkdir createrepo_folder
-      #     cd createrepo_folder
-      #     git clone https://github.com/rpm-software-management/createrepo_c
-      #     cd createrepo_c
-      #     mkdir build
-      #     cd build
-      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-      #     make -j
-      #     cp src/createrepo_c  /opt/createrepo
-      #     cd ../../..
-      #     mkdir -p $PWD/yum/noarch
-      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-      #     /opt/createrepo -h
-      #     /opt/createrepo -dp $PWD/yum/noarch
-      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      - name: Upload ${{ inputs.artifactId }} rpm package
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          mkdir createrepo_folder
+          cd createrepo_folder
+          git clone https://github.com/rpm-software-management/createrepo_c
+          cd createrepo_c
+          mkdir build
+          cd build
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          make -j
+          cp src/createrepo_c  /opt/createrepo
+          cd ../../..
+          mkdir -p $PWD/yum/noarch
+          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+          /opt/createrepo -h
+          /opt/createrepo -dp $PWD/yum/noarch
+          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   # Will set the following for the first time, then we can the line
-      #   continue-on-error: true
-      #   with:
-      #     token: ${{ secrets.BOT_TOKEN }}
-      #     no_fork: true
-      #     formula: liquibase
-      #     tag: "${{ github.event.release.tag_name }}"
-      #     force: true
+      - name: Update Homebrew formula for ${{ inputs.artifactId }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        # Will set the following for the first time, then we can the line
+        continue-on-error: true
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          no_fork: true
+          formula: liquibase
+          tag: "${{ github.event.release.tag_name }}"
+          force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         run: |
@@ -148,11 +148,10 @@ jobs:
           mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
-          ls -ltr
-          # TODO sendzip to sdkman
+          # TODO send zip to sdkman
 
-  # upload_windows_package:
-  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-  #   secrets: inherit
-  #   with:
-  #     version: ${{ inputs.version }}
+  upload_windows_package:
+    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -160,7 +160,7 @@ jobs:
           # Upload the release to Artifactory
           curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
           # Send the release to SDKMAN
-          curl -v -X POST \
+          curl -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -179,7 +179,15 @@ jobs:
           -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
           https://vendors.sdkman.io/default
           echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
-
+          # Announce the release to SDKMAN
+          curl -s -X POST \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
+          https://vendors.sdkman.io/announce/struct
+          echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
   # upload_windows_package:
   #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -144,7 +144,7 @@ jobs:
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_SDKMAN_URL }}
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
           mkdir -p liquibase-${{ inputs.version }}/bin/internal
@@ -154,8 +154,31 @@ jobs:
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  https://artifactory.datical.net/artifactory/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
-
+          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  ${{ secrets.ARTIFACTORY_SDKMAN_URL }}/liquibase-${{ inputs.version }}-sdkman.zip
+          # Send the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "${{ secrets.ARTIFACTORY_SDKMAN_URL }}/liquibase-${{ inputs.version }}-sdkman.zip"}' \
+          https://vendors.sdkman.io/release
+          # Set the default version for SDKMAN
+          curl -X PUT \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
+          https://vendors.sdkman.io/default
+          # Announce the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
+          https://vendors.sdkman.io/announce/struct
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -179,15 +179,7 @@ jobs:
           -d '{"candidate": "liquibase", "version": "$VERSION"}' \
           https://vendors.sdkman.io/default
           echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
-          # Announce the release to SDKMAN
-          curl -s -X POST \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "$VERSION", "url": "https://github.com/liquibase/liquibase/releases/tag/v$VERSION"}' \
-          https://vendors.sdkman.io/announce/struct
-          echo "Announced liquibase-$VERSION.zip to SDKMAN"
+
 
   # upload_windows_package:
   #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "maven"
+      # - name: Set up Java
+      #   uses: actions/setup-java@v4
+      #   with:
+      #     java-version: "17"
+      #     distribution: "temurin"
+      #     cache: "maven"
 
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: ${{ env.MAVEN_VERSION }}
+      # - name: Set up Maven
+      #   uses: stCarolas/setup-maven@v4.5
+      #   with:
+      #     maven-version: ${{ env.MAVEN_VERSION }}
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1.4
+      # - name: Set up Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: 3.1.4
 
-      - name: Get Reusable Files
-        run: |
-          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-          chmod +x $PWD/.github/sign_artifact.sh
+      # - name: Get Reusable Files
+      #   run: |
+      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+      #     chmod +x $PWD/.github/sign_artifact.sh
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # - name: Import GPG key
+      #   id: import_gpg
+      #   uses: crazy-max/ghaction-import-gpg@v6
+      #   with:
+      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
+      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-          aws-region: us-east-1
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+      #     aws-region: us-east-1
 
-      - name: Download ${{ inputs.artifactId }} Release
-        run: |
-          mkdir -p $PWD/.github/target
-          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      # - name: Download ${{ inputs.artifactId }} Release
+      #   run: |
+      #     mkdir -p $PWD/.github/target
+      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      - name: Build ${{ inputs.artifactId }} deb package
-        run: |
-          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      # - name: Build ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      - name: Install deb-s3 gem
-        run: gem install deb-s3
+      # - name: Install deb-s3 gem
+      #   run: gem install deb-s3
 
-      - name: Upload ${{ inputs.artifactId }} deb package
-        run: |
-          sudo apt install pinentry-tty
-          echo "2" | sudo update-alternatives --config pinentry
-          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-          export GPG_TTY=$(tty)
-          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Upload ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     sudo apt install pinentry-tty
+      #     echo "2" | sudo update-alternatives --config pinentry
+      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+      #     export GPG_TTY=$(tty)
+      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Convert deb to rpm
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y alien
-          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Convert deb to rpm
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y alien
+      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Upload ${{ inputs.artifactId }} rpm package
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-          mkdir createrepo_folder
-          cd createrepo_folder
-          git clone https://github.com/rpm-software-management/createrepo_c
-          cd createrepo_c
-          mkdir build
-          cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-          make -j
-          cp src/createrepo_c  /opt/createrepo
-          cd ../../..
-          mkdir -p $PWD/yum/noarch
-          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-          /opt/createrepo -h
-          /opt/createrepo -dp $PWD/yum/noarch
-          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      # - name: Upload ${{ inputs.artifactId }} rpm package
+      #   run: |
+      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+      #     mkdir createrepo_folder
+      #     cd createrepo_folder
+      #     git clone https://github.com/rpm-software-management/createrepo_c
+      #     cd createrepo_c
+      #     mkdir build
+      #     cd build
+      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+      #     make -j
+      #     cp src/createrepo_c  /opt/createrepo
+      #     cd ../../..
+      #     mkdir -p $PWD/yum/noarch
+      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+      #     /opt/createrepo -h
+      #     /opt/createrepo -dp $PWD/yum/noarch
+      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      - name: Update Homebrew formula for ${{ inputs.artifactId }}
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        # Will set the following for the first time, then we can the line
-        continue-on-error: true
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          no_fork: true
-          formula: liquibase
-          tag: "${{ github.event.release.tag_name }}"
-          force: true
+      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   # Will set the following for the first time, then we can the line
+      #   continue-on-error: true
+      #   with:
+      #     token: ${{ secrets.BOT_TOKEN }}
+      #     no_fork: true
+      #     formula: liquibase
+      #     tag: "${{ github.event.release.tag_name }}"
+      #     force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -154,7 +154,6 @@ jobs:
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          mv ./liquibase-$VERSION/internal ./liquibase-$VERSION/bin/
           cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
           # Upload the release to S3
@@ -188,8 +187,8 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-  upload_windows_package:
-    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
+  # upload_windows_package:
+  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+  #   secrets: inherit
+  #   with:
+  #     version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -141,6 +141,10 @@ jobs:
           force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
+        env:
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
           mkdir -p liquibase-${{ inputs.version }}/bin/internal
@@ -148,7 +152,33 @@ jobs:
           mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
-          # TODO send zip to sdkman
+          # Upload the release to Artifactory
+          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL
+          # Send the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-2.4.6.zip"}' \
+          https://vendors.sdkman.io/release
+          # Set the default version for SDKMAN
+          curl -X PUT \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
+          https://vendors.sdkman.io/default
+          # Announce the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
+          https://vendors.sdkman.io/announce/struct
+
 
   upload_windows_package:
     uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -152,6 +152,7 @@ jobs:
           mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
+          cd ..
           # Upload the release to Artifactory
           curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -142,12 +142,10 @@ jobs:
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_SDKMAN_URL }}
           SDKMAN_CONSUMER_KEY: ${{ secrets.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
+          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com/sdkman
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
           mkdir -p liquibase-$VERSION/bin/internal
@@ -158,16 +156,16 @@ jobs:
           mv ./liquibase-$VERSION/internal ./liquibase-$VERSION/bin/
           cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
-          # Upload the release to Artifactory
-          curl -s -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
-          echo "Uploaded liquibase-$VERSION.zip to $ARTIFACTORY_URL"
+          # Upload the release to S3
+          aws s3 cp liquibase-$VERSION.zip $S3_WEB_URL
+          echo "Uploaded liquibase-$VERSION.zip to s3"
           # Send the release to SDKMAN
           curl -s -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$ARTIFACTORY_URL"'/liquibase-'"$VERSION"'.zip"}' \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
           https://vendors.sdkman.io/release
           echo "Sent liquibase-$VERSION.zip to SDKMAN"
           # Set the default version for SDKMAN

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -155,7 +155,30 @@ jobs:
           cd ..
           # Upload the release to Artifactory
           curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip
-
+          # Send the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "$ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip"}' \
+          https://vendors.sdkman.io/release
+          # Set the default version for SDKMAN
+          curl -X PUT \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
+          https://vendors.sdkman.io/default
+          # Announce the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
+          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
+          https://vendors.sdkman.io/announce/struct
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -167,7 +167,7 @@ jobs:
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$ARTIFACTORY_URL'"/liquibase-'"$VERSION'".zip"}' \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$ARTIFACTORY_URL"'/liquibase-'"$VERSION"'.zip"}' \
           https://vendors.sdkman.io/release
           echo "Sent liquibase-$VERSION.zip to SDKMAN"
           # Set the default version for SDKMAN

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -158,7 +158,33 @@ jobs:
           # Upload the release to S3
           aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
           echo "Uploaded liquibase-$VERSION.zip to s3"
-
+          # Send the release to SDKMAN
+          curl -s -X POST \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
+          https://vendors.sdkman.io/release
+          echo "Sent liquibase-$VERSION.zip to SDKMAN"
+          # Set the default version for SDKMAN
+          curl -s -X PUT \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
+          https://vendors.sdkman.io/default
+          echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
+          # Announce the release to SDKMAN
+          curl -s -X POST \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
+          https://vendors.sdkman.io/announce/struct
+          echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
   # upload_windows_package:
   #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -154,7 +154,7 @@ jobs:
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
+          curl -v -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/sdkman/liquibase-${{ inputs.version }}-sdkman.zip
 
 
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -146,6 +146,7 @@ jobs:
           SDKMAN_CONSUMER_TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
           S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com/sdkman
+          S3_BUCKET: s3://repo.liquibase.com/sdkman/
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
           mkdir -p liquibase-$VERSION/bin/internal
@@ -157,7 +158,7 @@ jobs:
           cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
           # Upload the release to S3
-          aws s3 cp liquibase-$VERSION.zip $S3_WEB_URL
+          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
           echo "Uploaded liquibase-$VERSION.zip to s3"
           # Send the release to SDKMAN
           curl -s -X POST \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -159,6 +159,7 @@ jobs:
           cd ..
           # Upload the release to Artifactory
           curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
+          echo "Uploaded liquibase-$VERSION.zip to $ARTIFACTORY_URL"
           # Send the release to SDKMAN
           curl -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
@@ -167,6 +168,7 @@ jobs:
           -H "Accept: application/json" \
           -d '{"candidate": "liquibase", "version": "$VERSION", "url": "$ARTIFACTORY_URL/liquibase-$VERSION.zip"}' \
           https://vendors.sdkman.io/release
+          echo "Sent liquibase-$VERSION.zip to SDKMAN"
           # Set the default version for SDKMAN
           curl -X PUT \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
@@ -175,6 +177,7 @@ jobs:
           -H "Accept: application/json" \
           -d '{"candidate": "liquibase", "version": "$VERSION"}' \
           https://vendors.sdkman.io/default
+          echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
           # Announce the release to SDKMAN
           curl -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
@@ -183,6 +186,7 @@ jobs:
           -H "Accept: application/json" \
           -d '{"candidate": "liquibase", "version": "$VERSION", "url": "https://github.com/liquibase/liquibase/releases/tag/v$VERSION"}' \
           https://vendors.sdkman.io/announce/struct
+          echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -73,11 +73,11 @@ jobs:
       #     gpg_private_key: ${{ secrets.GPG_SECRET }}
       #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-      #     aws-region: us-east-1
+       - name: Configure AWS credentials
+         uses: aws-actions/configure-aws-credentials@v4
+         with:
+           role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+           aws-region: us-east-1
 
       # - name: Download ${{ inputs.artifactId }} Release
       #   run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -154,38 +154,11 @@ jobs:
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
-          cd ..
+          zip -r ../liquibase-$VERSION.zip ./
           # Upload the release to S3
           aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
           echo "Uploaded liquibase-$VERSION.zip to s3"
-          # Send the release to SDKMAN
-          curl -s -X POST \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
-          https://vendors.sdkman.io/release
-          echo "Sent liquibase-$VERSION.zip to SDKMAN"
-          # Set the default version for SDKMAN
-          curl -s -X PUT \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
-          https://vendors.sdkman.io/default
-          echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
-          # Announce the release to SDKMAN
-          curl -s -X POST \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
-          https://vendors.sdkman.io/announce/struct
-          echo "Announced liquibase-$VERSION.zip to SDKMAN"
+
 
   # upload_windows_package:
   #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -154,31 +154,8 @@ jobs:
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -u ${{ secrets.ARTIFACTORY_USER }}:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  ${{ secrets.ARTIFACTORY_SDKMAN_URL }}/liquibase-${{ inputs.version }}-sdkman.zip
-          # Send the release to SDKMAN
-          curl -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "${{ secrets.ARTIFACTORY_SDKMAN_URL }}/liquibase-${{ inputs.version }}-sdkman.zip"}' \
-          https://vendors.sdkman.io/release
-          # Set the default version for SDKMAN
-          curl -X PUT \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
-          https://vendors.sdkman.io/default
-          # Announce the release to SDKMAN
-          curl -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
-          https://vendors.sdkman.io/announce/struct
+          curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip
+
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -158,10 +158,10 @@ jobs:
           cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
+          curl -s -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
           echo "Uploaded liquibase-$VERSION.zip to $ARTIFACTORY_URL"
           # Send the release to SDKMAN
-          curl -X POST \
+          curl -s -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
@@ -170,7 +170,7 @@ jobs:
           https://vendors.sdkman.io/release
           echo "Sent liquibase-$VERSION.zip to SDKMAN"
           # Set the default version for SDKMAN
-          curl -X PUT \
+          curl -s -X PUT \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
@@ -179,7 +179,7 @@ jobs:
           https://vendors.sdkman.io/default
           echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
           # Announce the release to SDKMAN
-          curl -X POST \
+          curl -s -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -167,7 +167,7 @@ jobs:
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "$VERSION", "url": "$ARTIFACTORY_URL/liquibase-$VERSION.zip"}' \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$ARTIFACTORY_URL'"/liquibase-'"$VERSION'".zip"}' \
           https://vendors.sdkman.io/release
           echo "Sent liquibase-$VERSION.zip to SDKMAN"
           # Set the default version for SDKMAN
@@ -176,7 +176,7 @@ jobs:
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "$VERSION"}' \
+          -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
           https://vendors.sdkman.io/default
           echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Set up Java
-      #   uses: actions/setup-java@v4
-      #   with:
-      #     java-version: "17"
-      #     distribution: "temurin"
-      #     cache: "maven"
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
-      # - name: Set up Maven
-      #   uses: stCarolas/setup-maven@v4.5
-      #   with:
-      #     maven-version: ${{ env.MAVEN_VERSION }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
 
-      # - name: Set up Ruby
-      #   uses: ruby/setup-ruby@v1
-      #   with:
-      #     ruby-version: 3.1.4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.4
 
-      # - name: Get Reusable Files
-      #   run: |
-      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-      #     chmod +x $PWD/.github/sign_artifact.sh
+      - name: Get Reusable Files
+        run: |
+          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+          chmod +x $PWD/.github/sign_artifact.sh
 
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: crazy-max/ghaction-import-gpg@v6
-      #   with:
-      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
-      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_SECRET }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+          aws-region: us-east-1
 
-      # - name: Download ${{ inputs.artifactId }} Release
-      #   run: |
-      #     mkdir -p $PWD/.github/target
-      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      - name: Download ${{ inputs.artifactId }} Release
+        run: |
+          mkdir -p $PWD/.github/target
+          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      # - name: Build ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      - name: Build ${{ inputs.artifactId }} deb package
+        run: |
+          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      # - name: Install deb-s3 gem
-      #   run: gem install deb-s3
+      - name: Install deb-s3 gem
+        run: gem install deb-s3
 
-      # - name: Upload ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     sudo apt install pinentry-tty
-      #     echo "2" | sudo update-alternatives --config pinentry
-      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-      #     export GPG_TTY=$(tty)
-      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Upload ${{ inputs.artifactId }} deb package
+        run: |
+          sudo apt install pinentry-tty
+          echo "2" | sudo update-alternatives --config pinentry
+          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+          export GPG_TTY=$(tty)
+          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Convert deb to rpm
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y alien
-      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Convert deb to rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alien
+          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Upload ${{ inputs.artifactId }} rpm package
-      #   run: |
-      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-      #     mkdir createrepo_folder
-      #     cd createrepo_folder
-      #     git clone https://github.com/rpm-software-management/createrepo_c
-      #     cd createrepo_c
-      #     mkdir build
-      #     cd build
-      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-      #     make -j
-      #     cp src/createrepo_c  /opt/createrepo
-      #     cd ../../..
-      #     mkdir -p $PWD/yum/noarch
-      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-      #     /opt/createrepo -h
-      #     /opt/createrepo -dp $PWD/yum/noarch
-      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      - name: Upload ${{ inputs.artifactId }} rpm package
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          mkdir createrepo_folder
+          cd createrepo_folder
+          git clone https://github.com/rpm-software-management/createrepo_c
+          cd createrepo_c
+          mkdir build
+          cd build
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          make -j
+          cp src/createrepo_c  /opt/createrepo
+          cd ../../..
+          mkdir -p $PWD/yum/noarch
+          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+          /opt/createrepo -h
+          /opt/createrepo -dp $PWD/yum/noarch
+          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   # Will set the following for the first time, then we can the line
-      #   continue-on-error: true
-      #   with:
-      #     token: ${{ secrets.BOT_TOKEN }}
-      #     no_fork: true
-      #     formula: liquibase
-      #     tag: "${{ github.event.release.tag_name }}"
-      #     force: true
+      - name: Update Homebrew formula for ${{ inputs.artifactId }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        # Will set the following for the first time, then we can the line
+        continue-on-error: true
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          no_fork: true
+          formula: liquibase
+          tag: "${{ github.event.release.tag_name }}"
+          force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -189,8 +189,8 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-  # upload_windows_package:
-  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-  #   secrets: inherit
-  #   with:
-  #     version: ${{ inputs.version }}
+  upload_windows_package:
+    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -154,7 +154,7 @@ jobs:
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          zip -r ../liquibase-$VERSION.zip ./
+          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
           # Upload the release to S3
           aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
           echo "Uploaded liquibase-$VERSION.zip to s3"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -145,25 +145,44 @@ jobs:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_SDKMAN_URL }}
+          SDKMAN_CONSUMER_KEY: ${{ secrets.SDKMAN_CONSUMER_KEY }}
+          SDKMAN_CONSUMER_TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
+          VERSION: ${{ inputs.version }}
         run: |
-          wget -q https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
-          mkdir -p liquibase-${{ inputs.version }}/bin/internal
-          unzip liquibase-${{ inputs.version }}.zip -d liquibase-${{ inputs.version }}
-          mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
-          mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
-          cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./
+          wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
+          mkdir -p liquibase-$VERSION/bin/internal
+          unzip liquibase-$VERSION.zip -d liquibase-$VERSION
+          rm -rf liquibase-$VERSION.zip
+          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+          mv ./liquibase-$VERSION/internal ./liquibase-$VERSION/bin/
+          cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
           # Upload the release to Artifactory
-          curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip
+          curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-$VERSION.zip  $ARTIFACTORY_URL/liquibase-$VERSION.zip
           # Send the release to SDKMAN
           curl -v -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "$ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip"}' \
+          -d '{"candidate": "liquibase", "version": "$VERSION", "url": "$ARTIFACTORY_URL/liquibase-$VERSION.zip"}' \
           https://vendors.sdkman.io/release
-
+          # Set the default version for SDKMAN
+          curl -X PUT \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "$VERSION"}' \
+          https://vendors.sdkman.io/default
+          # Announce the release to SDKMAN
+          curl -X POST \
+          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"candidate": "liquibase", "version": "$VERSION", "url": "https://github.com/liquibase/liquibase/releases/tag/v$VERSION"}' \
+          https://vendors.sdkman.io/announce/struct
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -156,29 +156,14 @@ jobs:
           # Upload the release to Artifactory
           curl -u $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN -T liquibase-${{ inputs.version }}-sdkman.zip  $ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip
           # Send the release to SDKMAN
-          curl -X POST \
+          curl -v -X POST \
           -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
           -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
           -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "$ARTIFACTORY_URL/liquibase-${{ inputs.version }}-sdkman.zip"}' \
           https://vendors.sdkman.io/release
-          # Set the default version for SDKMAN
-          curl -X PUT \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}"}' \
-          https://vendors.sdkman.io/default
-          # Announce the release to SDKMAN
-          curl -X POST \
-          -H "Consumer-Key: ${{ secrets.SDKMAN_CONSUMER_KEY }}" \
-          -H "Consumer-Token: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "${{ inputs.version }}", "url": "https://git.io/release"}' \
-          https://vendors.sdkman.io/announce/struct
+
 
 
   # upload_windows_package:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -73,11 +73,11 @@ jobs:
       #     gpg_private_key: ${{ secrets.GPG_SECRET }}
       #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-       - name: Configure AWS credentials
-         uses: aws-actions/configure-aws-credentials@v4
-         with:
-           role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-           aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+          aws-region: us-east-1
 
       # - name: Download ${{ inputs.artifactId }} Release
       #   run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,41 +37,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Set up Java
-      #   uses: actions/setup-java@v4
-      #   with:
-      #     java-version: "17"
-      #     distribution: "temurin"
-      #     cache: "maven"
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
-      # - name: Set up Maven
-      #   uses: stCarolas/setup-maven@v4.5
-      #   with:
-      #     maven-version: ${{ env.MAVEN_VERSION }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
 
-      # - name: Set up Ruby
-      #   uses: ruby/setup-ruby@v1
-      #   with:
-      #     ruby-version: 3.1.4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.4
 
-      # - name: Get Reusable Files
-      #   run: |
-      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-      #     chmod +x $PWD/.github/sign_artifact.sh
+      - name: Get Reusable Files
+        run: |
+          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+          chmod +x $PWD/.github/sign_artifact.sh
 
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: crazy-max/ghaction-import-gpg@v6
-      #   with:
-      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
-      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_SECRET }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -79,66 +79,66 @@ jobs:
           role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
           aws-region: us-east-1
 
-      # - name: Download ${{ inputs.artifactId }} Release
-      #   run: |
-      #     mkdir -p $PWD/.github/target
-      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      - name: Download ${{ inputs.artifactId }} Release
+        run: |
+          mkdir -p $PWD/.github/target
+          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      # - name: Build ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      - name: Build ${{ inputs.artifactId }} deb package
+        run: |
+          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      # - name: Install deb-s3 gem
-      #   run: gem install deb-s3
+      - name: Install deb-s3 gem
+        run: gem install deb-s3
 
-      # - name: Upload ${{ inputs.artifactId }} deb package
-      #   run: |
-      #     sudo apt install pinentry-tty
-      #     echo "2" | sudo update-alternatives --config pinentry
-      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-      #     export GPG_TTY=$(tty)
-      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Upload ${{ inputs.artifactId }} deb package
+        run: |
+          sudo apt install pinentry-tty
+          echo "2" | sudo update-alternatives --config pinentry
+          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+          export GPG_TTY=$(tty)
+          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Convert deb to rpm
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y alien
-      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      - name: Convert deb to rpm
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alien
+          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      # - name: Upload ${{ inputs.artifactId }} rpm package
-      #   run: |
-      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-      #     mkdir createrepo_folder
-      #     cd createrepo_folder
-      #     git clone https://github.com/rpm-software-management/createrepo_c
-      #     cd createrepo_c
-      #     mkdir build
-      #     cd build
-      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-      #     make -j
-      #     cp src/createrepo_c  /opt/createrepo
-      #     cd ../../..
-      #     mkdir -p $PWD/yum/noarch
-      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-      #     /opt/createrepo -h
-      #     /opt/createrepo -dp $PWD/yum/noarch
-      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      - name: Upload ${{ inputs.artifactId }} rpm package
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          mkdir createrepo_folder
+          cd createrepo_folder
+          git clone https://github.com/rpm-software-management/createrepo_c
+          cd createrepo_c
+          mkdir build
+          cd build
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          make -j
+          cp src/createrepo_c  /opt/createrepo
+          cd ../../..
+          mkdir -p $PWD/yum/noarch
+          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+          /opt/createrepo -h
+          /opt/createrepo -dp $PWD/yum/noarch
+          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
-      #   uses: dawidd6/action-homebrew-bump-formula@v3
-      #   # Will set the following for the first time, then we can the line
-      #   continue-on-error: true
-      #   with:
-      #     token: ${{ secrets.BOT_TOKEN }}
-      #     no_fork: true
-      #     formula: liquibase
-      #     tag: "${{ github.event.release.tag_name }}"
-      #     force: true
+      - name: Update Homebrew formula for ${{ inputs.artifactId }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        # Will set the following for the first time, then we can the line
+        continue-on-error: true
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          no_fork: true
+          formula: liquibase
+          tag: "${{ github.event.release.tag_name }}"
+          force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -186,8 +186,8 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-  # upload_windows_package:
-  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-  #   secrets: inherit
-  #   with:
-  #     version: ${{ inputs.version }}
+  upload_windows_package:
+    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,108 +37,108 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
-          cache: "maven"
+      # - name: Set up Java
+      #   uses: actions/setup-java@v4
+      #   with:
+      #     java-version: "17"
+      #     distribution: "temurin"
+      #     cache: "maven"
 
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: ${{ env.MAVEN_VERSION }}
+      # - name: Set up Maven
+      #   uses: stCarolas/setup-maven@v4.5
+      #   with:
+      #     maven-version: ${{ env.MAVEN_VERSION }}
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1.4
+      # - name: Set up Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: 3.1.4
 
-      - name: Get Reusable Files
-        run: |
-          # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
-          curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
-          chmod +x $PWD/.github/sign_artifact.sh
+      # - name: Get Reusable Files
+      #   run: |
+      #     # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
+      #     mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/control
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/deb/control/postinst
+      #     curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+      #     curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/package-deb-pom.xml
+      #     curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/v0.6.3/.github/sign_artifact.sh
+      #     chmod +x $PWD/.github/sign_artifact.sh
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # - name: Import GPG key
+      #   id: import_gpg
+      #   uses: crazy-max/ghaction-import-gpg@v6
+      #   with:
+      #     gpg_private_key: ${{ secrets.GPG_SECRET }}
+      #     passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-          aws-region: us-east-1
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+      #     aws-region: us-east-1
 
-      - name: Download ${{ inputs.artifactId }} Release
-        run: |
-          mkdir -p $PWD/.github/target
-          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+      # - name: Download ${{ inputs.artifactId }} Release
+      #   run: |
+      #     mkdir -p $PWD/.github/target
+      #     # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
+      #     wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
 
-      - name: Build ${{ inputs.artifactId }} deb package
-        run: |
-          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+      # - name: Build ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
 
-      - name: Install deb-s3 gem
-        run: gem install deb-s3
+      # - name: Install deb-s3 gem
+      #   run: gem install deb-s3
 
-      - name: Upload ${{ inputs.artifactId }} deb package
-        run: |
-          sudo apt install pinentry-tty
-          echo "2" | sudo update-alternatives --config pinentry
-          echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
-          export GPG_TTY=$(tty)
-          echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Upload ${{ inputs.artifactId }} deb package
+      #   run: |
+      #     sudo apt install pinentry-tty
+      #     echo "2" | sudo update-alternatives --config pinentry
+      #     echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
+      #     export GPG_TTY=$(tty)
+      #     echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
+      #     deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Convert deb to rpm
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y alien
-          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+      # - name: Convert deb to rpm
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y alien
+      #     sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
-      - name: Upload ${{ inputs.artifactId }} rpm package
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-          mkdir createrepo_folder
-          cd createrepo_folder
-          git clone https://github.com/rpm-software-management/createrepo_c
-          cd createrepo_c
-          mkdir build
-          cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
-          make -j
-          cp src/createrepo_c  /opt/createrepo
-          cd ../../..
-          mkdir -p $PWD/yum/noarch
-          aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-          /opt/createrepo -h
-          /opt/createrepo -dp $PWD/yum/noarch
-          ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
-          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
-          aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
+      # - name: Upload ${{ inputs.artifactId }} rpm package
+      #   run: |
+      #     sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
+      #     ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+      #     mkdir createrepo_folder
+      #     cd createrepo_folder
+      #     git clone https://github.com/rpm-software-management/createrepo_c
+      #     cd createrepo_c
+      #     mkdir build
+      #     cd build
+      #     cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+      #     make -j
+      #     cp src/createrepo_c  /opt/createrepo
+      #     cd ../../..
+      #     mkdir -p $PWD/yum/noarch
+      #     aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
+      #     /opt/createrepo -h
+      #     /opt/createrepo -dp $PWD/yum/noarch
+      #     ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
+      #     mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+      #     aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
 
-      - name: Update Homebrew formula for ${{ inputs.artifactId }}
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        # Will set the following for the first time, then we can the line
-        continue-on-error: true
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          no_fork: true
-          formula: liquibase
-          tag: "${{ github.event.release.tag_name }}"
-          force: true
+      # - name: Update Homebrew formula for ${{ inputs.artifactId }}
+      #   uses: dawidd6/action-homebrew-bump-formula@v3
+      #   # Will set the following for the first time, then we can the line
+      #   continue-on-error: true
+      #   with:
+      #     token: ${{ secrets.BOT_TOKEN }}
+      #     no_fork: true
+      #     formula: liquibase
+      #     tag: "${{ github.event.release.tag_name }}"
+      #     force: true
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         env:
@@ -154,6 +154,7 @@ jobs:
           unzip liquibase-$VERSION.zip -d liquibase-$VERSION
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/internal ./liquibase-$VERSION/bin/
           cd liquibase-$VERSION && zip -r ../liquibase-$VERSION.zip ./
           cd ..
@@ -188,8 +189,8 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-  upload_windows_package:
-    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
+  # upload_windows_package:
+  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+  #   secrets: inherit
+  #   with:
+  #     version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -144,8 +144,7 @@ jobs:
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.zip
           mkdir -p liquibase-${{ inputs.version }}/bin/internal
-          unzip liquibase-${{ inputs.version }}.zip
-          ls -ltr
+          unzip liquibase-${{ inputs.version }}.zip -d liquibase-${{ inputs.version }}
           mv ./liquibase-${{ inputs.version }}/liquibase ./liquibase-${{ inputs.version }}/bin/
           mv ./liquibase-${{ inputs.version }}/internal ./liquibase-${{ inputs.version }}/bin/
           cd liquibase-${{ inputs.version }} && zip -r ../liquibase-${{ inputs.version }}-sdkman.zip ./

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -68,5 +68,5 @@ jobs:
 
   maven-release:
     needs: release
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.6.6
     secrets: inherit

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -268,7 +268,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.6.5
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.6.6
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/README.md
+++ b/README.md
@@ -451,4 +451,4 @@ Here the modules we want to generate and aggregate test reports must be specifie
 
 ### Releasing a new version of build-logic
 
-When you want to release new version of `build-logic`, it is important to update all the occurrences of previous version eg: `v0.6.3` with the new version eg : `v0.6.5` in all the files. As, the code for the new version internally refers to the old version.   
+When you want to release new version of `build-logic`, it is important to update all the occurrences of previous version eg: `v0.6.3` with the new version eg : `v0.6.6` in all the files. As, the code for the new version internally refers to the old version.   


### PR DESCRIPTION
I added the logic shown at https://sdkman.io/vendors

The send command has an `URL` input parameter where the package must be accessible, ~~that is why I created an **Artifactory** public repo `https://artifactory.datical.net/artifactory/sdkman` to store them~~ so its is uploaded to our package repo `s3://repo.liquibase.com/sdkman`. We will have download insights as well. An example of a POST request to send a new version to SDKMAN:

```
          curl -X POST \
          -H "Consumer-Key: ******" \
          -H "Consumer-Token: *******" \
          -H "Content-Type: application/json" \
          -H "Accept: application/json" \
          -d '{"candidate": "liquibase", "version": "4.26.0", "url": "https://s3.amazonaws.com/repo.liquibase.com/sdkman/liquibase-4.26.0.zip"}' \
          https://vendors.sdkman.io/release
```

Vendor logic tested from https://github.com/liquibase/liquibase-packaging/actions/runs/8263115718/job/22603842283