### PR TITLE
DAT-18307  DevOps :: Extension release fails when 2 drafts have the same name

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -178,8 +178,8 @@ jobs:
             fi
             if [ "$found" = true ] ; then
               # Get the draft release ID
-              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '.[] | select(.draft == true) | .id')
-              echo "Draft release ID: $RELEASE_ID"
+              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '[.[] | select(.draft == true)] | sort_by(.created_at) | last | .id')
+              echo "Newest Draft release ID: $RELEASE_ID"
               RELEASE_TITLE="v${{ inputs.version }}"
               # Update the release title
               # echo "Updating release title to $RELEASE_TITLE... for ${{ matrix.repository }}"


### PR DESCRIPTION
https://datical.atlassian.net/browse/DAT-18307

🔧 (os-extension-automated-release.yml): improve retrieval of draft release ID by sorting releases by created_at date and selecting the last one to ensure the newest draft release ID is used