### PR TITLE
feat: DAT-18744: add liquibase-aws-license-service to os-extension-automated-release.yml

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -10,7 +10,7 @@ on:
       repositories:
         description: 'Comma separated list of repositories to release'
         required: false
-        default: '["liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-parent-pom"]'
+        default: '["liquibase-aws-license-service",liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-parent-pom"]'
         type: string
 
 jobs:


### PR DESCRIPTION
- feat: add `liquibase-aws-license-service` to os-extension-automated-release.yml to release a new version of `liquibase-aws-license-service` automatically.

**NOTE**: going forward liquibase-aws-license-service will be synced with core version, ie it will jump from 1.0.2 to 4.30.0
