### PR TITLE
Remove unnecessary upload of event.json

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -191,12 +191,6 @@ jobs:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-${{ matrix.os }}-${{ steps.get-artifact-version.outputs.artifact_version }}-artifacts
           path: |
             ${{ inputs.artifactPath }}/target/*
-
-      - name: Save Event File
-        uses: actions/upload-artifact@v4
-        with:
-          name: Event File
-          path: ${{ github.event_path }}
     outputs:
       artifact_id: ${{ steps.get-artifact-id.outputs.artifact_id }}
       artifact_version: ${{ steps.get-artifact-version.outputs.artifact_version }}


### PR DESCRIPTION
When building multi-platform artifacts we upload an `Event File` object to the workflow. This will work once then fail on subsequent platform builds because the file already exists. I chose to remove this step because this file is not used anywhere. 

![image](https://github.com/user-attachments/assets/f930a040-96a9-4f87-bc0e-e845f569b8eb)
