### PR TITLE
use bash shell in windows runners due to required syntax

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id
+        shell: bash
         run: |
           artifact_id=$(mvn help:evaluate "-Dexpression=project.artifactId" -q -DforceStdout)
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
@@ -149,6 +150,7 @@ jobs:
       - name: Get Artifact Version
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-version
+        shell: bash
         run: |
           artifact_version=$(mvn help:evaluate "-Dexpression=project.version" -q -DforceStdout)
           echo "artifact_version=$artifact_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
use bash in windows runners to avoid syntax mismatches
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell