### PR TITLE
chore: do not release sources and javadoc for pom project

### DIFF
--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -62,7 +62,7 @@ jobs:
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
                       -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
                       -Dtypes=pom.asc \
-                      -Dclassifiers=bin
+                      -Dclassifiers=,
 
   maven-release:
     needs: release

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -62,7 +62,7 @@ jobs:
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
                       -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
                       -Dtypes=pom.asc \
-                      -Dclassifiers=asc
+                      -Dclassifiers=bin
 
   maven-release:
     needs: release

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -62,6 +62,7 @@ jobs:
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
                       -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
                       -Dtypes=pom.asc
+                      -Dclassifiers=asc
 
   maven-release:
     needs: release

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -60,13 +60,11 @@ jobs:
                       -DpomFile=${{ env.artifact_id }}-${version}.pom \
                       -DgeneratePom=false \
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
-                      -Dsources=${{ env.artifact_id }}-${version}-sources.jar \
-                      -Djavadoc=${{ env.artifact_id }}-${version}-javadoc.jar \
-                      -Dfiles=${{ env.artifact_id }}-${version}-sources.jar.asc,${{ env.artifact_id }}-${version}-javadoc.jar.asc,${{ env.artifact_id }}-${version}.pom.asc \
-                      -Dtypes=jar.asc,jar.asc,pom.asc \
-                      -Dclassifiers=sources,javadoc,
+                      -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
+                      -Dtypes=pom.asc
 
   maven-release:
     needs: release
     uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.7.8
     secrets: inherit
+    

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -61,7 +61,7 @@ jobs:
                       -DgeneratePom=false \
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
                       -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
-                      -Dtypes=pom.asc
+                      -Dtypes=pom.asc \
                       -Dclassifiers=asc
 
   maven-release:

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -62,7 +62,7 @@ jobs:
                       -Dfile=${{ env.artifact_id }}-${version}.pom \
                       -Dfiles=${{ env.artifact_id }}-${version}.pom.asc \
                       -Dtypes=pom.asc \
-                      -Dclassifiers=,
+                      -Dclassifiers=
 
   maven-release:
     needs: release

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -66,6 +66,6 @@ jobs:
 
   maven-release:
     needs: release
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     secrets: inherit
     


### PR DESCRIPTION
This PR reflect changes made on parent-pom project, as a pom project do not requires source and javadoc.