### PR TITLE
4.29.0 oss release issue

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
           mkdir -p liquibase-$VERSION/bin/internal
-          unzip liquibase-$VERSION.zip 
+          unzip liquibase-$VERSION.zip -d liquibase-$VERSION
           rm -rf liquibase-$VERSION.zip
           mv ./liquibase-$VERSION/liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -155,10 +155,10 @@ jobs:
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
           mkdir -p liquibase-$VERSION/bin/internal
-          unzip liquibase-$VERSION.zip
+          unzip liquibase-$VERSION.zip 
           rm -rf liquibase-$VERSION.zip
-          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
-          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
+          mv ./liquibase-$VERSION/liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+          mv ./liquibase-$VERSION/liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
           zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
           # Upload the release to S3
           aws s3 cp liquibase-$VERSION.zip $S3_BUCKET


### PR DESCRIPTION
fix: `.github/workflows/package.yml`: the `mv ./liquibase-4.29.0/liquibase ./liquibase-4.29.0/bin/` command is trying to move a file or directory named liquibase which does not exist in the extracted folder `liquibase-4.29.0`.

with the fix, it should ensure that the file or directory we are trying to move exists and is correctly referenced. Based on the contents of the extracted folder, it looks like the liquibase executable is in the root of liquibase-4.29.0.

Fix for error 
<img width="1312" alt="Screenshot 2024-07-25 at 10 29 17 AM" src="https://github.com/user-attachments/assets/c92e7b10-2ede-49a4-baf4-cb861d6c4a86">
