### PR TITLE
🔧 : Update fossa_ai.yml run conditions 

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -162,7 +162,10 @@ jobs:
   generate-oss-pro-sbom-reports:
     runs-on: ubuntu-latest
     permissions: write-all
-    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'repository_dispatch')
+      || (github.event_name == 'workflow_dispatch' && !needs.fossa-scan.result)
+
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:


### PR DESCRIPTION
The reason for this change is because the `fossa_ai.yml` was running even on run of Unit and Integration Tests of OSS:
https://github.com/liquibase/liquibase/actions/runs/13268732878/job/37043608565.

<img width="1319" alt="Screenshot 2025-02-11 at 11 59 46 AM" src="https://github.com/user-attachments/assets/5dd2fedf-341d-4212-b90c-9fc852c70576" />

✅ Runs if repository_dispatch (always runs)
✅ Runs if workflow_dispatch AND first-job did NOT run
❌ Skips if workflow_dispatch AND first-job ran
❌ Skips for any other events (push, pull_request, schedule)


