### PR TITLE
🔧 Use --experimental-force-first-party-scans flag

### DIFF
--- a/.github/workflows/generate-upload-fossa-report.yml
+++ b/.github/workflows/generate-upload-fossa-report.yml
@@ -37,7 +37,7 @@ jobs:
           export FOSSA_API_KEY="${{ secrets.FOSSA_API_KEY }}"
 
       - name: Analyze project
-        run: fossa analyze --static-only-analysis
+        run: fossa analyze --experimental-force-first-party-scans
 
       - name: Generate report
         run: |


### PR DESCRIPTION
This pull request includes a modification to the `.github/workflows/generate-upload-fossa-report.yml` file to improve the analysis process during the CI workflow.

CI workflow improvement:

* [`.github/workflows/generate-upload-fossa-report.yml`](diffhunk://#diff-80879043f56f0d1ad5339d692506295927c2dc42208a159d095c4a2a45c87b41L40-R40): Changed the `fossa analyze` command to use the `--experimental-force-first-party-scans` flag instead of `--static-only-analysis` to enhance the analysis process.