### PR TITLE
DAT-19298 DevOps :: Refactor test.yml to use localstack for redshift extensions

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -71,6 +71,11 @@ on:
           required: false
           type: boolean
           default: false
+        aws_redshift:
+          description: 'Deploy or destroy the aws_redshift infrastructure'
+          required: false
+          type: boolean
+          default: false
         stack_id:
             description: 'The stack ID to destroy'
             required: false
@@ -164,6 +169,7 @@ jobs:
             spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mssql ${{ inputs.aws_mssql }}
             spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_aurora_postgres ${{ inputs.aws_aurora_postgres }}
             spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mysql ${{ inputs.aws_mysql }}
+            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_redshift ${{ inputs.aws_redshift }}
             spacectl stack deploy --id $EPHEMERAL_STACK_ID --auto-confirm
     
       - name: Destroy ephemeral infra


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/ephemeral-cloud-infra.yml` file to add support for deploying or destroying AWS Redshift infrastructure.

Changes to support AWS Redshift:

* Added `aws_redshift` as an input parameter with a description, required status, type, and default value.
* Updated the `jobs` section to set the environment variable `TF_VAR_create_aws_redshift` based on the new `aws_redshift` input parameter.