### PR TITLE
🔧 DAT-18295: add a toggle to deployToMavenCentral

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         type: string
+      deployToMavenCentral:
+        description: 'Specify it if you want to deploy to maven'
+        required: false
+        default: 'true'
+        type: boolean
     secrets:
       SONATYPE_USERNAME:
         description: 'SONATYPE_USERNAME from the caller workflow'
@@ -24,11 +29,13 @@ on:
 jobs:
   maven-release:
     uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.7.8
+    if: inputs.deployToMavenCentral == true
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
       
   release:
+    if: inputs.deployToMavenCentral == true
     runs-on: ubuntu-latest
     needs: maven-release
     steps:
@@ -146,7 +153,7 @@ jobs:
                       -Dclassifiers=,sources,javadoc,
 
   deploy_xsd:
-    if: inputs.nameSpace != ''
+    if: inputs.nameSpace != '' && inputs.deployToMaven == true
     name: Upload xsds
     runs-on: ubuntu-20.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -190,4 +197,3 @@ jobs:
           done
           
           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/${{ inputs.nameSpace }}/ --only-show-errors
-                    


### PR DESCRIPTION
feat: `.github/workflows/extension-release-published.yml`: add a `deployToMavenCentral` input parameter
NOTE : if you don't push to sonatype, you don't release to maven 