### PR TITLE
DAT-18153: Make multiplatform checks extension workflow work with PRs

### DIFF
--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -127,7 +127,7 @@ jobs:
           repository: liquibase/liquibase-checks
           token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Build liquibase-checks version ${{ inputs.version }} jar.
+      - name: Build liquibase-checks version ${{ inputs.version }} jar
         run: |
           cd scripting
           mvn versions:set -DnewVersion='${{ inputs.version }}' -DgenerateBackupPoms=false
@@ -301,6 +301,6 @@ jobs:
       - name: Upload multiplatform artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.head_ref || github.ref_name }}-multiplatform-artifacts
+          name: ${{ inputs.version }}-multiplatform-artifacts
           path: |
             scripting/target/*

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Save Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.ref }}-multiplatform-artifacts
+          name: ${{ github.head_ref || github.ref_name }}-multiplatform-artifacts
           path: |
             scripting/target/*
 

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -1,6 +1,9 @@
 name: Build and Publish
 env:
   java-version: 17
+  # Set liquibase.version to version 0-SNAPSHOT because we are
+  # building all required dependencies from the branches locally
+  LIQUIBASE_VERSION: '0-SNAPSHOT'
 on:
   workflow_call:
     inputs:
@@ -15,7 +18,7 @@ on:
         type: string
         default: "DAT-16671"
       version:
-        description: 'The -Dliquibase.version to use when building the artifacts.'
+        description: 'The version to mark the generated artifacts'
         required: true
         type: string
 
@@ -118,7 +121,8 @@ jobs:
             ]
 
       - name: Build Liquibase-pro
-        run: mvn -f liquibase-pro/pom-combined.xml clean install -DskipTests -P '!run-proguard' "-Dliquibase.version=${{ inputs.version }}"
+        # Set liquibase.version to version 0-SNAPSHOT because we are just building all the dependencies from the branches locally
+        run: mvn -f liquibase-pro/pom-combined.xml clean install -DskipTests -P '!run-proguard' "-Dliquibase.version=${{ env.LIQUIBASE_VERSION }}"
 
       - uses: actions/checkout@v4
         if: ${{ inputs.version }}
@@ -132,7 +136,7 @@ jobs:
           cd scripting
           mvn versions:set -DnewVersion='${{ inputs.version }}' -DgenerateBackupPoms=false
           cd ..
-          mvn clean install -DskipTests=true -pl '!liquibase-scripting-integration-tests' "-Dliquibase.version=${{ inputs.version }}"
+          mvn clean install -DskipTests=true -pl '!liquibase-scripting-integration-tests' "-Dliquibase.version=${{ env.LIQUIBASE_VERSION }}"
           mv scripting/target/liquibase-checks-${{ inputs.version }}.jar scripting/target/liquibase-checks-${{ matrix.os }}-${{ inputs.version }}.jar
 
       - name: get GITHUB_WORKSPACE

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -11,12 +11,12 @@ on:
         description: 'The liquibase core branch to checkout.'
         required: false
         type: string
-        default: "DAT-16671"
+        default: 'DAT-16671'
       pro-branch:
         description: 'The liquibase commercial branch to checkout.'
         required: false
         type: string
-        default: "DAT-16671"
+        default: 'DAT-16671'
       version:
         description: 'The version to mark the generated artifacts'
         required: true
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Build & Package java 17 - ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
@@ -256,7 +256,7 @@ jobs:
           name: liquibase-checks-windows-latest-${{ inputs.version }}-artifacts
           path: /tmp
 
-      - name: Run script for specific version
+      - name: Create multiplatform jar
         run: |
           #Copy the .jar files from Linux, Windows, and Mac builds to /tmp/linux, /tmp/windows, and /tmp/mac
           rm -r -f /tmp/linux /tmp/windows /tmp/mac
@@ -281,7 +281,7 @@ jobs:
           repository: liquibase/liquibase-checks
           token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Publish specific version to GPM
+      - name: Publish multiplatform jar to GPM
         env:
           MAVEN_USERNAME: liquibot
           MAVEN_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -4,8 +4,18 @@ env:
 on:
   workflow_call:
     inputs:
+      core-branch:
+        description: 'The liquibase core branch to checkout.'
+        required: true
+        type: string
+        default: "DAT-16671"
+      pro-branch:
+        description: 'The liquibase commercial branch to checkout.'
+        required: true
+        type: string
+        default: "DAT-16671"
       version:
-        description: 'version'
+        description: 'The -Dliquibase.version to use when building the artifacts.'
         required: true
         type: string
 
@@ -24,7 +34,7 @@ jobs:
         name: Checkout OSS
         with:
           repository: liquibase/liquibase
-          ref: "DAT-16671"
+          ref: ${{ inputs.core-version }}
           path: liquibase
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -32,7 +42,7 @@ jobs:
         name: Checkout liquibase-pro
         with:
           repository: liquibase/liquibase-pro
-          ref: "DAT-16671"
+          ref: ${{ inputs.core-version }}
           path: liquibase-pro
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -108,7 +118,7 @@ jobs:
             ]
 
       - name: Build Liquibase-pro
-        run: mvn -f liquibase-pro/pom-combined.xml clean install -DskipTests -P '!run-proguard' "-Dliquibase.version=DAT-16671-SNAPSHOT"
+        run: mvn -f liquibase-pro/pom-combined.xml clean install -DskipTests -P '!run-proguard' "-Dliquibase.version=${{ inputs.version }}"
 
       - uses: actions/checkout@v4
         if: ${{ inputs.version }}
@@ -117,20 +127,13 @@ jobs:
           repository: liquibase/liquibase-checks
           token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Build specific version
-        if: ${{ inputs.version }}
+      - name: Build liquibase-checks version ${{ inputs.version }} jar.
         run: |
-            cd scripting
-            mvn versions:set -DnewVersion='${{ inputs.version }}' -DgenerateBackupPoms=false
-            cd ..
-            mvn clean install -DskipTests=true -pl '!liquibase-scripting-integration-tests' "-Dliquibase.version=DAT-16671-SNAPSHOT"
-            mv scripting/target/liquibase-checks-${{ inputs.version }}.jar scripting/target/liquibase-checks-${{ matrix.os }}-${{ inputs.version }}.jar
-
-      - name: Build and Package checks
-        if: ${{ !inputs.version }}
-        run: |
-          mvn clean install -DskipTests=true -pl '!liquibase-scripting-integration-tests' "-Dliquibase.version=DAT-16671-SNAPSHOT"
-          mv scripting/target/liquibase-checks-0-SNAPSHOT.jar scripting/target/liquibase-checks-${{ matrix.os }}-0-SNAPSHOT.jar
+          cd scripting
+          mvn versions:set -DnewVersion='${{ inputs.version }}' -DgenerateBackupPoms=false
+          cd ..
+          mvn clean install -DskipTests=true -pl '!liquibase-scripting-integration-tests' "-Dliquibase.version=${{ inputs.version }}"
+          mv scripting/target/liquibase-checks-${{ inputs.version }}.jar scripting/target/liquibase-checks-${{ matrix.os }}-${{ inputs.version }}.jar
 
       - name: get GITHUB_WORKSPACE
         if: always()
@@ -142,7 +145,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: liquibase-checks-${{ matrix.os }}-artifacts
+          name: liquibase-checks-${{ matrix.os }}-${{ inputs.version }}-artifacts
           path: ${{ env.artifact_path }}
 
       - name: Save Event File
@@ -234,23 +237,22 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: liquibase-checks-ubuntu-latest-artifacts
+          name: liquibase-checks-ubuntu-latest-${{ inputs.version }}-artifacts
           path: /tmp
 
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: liquibase-checks-macos-latest-artifacts
+          name: liquibase-checks-macos-latest-${{ inputs.version }}-artifacts
           path: /tmp
 
       - name: Download Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: liquibase-checks-windows-latest-artifacts
+          name: liquibase-checks-windows-latest-${{ inputs.version }}-artifacts
           path: /tmp
 
       - name: Run script for specific version
-        if: ${{ inputs.version }}
         run: |
           #Copy the .jar files from Linux, Windows, and Mac builds to /tmp/linux, /tmp/windows, and /tmp/mac
           rm -r -f /tmp/linux /tmp/windows /tmp/mac
@@ -269,36 +271,13 @@ jobs:
           cd /tmp/liquibase-checks-${{ inputs.version }}/
           zip -r ../liquibase-checks-${{ inputs.version }}.jar *
 
-      - name: Run script
-        if: ${{ !inputs.version }}
-        run: |
-          #Copy the .jar files from Linux, Windows, and Mac builds to /tmp/linux, /tmp/windows, and /tmp/mac
-          rm -r -f /tmp/linux /tmp/windows /tmp/mac
-          mkdir /tmp/linux /tmp/windows /tmp/mac
-          unzip -d /tmp/linux /tmp/liquibase-checks-ubuntu-latest-0-SNAPSHOT.jar
-          unzip -d /tmp/windows /tmp/liquibase-checks-windows-latest-0-SNAPSHOT.jar
-          unzip -d /tmp/mac /tmp/liquibase-checks-macos-latest-0-SNAPSHOT.jar
-          rm -r -f /tmp/liquibase-checks
-          mkdir /tmp/liquibase-checks
-          cp -a /tmp/linux/* /tmp/liquibase-checks/
-          cp -a /tmp/windows/* /tmp/liquibase-checks/
-          cp -a /tmp/mac/* /tmp/liquibase-checks/
-          rm /tmp/liquibase-checks/vfs/fileslist.txt
-          cat /tmp/linux/vfs/fileslist.txt /tmp/windows/vfs/fileslist.txt /tmp/mac/vfs/fileslist.txt > /tmp/liquibase-checks/vfs/fileslist.txt
-          rm -f /tmp/liquibase-checks.jar
-          cd /tmp/liquibase-checks/
-          zip -r ../liquibase-checks.jar *
-          
-
       - uses: actions/checkout@v4
-        if: ${{ inputs.version }}
         name: Checkout liquibase-checks # We need to checkout the checks repo when this workflow is called from liquibase/liquibase
         with:
           repository: liquibase/liquibase-checks
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Publish specific version to GPM
-        if: ${{ inputs.version }}
         env:
           MAVEN_USERNAME: liquibot
           MAVEN_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
@@ -325,15 +304,3 @@ jobs:
           name: ${{ github.head_ref || github.ref_name }}-multiplatform-artifacts
           path: |
             scripting/target/*
-
-      - name: Publish to GPM
-        if: ${{ !inputs.version }}
-        working-directory: /tmp
-        env:
-          MAVEN_USERNAME: liquibot
-          MAVEN_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-        run: |
-          mvn deploy:deploy-file -Dfile=liquibase-checks.jar \
-          -DpomFile=${{ github.workspace }}/scripting/pom.xml -DrepositoryId=liquibase-checks \
-          -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
-          -Dtoken=${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -37,7 +37,7 @@ jobs:
         name: Checkout OSS
         with:
           repository: liquibase/liquibase
-          ref: ${{ inputs.core-version }}
+          ref: ${{ inputs.core-branch }}
           path: liquibase
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -45,7 +45,7 @@ jobs:
         name: Checkout liquibase-pro
         with:
           repository: liquibase/liquibase-pro
-          ref: ${{ inputs.core-version }}
+          ref: ${{ inputs.pro-branch }}
           path: liquibase-pro
           token: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -319,7 +319,7 @@ jobs:
           -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
           -DpomFile=scripting/pom.xml
 
-      - name: Save Artifacts
+      - name: Upload multiplatform artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.head_ref || github.ref_name }}-multiplatform-artifacts

--- a/.github/workflows/build-publish-liquibase-checks.yml
+++ b/.github/workflows/build-publish-liquibase-checks.yml
@@ -6,12 +6,12 @@ on:
     inputs:
       core-branch:
         description: 'The liquibase core branch to checkout.'
-        required: true
+        required: false
         type: string
         default: "DAT-16671"
       pro-branch:
         description: 'The liquibase commercial branch to checkout.'
-        required: true
+        required: false
         type: string
         default: "DAT-16671"
       version:


### PR DESCRIPTION
Keeps most of the same behavior but hardcodes less things. `inputs.version` was required, but there were a lot of places that had `if: !inputs.version`, so i removed these. 

Here's an outline of what this does:
1. Check out liquibase oss and pro on appropriate branches (now workflow inputs).
2. Build liquibase oss and core to get the necessary dependencies to build `liquibase-checks`. We are building this without setting any versions, so this will be installed under version `0-SNAPSHOT` in this workflow. The true version will correspond to the input branches.
3. Build liquibase-checks for each platform
4. Upload each of the platforms liquibase-checks jars to the workflow. << ✨ new
5. After this workflow has completed for windows, linux and macos we kick off a new workflow to combine these. This workflow effectively unzips each jar on top of each other. 
6. Once we have a new multiplatform jar we set the version of this jar to the workflow's input version `inputs.version`. This will be the branch name in the liquibase-checks repo, but can be set via workflow dispatch. (<< ✨ new)
7. Upload this versioned jar to GPM and the workflow (<< ✨ new). 

With corresponding updates to the liquibase-checks repo we now have something that should generate workflow and GPM multiplatform snapshot artifacts for both prs and merges to main.

This branch was supposed to be DAT-18153.