### PR TITLE
🔧 update s3 location for sboms

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -220,6 +220,6 @@ jobs:
 
       - name: Upload OSS FOSSA Results to s3
         run: |
-          aws s3 cp oss-sbom.html s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
-          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
-          aws s3 cp pro-sbom-spdx-json.json s3://liquibaseorg-origin/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
+          aws s3 cp oss-sbom.html s3://liquibase-release-sboms/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
+          aws s3 cp pro-sbom-cyclonedx-json.json s3://liquibase-release-sboms/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/
+          aws s3 cp pro-sbom-spdx-json.json s3://liquibase-release-sboms/sbom-lb-lbpro-releases/liquibase-${{ steps.setup.outputs.latest_version }}_${{ steps.get-timestamp.outputs.timestamp }}/


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/fossa_ai.yml` file to update the S3 bucket paths for uploading OSS FOSSA results. The most important change is the modification of the S3 bucket name to a new destination.

Changes to S3 bucket paths:

* [`.github/workflows/fossa_ai.yml`](diffhunk://#diff-16fa3dae8fcf42e25227fd7efbf7683e56bb393265c17267bd5a6eada811edfeL223-R225): Updated the S3 bucket paths from `s3://liquibaseorg-origin/sbom-lb-lbpro-releases/` to `s3://liquibase-release-sboms/sbom-lb-lbpro-releases/` for uploading OSS FOSSA results.