### PR TITLE
🔧 DAT-19850: edit concurrency group based on os

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{ inputs.combineJars }}
     runs-on: ${{ matrix.os }}
     concurrency:
-      group: attach-artifact-${{ github.ref }}
+      group: attach-artifact-${{ github.ref }}-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Why the change ?
-> https://datical.atlassian.net/browse/DAT-19850?focusedCommentId=161891

There are 2 issues here: 

Issue1: Race Condition Between Concurrent PRs ticket [DAT-18547](https://datical.atlassian.net/browse/DAT-18547) - resolved, solution was to  use the concurrency feature to cancel in-flight jobs and only keep the latest for a specific ref hence using ${{ github.ref }} 

Issue2: Current issue, the real problem lies in how thhe above concurrency is applied per OS runner. As we are doing a matrix build across our OS’s -ubuntu-latest, macos-latest, windows-latest, the same concurrency.group is shared by all of them. That means:

When one OS’s job is running eg: windowsOS -> a job on another OS eg: MacOS for the same ref is getting canceled even though it's part of the same overall workflow.

Solution: we can add the concurrency to include OS in that way each OS runner has its own concurrency set and preventing from cross cancellation but still keeping it that within the same OS + ref, only the latest job runs.



This pull request includes a change to the concurrency group in the GitHub Actions workflow for attaching artifacts. The change ensures that the concurrency group is unique per operating system.

* [`.github/workflows/extension-attach-artifact-release.yml`](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L71-R71): Updated the `concurrency` group to include the operating system in its name to avoid conflicts when running on different OSes.