### PR TITLE
Codeql issue hashicorp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,11 +97,13 @@ jobs:
         ${{ inputs.extraCommand }}
 
     - name: Set up Maven
+      if: matrix.language == 'java'
       uses: stCarolas/setup-maven@v4.5
       with:
         maven-version: "3.9.5"
     # look for dependencies in maven
     - name: maven-settings-xml-action
+      if: matrix.language == 'java'
       uses: whelk-io/maven-settings-xml-action@v21
       with:
         repositories: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,6 +96,53 @@ jobs:
       run: |
         ${{ inputs.extraCommand }}
 
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: "3.9.5"
+    # look for dependencies in maven
+    - name: maven-settings-xml-action
+      uses: whelk-io/maven-settings-xml-action@v21
+      with:
+        repositories: |
+          [
+            {
+              "id": "liquibase",
+              "url": "https://maven.pkg.github.com/liquibase/liquibase",
+              "releases": {
+                "enabled": "true"
+              },
+              "snapshots": {
+                "enabled": "true",
+                "updatePolicy": "always"
+              }
+            },
+            {
+              "id": "liquibase-pro",
+              "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+              "releases": {
+                "enabled": "true"
+              },
+              "snapshots": {
+                "enabled": "true",
+                "updatePolicy": "always"
+              }
+            }
+          ]
+        servers: |
+          [
+            {
+              "id": "liquibase-pro",
+              "username": "liquibot",
+              "password": "${{ secrets.LIQUIBOT_PAT }}"
+            },
+            {
+              "id": "liquibase",
+              "username": "liquibot",
+              "password": "${{ secrets.LIQUIBOT_PAT }}"
+            }
+          ]
+
     # users can specify the custom build command via the buildCommand input.
     # If no custom command is provided, it will be 'autobuild' by codeql in step set-build-mode  .
 


### PR DESCRIPTION
fix:`.github/workflows/codeql.yml`: [codeql fails in hashicorp with 401 Unauth ](https://github.com/liquibase/hashicorp-vault-plugin/actions/runs/8913021766/job/24477876453#step:7:75).
Successful run when built with adding: maven-settings-xml-action: https://github.com/liquibase/hashicorp-vault-plugin/actions/runs/8913988741

comments on the ticket: https://datical.atlassian.net/browse/DAT-17435?focusedCommentId=141375