### PR TITLE
Delete checks permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,8 +18,6 @@ on:
         required: false
         default: true
         type: boolean
-      permissions:
-      checks: write
       
 jobs:
   sonar:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/create-release.yml` file. The change removes the `permissions` section, specifically the `checks: write` permission, from the workflow configuration.

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L21-L22): Removed the `permissions` section, including the `checks: write` permission.