### PR TITLE
use bash shell for artifact ID and version

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -182,12 +182,14 @@ jobs:
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id
-        run: echo "::set-output name=artifact_id::$(mvn help:evaluate \"-Dexpression=project.artifactId\" -q -DforceStdout)"
+        shell: bash
+        run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
 
       - name: Get Artifact Version
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-version
-        run: echo "::set-output name=artifact_version::$(mvn help:evaluate \"-Dexpression=project.version\" -q -DforceStdout)"
+        shell: bash
+        run: echo "::set-output name=artifact_version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
       - name: Save Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -182,12 +182,12 @@ jobs:
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id
-        run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
+        run: echo "::set-output name=artifact_id::$(mvn help:evaluate \"-Dexpression=project.artifactId\" -q -DforceStdout)"
 
       - name: Get Artifact Version
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-version
-        run: echo "::set-output name=artifact_version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+        run: echo "::set-output name=artifact_version::$(mvn help:evaluate \"-Dexpression=project.version\" -q -DforceStdout)"
 
       - name: Save Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -183,13 +183,13 @@ jobs:
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id
         shell: bash
-        run: echo "::set-output name=artifact_id::$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
+        run: echo "artifact_id=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Get Artifact Version
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-version
         shell: bash
-        run: echo "::set-output name=artifact_version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+        run: echo "artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Save Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I don't actually know if this is going to work, but this currently fails on Windows builds:

https://github.com/liquibase/liquibase-checks/actions/runs/10374118321/job/28720832834?pr=72#step:11:15