### PR TITLE
Fix/dat 17435

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        if ${{ inputs.buildCommand }} != ''
+        if [[ -n ${{ inputs.buildCommand }} ]]
         then
           echo "Build command is provided. Setting buildMode to manual"
           echo "buildMode=manual" >> $GITHUB_OUTPUT

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,14 +59,17 @@ jobs:
       id: set-build-mode
       run: |
         if [[ -n "${{ inputs.buildCommand }}" ]]
+        buildMode=''
         then
           echo "Build command is provided. Setting buildMode to manual"
-          echo "buildMode=manual" >> $GITHUB_OUTPUT
+          buildMode='manual'
+          echo "buildMode=$buildMode" >> $GITHUB_OUTPUT
         else
             echo "Build command is not provided. Setting buildMode to autobuild"
-            echo "buildMode=autobuild" >> $GITHUB_OUTPUT
+            buildMode='autobuild'
+            echo "buildMode=$buildMode" >> $GITHUB_OUTPUT
         fi
-
+        echo $buildMode
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -97,9 +100,9 @@ jobs:
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 
     - name: Build
-      if: ${{ steps.set-build-mode.outputs.buildMode }} == manual
+      if: ${{ steps.set-build-mode.outputs.buildMode }} == 'manual'
       run: |
-        echo "${{ steps.set-build-mode.outputs.buildMode }}"
+        echo ${{ steps.set-build-mode.outputs.buildMode }}
         ${{ inputs.buildCommand }}
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,6 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        buildMode=''
         if [[ -n "${{ inputs.buildCommand }}" ]]
         then
           echo "Build command is provided. Setting buildMode to manual"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,8 +58,8 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        if [[ -n "${{ inputs.buildCommand }}" ]]
         buildMode=''
+        if [[ -n "${{ inputs.buildCommand }}" ]]
         then
           echo "Build command is provided. Setting buildMode to manual"
           buildMode='manual'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,7 +97,7 @@ jobs:
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 
     - name: Build
-      if: ${{ steps.set-build-mode.outputs.buildMode }} == 'manual'
+      if: ${{ steps.set-build-mode.outputs.buildMode }} == manual
       run: |
         echo "${{ steps.set-build-mode.outputs.buildMode }}"
         ${{ inputs.buildCommand }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,7 +101,6 @@ jobs:
     - name: Build
       if: steps.set-build-mode.outputs.buildMode  == 'manual'
       run: |
-        echo ${{ steps.set-build-mode.outputs.buildMode }}
         ${{ inputs.buildCommand }}
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,6 +99,7 @@ jobs:
     - name: Build
       if: ${{ steps.set-build-mode.outputs.buildMode }} == 'manual'
       run: |
+        echo "${{ steps.set-build-mode.outputs.buildMode }}"
         ${{ inputs.buildCommand }}
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ on:
         required: false
         default: ''
         type: string
-      buildCommands:
+      buildCommand:
         description: 'Custom build command'
         required: false
         default: ''

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,13 +63,12 @@ jobs:
         then
           echo "Build command is provided. Setting buildMode to manual"
           buildMode='manual'
-          echo "buildMode=$buildMode" >> $GITHUB_OUTPUT
         else
             echo "Build command is not provided. Setting buildMode to autobuild"
             buildMode='autobuild'
-            echo "buildMode=$buildMode" >> $GITHUB_OUTPUT
         fi
-        echo $buildMode
+        echo "buildMode=$buildMode" >> $GITHUB_OUTPUT
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ on:
       buildCommands:
         description: 'Custom build command'
         required: false
-        default: '[]'
+        default: ''
         type: string
 
 jobs:
@@ -45,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         language: ${{fromJson(inputs.languages)}}
-        buildCommand: ${{fromJson(inputs.buildCommands)}}
 
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
@@ -59,7 +58,7 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        if ${{ matrix.buildCommand }} != ''
+        if ${{ inputs.buildCommand }} != ''
         then
           echo "Build command is provided. Setting buildMode to manual"
           echo "buildMode=manual" >> $GITHUB_OUTPUT

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    # setting a build mode based on whether a buildCommand is provided or not.
+    # If a buildCommand is provided, it sets the build mode to "manual"; otherwise, it sets it to "autobuild".
     - name: set build mode
       id: set-build-mode
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,7 +100,7 @@ jobs:
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 
     - name: Build
-      if: false
+      if: steps.set-build-mode.outputs.buildMode == "manual"
       run: |
         echo ${{ steps.set-build-mode.outputs.buildMode }}
         ${{ inputs.buildCommand }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,10 @@ on:
         required: false
         default: ''
         type: string
-      buildCommand:
+      buildCommands:
         description: 'Custom build command'
         required: false
-        default: ''
+        default: '[]'
         type: string
 
 jobs:
@@ -45,6 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         language: ${{fromJson(inputs.languages)}}
+        buildCommand: ${{fromJson(inputs.buildCommands)}}
 
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
@@ -58,13 +59,13 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        if ${{ inputs.buildCommand }} != ''
+        if ${{ matrix.buildCommand }} != ''
         then
-          echo "Build command is provided. Setting buildMode to 'manual'
-          echo "buildMode='manual'" >> $GITHUB_OUTPUT
+          echo "Build command is provided. Setting buildMode to manual"
+          echo "buildMode=manual" >> $GITHUB_OUTPUT
         else
-            echo "Build command is not provided. Setting buildMode to 'autobuild'
-            echo "buildMode='autobuild'" >> $GITHUB_OUTPUT
+            echo "Build command is not provided. Setting buildMode to autobuild"
+            echo "buildMode=autobuild" >> $GITHUB_OUTPUT
         fi
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
     - name: set build mode
       id: set-build-mode
       run: |
-        if [[ -n ${{ inputs.buildCommand }} ]]
+        if [[ -n "${{ inputs.buildCommand }}" ]]
         then
           echo "Build command is provided. Setting buildMode to manual"
           echo "buildMode=manual" >> $GITHUB_OUTPUT

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,7 +100,7 @@ jobs:
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 
     - name: Build
-      if: steps.set-build-mode.outputs.buildMode == "manual"
+      if: steps.set-build-mode.outputs.buildMode  == 'manual'
       run: |
         echo ${{ steps.set-build-mode.outputs.buildMode }}
         ${{ inputs.buildCommand }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,7 +100,7 @@ jobs:
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 
     - name: Build
-      if: ${{ steps.set-build-mode.outputs.buildMode }} == 'manual'
+      if: false
       run: |
         echo ${{ steps.set-build-mode.outputs.buildMode }}
         ${{ inputs.buildCommand }}


### PR DESCRIPTION
fix: `.github/workflows/codeql.yml`: setting a build mode based on whether a buildCommand is provided or not. If a buildCommand is provided, it sets the build mode to "manual"; otherwise, it sets it to "autobuild"