### PR TITLE
DAT-17536

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,21 @@
+name: Slack Notification
+
+jobs:
+    slack-notification:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Notify Slack on Build Failure
+          if: ${{ failure() && inputs.nightly }}
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_COLOR: ${{ job.status }}
+            SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} <@U042HRTL4DT>"
+            SLACK_TITLE: "❌ ${{ github.repository }} ❌ Tests failed on branch ${{ github.ref }} for commit ${{ github.sha }} in repository ${{github.repository}}"
+            SLACK_USERNAME: liquibot
+            SLACK_WEBHOOK: ${{ secrets.NIGHTLY_BUILDS_SLACK_WEBHOOK }}
+            SLACK_ICON_EMOJI: ":robot_face:"
+            SLACK_FOOTER: "${{ github.repository }}"
+            SLACK_LINK_NAMES: true

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,5 +1,8 @@
 name: Slack Notification
 
+on:
+  workflow_call:
+
 jobs:
     slack-notification:
         runs-on: ubuntu-latest

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,14 +1,14 @@
 name: Slack Notification
 
 on:
-  workflow_call:
+  repository_dispatch:
+    types: [ test-failure ]
 
 jobs:
     slack-notification:
         runs-on: ubuntu-latest
         steps:
         - name: Notify Slack on Build Failure
-          if: ${{ failure() }}
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -7,11 +7,8 @@ jobs:
     slack-notification:
         runs-on: ubuntu-latest
         steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-
         - name: Notify Slack on Build Failure
-          if: ${{ failure() && inputs.nightly }}
+          if: ${{ failure() }}
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
feat: `.github/workflows/slack-notification.yml`: reusable workflow for slack notification for test failures.

- In order to test this I need to merge this in `master` branch 
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch

- Draft Pr to test in PRO : https://github.com/liquibase/liquibase-pro/pull/1734