### PR TITLE
🔧 checkout ref value

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -171,7 +171,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          
       - name: Install FOSSA CLI
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/fossa_ai.yml` file. The change ensures that the code checkout step in the workflow fetches the entire history by setting the `fetch-depth` to 0 and checks out the specific branch or tag referenced by `github.ref`.