### PR TITLE
DAT-17392

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check Security Vulnerabilities
     strategy:
+      fail-fast: false # Continue running jobs even if one fails
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:


### PR DESCRIPTION
fix: `.github/workflows/os-extension-automated-release.yml`  : Continue running jobs even if one repository fails