### PR TITLE
🔧 homebrew PR creation issue

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -241,6 +241,7 @@ jobs:
           else
             echo "PR_EXISTS=true" >> $GITHUB_ENV
           fi
+            echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew formula for ${{ inputs.artifactId }}
         if: ${{ env.PR_EXISTS == false && inputs.dry_run == false }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -244,7 +244,7 @@ jobs:
             echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew formula for ${{ inputs.artifactId }}
-        if: ${{ env.PR_EXISTS == false && inputs.dry_run == false }}
+        if: ${{ env.PR_EXISTS == 'false' && inputs.dry_run == false }}
         uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: liquibase

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -241,7 +241,8 @@ jobs:
           else
             echo "PR_EXISTS=true" >> $GITHUB_ENV
           fi
-            echo "PR_EXISTS is set to $PR_EXISTS"
+          # Check PR_EXISTS value
+          echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew formula for ${{ inputs.artifactId }}
         if: ${{ env.PR_EXISTS == 'false' && inputs.dry_run == false }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/package.yml` file. The change ensures that the `PR_EXISTS` environment variable is correctly checked as a string in the conditional statement.

* [`.github/workflows/package.yml`](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R244-R248): Modified the conditional check for `PR_EXISTS` to compare it as a string ('false') instead of a boolean (false).