### PR TITLE
🔧 output the value of $PR_EXISTS properly

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -237,11 +237,15 @@ jobs:
           echo "pr_title: $pr_title"
           # Set the environment variable based on whether the PR exists
           if [ -z "$pr_title" ]; then
-            echo "PR_EXISTS=false" >> $GITHUB_ENV
+            echo "PR_EXISTS=false" 
           else
-            echo "PR_EXISTS=true" >> $GITHUB_ENV
+            echo "PR_EXISTS=true"
           fi
-          # Check PR_EXISTS value
+          
+          # Store it in GitHub environment for later steps
+          echo "PR_EXISTS=$PR_EXISTS" >> $GITHUB_ENV
+
+          # Echo it immediately to see the value in logs
           echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew formula for ${{ inputs.artifactId }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/package.yml` file. The change involves updating the way the `PR_EXISTS` environment variable is set and stored for later steps in the GitHub Actions workflow.

* [`.github/workflows/package.yml`](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L240-R248): Modified the script to store the `PR_EXISTS` value in the GitHub environment for later steps and immediately echo the value to see it in the logs.