### PR TITLE
🔧 Update workflow to use Ubuntu 22.04 for deployment

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -285,7 +285,7 @@ jobs:
   deploy_xsd:
     if: inputs.nameSpace != '' && inputs.deployToMavenCentral == true && inputs.dry_run == false
     name: Upload xsds
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer version of the Ubuntu runner.

* [`.github/workflows/extension-release-published.yml`](diffhunk://#diff-8f35892fff793298c429a326782b9912e79873322b834b9f18da1b918718e39aL288-R288): Changed the `runs-on` parameter for the `deploy_xsd` job from `ubuntu-20.04` to `ubuntu-22.04`.