### PR TITLE
🔧 DAT-19574: add branch as an input parameter to workflows

### DIFF
--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -56,6 +56,10 @@ on:
         required: true
         description: 'Version to publish'
         type: string
+      branch:
+        required: true
+        description: 'Branch to check out'
+        type: string
     secrets:
       SONAR_TOKEN:
         description: "SONAR_TOKEN from the caller workflow"
@@ -87,6 +91,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.branch }}
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Configure AWS Credentials

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -17,6 +17,10 @@ on:
         required: true
         description: "Repository to check out"
         type: string
+      branch:
+        required: true
+        description: "Branch to check out"
+        type: string
 
 jobs:
   build:
@@ -30,7 +34,8 @@ jobs:
       combineJars: true
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
-
+      branch: ${{ inputs.branch }}
+      
   publish-main-snapshots-to-gpm:
     name: Publish to GPM
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes changes to two GitHub Actions workflows: `pro-extension-build-for-liquibase.yml` and `publish-for-liquibase.yml`. The main purpose of these changes is to add support for specifying a branch to check out during the workflow execution.

### Changes to GitHub Actions workflows:

* `.github/workflows/pro-extension-build-for-liquibase.yml`:
  * Added a new required input parameter `branch` to specify the branch to check out.
  * Updated the `actions/checkout` step to use the new `branch` input parameter.

* `.github/workflows/publish-for-liquibase.yml`:
  * Added a new required input parameter `branch` to specify the branch to check out.
  * Updated the `build` job to include the new `branch` input parameter.