### PR TITLE
DAT-19650: remove artifact path because liquibase-checks was refactored

### DIFF
--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -30,7 +30,6 @@ jobs:
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'
       java: "[17, 21]"
-      artifactPath: liquibase-checks
       combineJars: true
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}


### PR DESCRIPTION
The multimodule pom project in liquibase-checks was refactored into a single project, and thus, the artifact is not in a subdirectory.