### PR TITLE
change slack color to red incase of failure

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -11,7 +11,7 @@ jobs:
         - name: Notify Slack on Build Failure
           uses: rtCamp/action-slack-notify@v2
           env:
-            SLACK_COLOR: ${{ job.status }}
+            SLACK_COLOR: ${{ github.event.action == 'test-failure' }}
             SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.event.client_payload.server_url }}/${{ github.event.client_payload.repository }}/actions/runs/${{ github.event.client_payload.run_id }} <@U042HRTL4DT>. Triggered by repository: ${{ github.event.client_payload.repository }} and job: ${{ github.job }}"
             SLACK_TITLE: "❌ ${{ github.event.client_payload.repository }} ❌ Tests failed on branch ${{ github.event.client_payload.branch }} for commit ${{ github.event.client_payload.sha }} in repository ${{ github.event.client_payload.repository }}"
             SLACK_USERNAME: liquibot


### PR DESCRIPTION
fix: `.github/workflows/slack-notification.yml`: if the `event.action` equals `'test-failure'`, `SLACK_COLOR` will be set to `'danger'` resulting red in Slack bar, indicating a failure. 