### PR TITLE
[GHSA-pj29-2cg8-7jjm] Refusal to Install Liquibase on Production and Pre-production Servers Due to Packaging and Security Concerns

### DIFF
--- a/.github/package-deb-pom.xml
+++ b/.github/package-deb-pom.xml
@@ -56,7 +56,7 @@
 							<type>directory</type>
 							<mapper>
 								<type>perm</type>
-								<prefix>/usr/bin</prefix>
+								<prefix>/opt/liquibase</prefix>
 								<filemode>755</filemode>
 							</mapper>
 						</data>

--- a/src/liquibase/deb/control/postinst
+++ b/src/liquibase/deb/control/postinst
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Define LIQUIBASE_HOME
-LIQUIBASE_HOME="/usr/bin"
+LIQUIBASE_HOME="/opt/liquibase"


### PR DESCRIPTION
This pull request includes changes to update the installation directory of Liquibase within the Debian package configuration. The most important changes include modifying the directory prefix in the `.github/package-deb-pom.xml` file and updating the `LIQUIBASE_HOME` environment variable in the `postinst` script.

Changes to installation directory:

* [`.github/package-deb-pom.xml`](diffhunk://#diff-7ba03948b348b869252b6a868a4da5fed7cfed73a962c52b029578b170a6517dL59-R59): Changed the directory prefix from `/usr/bin` to `/opt/liquibase` to align with the new installation path.
* [`src/liquibase/deb/control/postinst`](diffhunk://#diff-3477e4c9d7cea3a345126174f85c9f7b993f82909c831d1e089925f1dbf33f85L4-R4): Updated the `LIQUIBASE_HOME` environment variable to reflect the new installation directory `/opt/liquibase`.