### PR TITLE
🔧 use concurrency group to run one job at a time during PR merges

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -262,6 +262,8 @@ jobs:
     name: Attach Artifact to Release
     needs: [ combineJars ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: attach-artifact-${{ github.ref }}
     steps:
       - run: sleep 30
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -68,6 +68,8 @@ jobs:
     name: Build & Package - ${{ matrix.os }}
     if: ${{ inputs.combineJars }}
     runs-on: ${{ matrix.os }}
+    concurrency:
+      group: attach-artifact-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/extension-attach-artifact-release.yml`. The change introduces a concurrency group to the build and package job to prevent multiple runs from interfering with each other.

* [`.github/workflows/extension-attach-artifact-release.yml`](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9R71-R72): Added a `concurrency` group to the build and package job to ensure that only one job runs at a time for the same reference.