### PR TITLE
🔧 Need to keep upload and download artifact on same version

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -255,7 +255,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/os-extension-test.yml` file to update the version of the `sonar-pull-request.yml` workflow being used.

* [`.github/workflows/os-extension-test.yml`](diffhunk://#diff-43ea773ed34788e59031ecce17de6fe3c738530fa5aaaab22805ebf12ab58001L258-R258): Updated the `uses` line to reference the `main` branch of the `liquibase/build-logic/.github/workflows/sonar-pull-request.yml` instead of a specific version (`v0.7.8`).