### PR TITLE
DAT-19350 configure test-harness to deploy master-snapshot to GPM

### DIFF
--- a/.github/workflows/extension-deploy-master-snapshot.yml
+++ b/.github/workflows/extension-deploy-master-snapshot.yml
@@ -1,0 +1,75 @@
+name: Deploy Master Snapshot
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+          server-id: github
+          server-username: liquibot
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      # look for dependencies in maven
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              },
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              }
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT }}"
+              },
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT }}"
+              }
+            ]
+              
+      - name: Update version to master-SNAPSHOT
+        run: mvn versions:set -DnewVersion=master-SNAPSHOT
+
+      - name: Build and deploy snapshot
+        run: mvn deploy -P release -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying master snapshots. The workflow is triggered by pushes to the `main` branch and includes steps for setting up the Java Development Kit (JDK), configuring Maven settings, updating the project version, and deploying the snapshot.

Key changes:

* [`.github/workflows/extension-deploy-master-snapshot.yml`](diffhunk://#diff-1b971d3626975dfeabd0ea768d67c2df4af2174804ded98b4f7f1377e75ca483R1-R75): Added a new workflow named `Deploy Master Snapshot` that runs on `ubuntu-latest` and includes steps for checking out code, setting up JDK 17, configuring Maven settings, updating the project version to `master-SNAPSHOT`, and building and deploying the snapshot.