### PR TITLE
🔧 : Fix/generate-oss-pro-sbom-reports

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -40,6 +40,7 @@ on:
     types: [oss-released-version]
 
 jobs:
+  # run only on workflow_call event
   fossa-scan:
     runs-on: ubuntu-latest
     permissions: write-all
@@ -162,8 +163,9 @@ jobs:
         with:
           name: sbom
           path: sbom.html
-
-  generate-oss-pro-sbom-reports:
+     
+  # run only on repository_dispatch event and workflow_dispatch event
+  generate-oss-pro-sbom-reports: 
     runs-on: ubuntu-latest
     permissions: write-all
     if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
@@ -171,40 +173,39 @@ jobs:
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:
-      - name: Checkout Code
-        if: github.event_name == 'repository_dispatch'
-        uses: actions/checkout@v4
-
-      - name: Checkout Code
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.inputs.repo_name }}
-          ref: ${{ github.event.inputs.branch_name }}
-      
       - name: Setup 
         id: setup
         run: |
-          echo "repo_name=${{ github.event.inputs.repo_name || github.event.client_payload.repo_name}}" >> $GITHUB_OUTPUT
+          echo "repo_name=${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }}" >> $GITHUB_OUTPUT
           echo "latest_version=${{ github.event.inputs.latest_version || github.event.client_payload.latest_version}}" >> $GITHUB_OUTPUT
+          echo "branch_name=${{ github.event.inputs.branch_name || github.event.client_payload.branch_name}}" >> $GITHUB_OUTPUT
+          
+          # remove the org_name from repo_name
+          fossa_repo_name="$(echo ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} | cut -d'/' -f2)" 
+          echo "fossa_repo_name=$fossa_repo_name" >> $GITHUB_OUTPUT
 
-
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.setup.outputs.repo_name }}
+          ref: ${{ steps.setup.outputs.branch_name }}
+          
       - name: Install FOSSA CLI
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
       - name: Run FOSSA SBOM Report for OSS
