### PR TITLE
🔧 Update pro-extension-test.yml secrets requirements

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -70,16 +70,16 @@ on:
         required: true
       AZURE_TENANT_ID:
         description: "Azure Active Directory (AD) tenant ID."
-        required: true
+        required: false
       AZURE_CLIENT_SECRET:
         description: "Secret key for Azure authentication."
-        required: true
+        required: false
       AZURE_CLIENT_ID:
         description: "Client ID for Azure service authentication."
-        required: true
+        required: false
       LIQUIBASE_AZURE_STORAGE_ACCOUNT:
         description: "Azure Storage Account name for Liquibase."
-        required: true
+        required: false
   
 env:
   AWS_REGION: us-east-1


### PR DESCRIPTION
NOTE: not all pro-extensions need the Azure-secrets. Hence, adding `required: false` for the Azure secrets. 