### PR TITLE
update actions/upload-artifact version to v4

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -148,7 +148,7 @@ jobs:
 
 
       - name: Upload CSV to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: enterprise_report
           path: ${{ inputs.version_number_for_report_generation }}/enterprise_report.csv

--- a/.github/workflows/generate-upload-fossa-report.yml
+++ b/.github/workflows/generate-upload-fossa-report.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload to build page
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fossa-reports
           path: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use the latest version of the `upload-artifact` action.

* [`.github/workflows/fossa.yml`](diffhunk://#diff-0fb7586e3d92a536569e18dec5c4c7fb63f855d76efdf16ef133c5355013a881L151-R151): Updated the `upload-artifact` action from version 3 to version 4.
* [`.github/workflows/generate-upload-fossa-report.yml`](diffhunk://#diff-80879043f56f0d1ad5339d692506295927c2dc42208a159d095c4a2a45c87b41L76-R76): Updated the `upload-artifact` action from version 3 to version 4.