### PR TITLE
🔧 Update sonar-pr condition to include Java 17 check

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -445,7 +445,7 @@ jobs:
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{needs.build.outputs.artifact_version}}.pom
 
   sonar-pr:
-    if: ${{ !inputs.nightly }}
+    if: ${{ !inputs.nightly && inputs.java == '17' }}
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request includes a conditional update to the `sonar-pr` job within the `.github/workflows/pro-extension-test.yml` file. The change ensures that the job only runs when the `nightly` input is false and the `java` input is set to '17' as the [sonar-pull-request.yml](https://github.com/liquibase/build-logic/blob/main/.github/workflows/sonar-pull-request.yml#L104) expects `test-reports-jdk-17-ubuntu-latest` artifacts

* [`.github/workflows/pro-extension-test.yml`](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cL448-R448): Updated the condition for the `sonar-pr` job to check both `inputs.nightly` and `inputs.java` values.