### PR TITLE
🔧 Update actions/download-artifact version

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -365,19 +365,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Download Ubuntu Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{needs.build.outputs.artifact_id}}-ubuntu-latest-${{needs.build.outputs.artifact_version}}-artifacts
           path: /tmp/ubuntu
 
       - name: Download macOS Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{needs.build.outputs.artifact_id}}-macos-latest-${{needs.build.outputs.artifact_version}}-artifacts
           path: /tmp/macos
 
       - name: Download Windows Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{needs.build.outputs.artifact_id}}-windows-latest-${{needs.build.outputs.artifact_version}}-artifacts
           path: /tmp/windows


### PR DESCRIPTION
fix: `.github/workflows/pro-extension-test.yml` : use version 3 of `actions/download-artifact`. 
failing workflows : https://github.com/liquibase/liquibase-checks/actions/runs/10796187033/job/29945308542?pr=90
`Error: This request has been automatically failed because it uses a deprecated version of ``actions/download-artifact: v2``. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/`

<img width="1845" alt="Screenshot 2024-09-10 at 11 30 59 AM" src="https://github.com/user-attachments/assets/b60421c6-0f30-415b-b73d-6949f3e6602f">

