### PR TITLE
🔧 (extension-attach-artifact-release.yml): use matrix.os value for ru…

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -58,7 +58,7 @@ jobs:
         os: ${{fromJson(inputs.os || '["ubuntu-latest"]')}}
     name: Build & Package - ${{ matrix.os }}
     if: ${{ inputs.combineJars }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
…ns-on field to allow flexibility in choosing operating system for the workflow job.