### PR TITLE
🔧 DAT-19449: update permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,9 @@ on:
         required: false
         default: true
         type: boolean
-  
+      permissions:
+      checks: write
+      
 jobs:
   sonar:
     if: ${{ inputs.sonar == true }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/create-release.yml` file. The change adds permissions to write checks for the workflow. Based on the issue discussed here: https://github.com/dorny/test-reporter/issues/229

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R21-R22): Added `permissions` with `checks: write` to the workflow configuration.