### PR TITLE
🔧 : Ensure VERSION_NUMBER is populated correctly when the workflow is triggered by workflow_call.

### DIFF
--- a/.github/workflows/generate-upload-fossa-report.yml
+++ b/.github/workflows/generate-upload-fossa-report.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      VERSION_NUMBER: ${{ inputs.version_number_for_report_generation }}
     permissions:
       contents: read
       packages: write
@@ -64,7 +65,7 @@ jobs:
         if: always()
         run: |
           csv_filename="${{ steps.get_repo_name.outputs.repo_name }}.csv"
-          aws s3 cp $csv_filename s3://liquibaseorg-origin/enterprise_fossa_report/${{ github.event.inputs.version_number_for_report_generation }}/raw_reports/
+          aws s3 cp $csv_filename s3://liquibaseorg-origin/enterprise_fossa_report/${{ env.VERSION_NUMBER }}/raw_reports/
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/generate-upload-fossa-report.yml` file to enhance the handling of version numbers during the FOSSA report generation and upload process.

Changes in environment variables:

* Added `VERSION_NUMBER` environment variable to utilize the input version number for report generation.

Changes in S3 upload command:

* Modified the S3 upload command to use the newly defined `VERSION_NUMBER` environment variable instead of the previous direct reference to `github.event.inputs.version_number_for_report_generation`.