-        if: ${{ steps.setup.outputs.repo_name == 'liquibase' }}
+        if: ${{ steps.setup.outputs.fossa_repo_name == 'liquibase' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format html 2>&1 | tee oss-sbom.html
+          fossa report -p ${{ steps.setup.outputs.fossa_repo_name }} attribution --format html 2>&1 | tee oss-sbom.html
 
       - name: Run FOSSA SBOM Reports for OSS-pro
-        if: ${{ steps.setup.outputs.repo_name == 'liquibase-pro' }}
+        if: ${{ steps.setup.outputs.fossa_repo_name == 'liquibase-pro' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
-          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
+          fossa report -p ${{ steps.setup.outputs.fossa_repo_name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
+          fossa report -p ${{ steps.setup.outputs.fossa_repo_name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -214,11 +215,11 @@ jobs:
           aws-region: us-east-1
 
       - name: Get current timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        id: get-timestamp
+        run: echo "timestamp=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Upload OSS FOSSA Results to s3
         run: |
-          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
+          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
+          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/

--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -32,6 +32,7 @@ on:
       repo_name:
         required: true
         type: string
+        description: "The name of the repo should be org/repo_name. eg: liquibase/repo_name or datical/repo_name"
       branch_name:
         required: true
         type: string  

--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -32,6 +32,9 @@ on:
       repo_name:
         required: true
         type: string
+      branch_name:
+        required: true
+        type: string  
   repository_dispatch:
     types: [oss-released-version]
 
@@ -39,7 +42,7 @@ jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     permissions: write-all
-    if: github.event_name != 'repository_dispatch'
+    if: github.event_name != 'repository_dispatch' && github.event_name != 'workflow_dispatch'
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
@@ -162,35 +165,45 @@ jobs:
   generate-oss-pro-sbom-reports:
     runs-on: ubuntu-latest
     permissions: write-all
-    if: >-
-      (github.event_name == 'repository_dispatch')
-      || (github.event_name == 'workflow_dispatch' && !needs.fossa-scan.result)
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
 
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     steps:
       - name: Checkout Code
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Checkout Code
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-          
+          repository: ${{ github.event.inputs.repo_name }}
+          ref: ${{ github.event.inputs.branch_name }}
+      
+      - name: Setup 
+        id: setup
+        run: |
+          echo "repo_name=${{ github.event.inputs.repo_name || github.event.client_payload.repo_name}}" >> $GITHUB_OUTPUT
+          echo "latest_version=${{ github.event.inputs.latest_version || github.event.client_payload.latest_version}}" >> $GITHUB_OUTPUT
+
+
       - name: Install FOSSA CLI
         run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
       - name: Run FOSSA SBOM Report for OSS
-        if: ${{ github.event.inputs.repo_name == 'liquibase' || github.event.client_payload.repo_name == 'liquibase' }}
+        if: ${{ steps.setup.outputs.repo_name == 'liquibase' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format html 2>&1 | tee oss-sbom.html
+          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format html 2>&1 | tee oss-sbom.html
 
       - name: Run FOSSA SBOM Reports for OSS-pro
-        if: ${{ github.event.inputs.repo_name == 'liquibase-pro' || github.event.client_payload.repo_name == 'liquibase-pro' }}
+        if: ${{ steps.setup.outputs.repo_name == 'liquibase-pro' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
-          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
+          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
+          fossa report -p ${{ steps.setup.outputs.repo_name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -205,6 +218,6 @@ jobs:
 
       - name: Upload OSS FOSSA Results to s3
         run: |
-          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ env.timestamp }}/

--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -183,14 +183,14 @@ jobs:
         if: ${{ github.event.inputs.repo_name == 'liquibase' || github.event.client_payload.repo_name == 'liquibase' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ github.event.repository.name }} attribution --format html 2>&1 | tee oss-sbom.html
+          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format html 2>&1 | tee oss-sbom.html
 
       - name: Run FOSSA SBOM Reports for OSS-pro
         if: ${{ github.event.inputs.repo_name == 'liquibase-pro' || github.event.client_payload.repo_name == 'liquibase-pro' }}
         run: |
           # https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/report.md
-          fossa report -p ${{ github.event.repository.name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
-          fossa report -p ${{ github.event.repository.name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
+          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format cyclonedx-json 2>&1 | tee pro-sbom-cyclonedx-json.json
+          fossa report -p ${{ github.event.inputs.repo_name || github.event.client_payload.repo_name }} attribution --format spdx-json 2>&1 | tee pro-sbom-spdx-json.json
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -205,6 +205,6 @@ jobs:
 
       - name: Upload OSS FOSSA Results to s3
         run: |
-          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version }}_${{ env.timestamp }}/
-          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/
+          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ github.event.inputs.latest_version || github.event.client_payload.latest_version }}_${{ env.timestamp }}/


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/fossa_ai.yml` file to enhance the workflow for generating and uploading FOSSA SBOM reports. The most important changes include adding new input parameters, modifying conditions for job execution, and updating steps to use these new inputs.

Enhancements to workflow inputs and conditions:

* Added `description` for the `repo_name` input and introduced a new `branch_name` input to the workflow.
* Modified the condition for the `fossa-scan` job to run only on specific events (`repository_dispatch` and `workflow_dispatch`).
* Changed the condition for the `generate-oss-pro-sbom-reports` job to simplify the event checks.

Updates to job steps:

* Added a `Setup` step to extract and set up necessary inputs like `repo_name`, `latest_version`, and `branch_name`.
* Updated the `Checkout Code` step to use the `repo_name` and `branch_name` from the setup step outputs.
* Modified the `Run FOSSA SBOM Report for OSS` and `Run FOSSA SBOM Reports for OSS-pro` steps to use the parsed `fossa_repo_name` from the setup step.
* Changed the `Get current timestamp` step to use `GITHUB_OUTPUT` instead of `GITHUB_ENV`.
* Updated the `Upload OSS FOSSA Results to s3` step to use the `latest_version` and `timestamp` from the setup and timestamp steps.