### PR TITLE
os-extension-test: fix checkout ref

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -154,6 +154,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
The tests are now running against the PR code and not main branch.

Before that, the tests of the main branch were run, but not the PR tests... that caused e.g. that the automerge of https://github.com/liquibase/liquibase-percona/pull/457 failed the build.