### PR TITLE
🔧 use shell:bash to run Linux commands

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -155,6 +155,7 @@ jobs:
 
       - name: Run extra Linux command
         if: inputs.extraLinuxCommand != ''
+        shell: bash
         run: |
           ${{ inputs.extraLinuxCommand }}
 

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -159,6 +159,12 @@ jobs:
         run: |
           ${{ inputs.extraLinuxCommand }}
 
+      - name: Run extra Windows Command
+        if: inputs.extraWindowsCommand != ''
+        shell: cmd
+        run: |
+          ${{ inputs.extraWindowsCommand }}
+          
       - name: Build and Package latest liquibase version
         if: ${{ inputs.nightly }}
         shell: bash

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Run extra Windows Command
         if: inputs.extraWindowsCommand != '' && runner.os == 'Windows'
-        shell: cmd
+        shell: powershell
         run: |
           ${{ inputs.extraWindowsCommand }}
           

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -154,7 +154,7 @@ jobs:
           ${{ inputs.extraCommand }}
 
       - name: Run extra Linux command
-        if: inputs.extraLinuxCommand != ''
+        if: inputs.extraLinuxCommand != '' && runner.os == 'Linux'
         shell: bash
         run: |
           ${{ inputs.extraLinuxCommand }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -160,7 +160,7 @@ jobs:
           ${{ inputs.extraLinuxCommand }}
 
       - name: Run extra Windows Command
-        if: inputs.extraWindowsCommand != ''
+        if: inputs.extraWindowsCommand != '' && runner.os == 'Windows'
         shell: cmd
         run: |
           ${{ inputs.extraWindowsCommand }}


### PR DESCRIPTION
- specify shell: bash, it will run the commands in a Bash shell, capable of executing Linux commands.
- extra step for Running Windows Command