### PR TITLE
remove -d to folder

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
           mkdir -p liquibase-$VERSION/bin/internal
-          unzip liquibase-$VERSION.zip -d liquibase-$VERSION
+          unzip liquibase-$VERSION.zip
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/


### PR DESCRIPTION
fix: `.github/workflows/package.yml`: remove -d option as it is directing to an extra folder. 
Error: https://github.com/liquibase/liquibase/actions/runs/10096594193/job/27919506000#step:16:173
<img width="1312" alt="Screenshot 2024-07-25 at 10 29 17 AM" src="https://github.com/user-attachments/assets/6eb70956-21ee-4468-afa3-311d32d69c34">
