### PR TITLE
DAT-18178: Upload multiplatform artifacts for checks extension workflow

### DIFF
--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -319,6 +319,13 @@ jobs:
           -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
           -DpomFile=scripting/pom.xml
 
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.ref }}-multiplatform-artifacts
+          path: |
+            scripting/target/*
+
       - name: Publish to GPM
         if: ${{ !inputs.version }}
         working-directory: /tmp


### PR DESCRIPTION
Currently only deploys to GPM. This change updates to upload to the workflow as well for easier testing.