### PR TITLE
DAT-18326 test-harness is failing at createRelease step

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,9 +13,15 @@ on:
         required: false
         default: "."
         type: string
+      sonar:
+        description: 'Specify it if you want to run sonar scan'
+        required: false
+        default: true
+        type: boolean
   
 jobs:
   sonar:
+    if: ${{ inputs.sonar == true }}
     uses: liquibase/build-logic/.github/workflows/sonar-push.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
🔧 (create-release.yml): add support for running Sonar scan by introducing a new 'sonar' input parameter with a default value of true