### PR TITLE
CRUC-58 DevOps :: Remove Individual IAM Users and Transition to OIDC or Specific Static Credentials

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -71,7 +71,6 @@ on:
 env:
   AWS_REGION: us-east-1
   LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-  AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MAVEN_VERSION: "3.9.5"
 
@@ -87,6 +86,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
+          aws-region: us-east-1
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -238,6 +243,12 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
+          aws-region: us-east-1
+          
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -65,18 +65,13 @@ on:
       PRO_LICENSE_KEY:
         description: "PRO_LICENSE_KEY from the caller workflow"
         required: true
-      GHA_AWS_KEY_ID:
-        description: "GHA_AWS_KEY_ID from the caller workflow"
+      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA:
+        description: "OIDC Role from the caller workflow"
         required: true
-      GHA_AWS_KEY:
-        description: "GHA_AWS_KEY from the caller workflow"
-        required: true
-
 env:
   AWS_REGION: us-east-1
   LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_KEY }}
+  AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MAVEN_VERSION: "3.9.5"
 

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -25,7 +25,6 @@ jobs:
     
     env:
       LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
 
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +38,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
+          aws-region: us-east-1
+          
       # look for dependencies in maven
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -25,8 +25,7 @@ jobs:
     
     env:
       LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_KEY }}
+      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       AWS_REGION: us-east-1
       LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +39,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
+          aws-region: us-east-1
+          
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -26,8 +26,7 @@ jobs:
     env:
       AWS_REGION: us-east-1
       LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.GHA_AWS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_AWS_KEY }}
+      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to update the AWS authentication method from using access keys to using OIDC roles.

Changes to GitHub Actions workflows:

* [`.github/workflows/pro-extension-test.yml`](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cL68-R74): Replaced `GHA_AWS_KEY_ID` and `GHA_AWS_KEY` with `AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA` for AWS authentication.
* [`.github/workflows/sonar-pull-request.yml`](diffhunk://#diff-fc000050ca00a39fcce28bc1e5b62492255b4c9cb8b333da82c2202975892a43L28-R28): Updated the environment variables to use `AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA` instead of `GHA_AWS_KEY_ID` and `GHA_AWS_KEY`.
* [`.github/workflows/sonar-push.yml`](diffhunk://#diff-3cf0243751c2d2f0a56ede5613cabea668e70c7469a6c7374147704cd4078726L29-R29): Changed the AWS authentication method to use `AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA` in place of `GHA_AWS_KEY_ID` and `GHA_AWS_KEY`.