### PR TITLE
✨ DAT-19740: upload ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -238,6 +238,13 @@ jobs:
         with:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-${{ matrix.os }}-${{ steps.get-artifact-version.outputs.artifact_version }}-events
           path: ${{ github.event_path }}
+          
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts
+          path: |
+            target/*
 
     outputs:
       artifact_id: ${{ steps.get-artifact-id.outputs.artifact_id }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -239,7 +239,8 @@ jobs:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-${{ matrix.os }}-${{ steps.get-artifact-version.outputs.artifact_version }}-events
           path: ${{ github.event_path }}
           
-      - name: Save Artifacts
+      - name: Save Artifacts for Ubuntu Latest to be used for GPM publishing
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts


### PR DESCRIPTION
- To facilitate the publication of artifacts to GPM here in azure-extension for checks to consume it : I need to upload `${{ steps.get-artifact-id.outputs.artifact_id }}-artifacts` to the build page here: https://github.com/liquibase/liquibase-azure-extension/actions/runs/13721607940. 

- Resolving issue of `The following artifacts could not be resolved: org.liquibase.ext:liquibase-azure-extension:jar:1.0.0-SNAPSHOT (absent)` https://github.com/liquibase/liquibase-checks/actions/runs/13638267536/job/38144289006#step:13:2521