### PR TITLE
slack notification changes

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,4 +1,4 @@
-name: Slack Notification
+name: Test Failure Notification
 
 on:
   repository_dispatch:
@@ -12,7 +12,7 @@ jobs:
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_COLOR: ${{ job.status }}
-            SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} <@U042HRTL4DT>"
+            SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} <@U042HRTL4DT>. Triggered by repository: ${{ github.event.repository.full_name }} and job: ${{ github.job }}"
             SLACK_TITLE: "❌ ${{ github.repository }} ❌ Tests failed on branch ${{ github.ref }} for commit ${{ github.sha }} in repository ${{github.repository}}"
             SLACK_USERNAME: liquibot
             SLACK_WEBHOOK: ${{ secrets.NIGHTLY_BUILDS_SLACK_WEBHOOK }}


### PR DESCRIPTION
fix: ``.github/workflows/slack-notification.yml: In the `SLACK_MESSAGE` ,` ${{ github.event.repository.full_name }}` will be replaced by the full name of the repository that triggered the workflow, and `${{ github.job }}` will be replaced by the id of the job that is currently running 🤞 