### PR TITLE
hotfix for SDKman to reference the Cloudfront Distribution

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -270,7 +270,7 @@ jobs:
           SDKMAN_CONSUMER_KEY: ${{ secrets.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com/sdkman
+          S3_WEB_URL: repo.liquibase.com/sdkman
           S3_BUCKET: s3://repo.liquibase.com/sdkman/
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -270,7 +270,7 @@ jobs:
           SDKMAN_CONSUMER_KEY: ${{ secrets.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ secrets.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          S3_WEB_URL: repo.liquibase.com/sdkman
+          S3_WEB_URL: https://repo.liquibase.com/sdkman
           S3_BUCKET: s3://repo.liquibase.com/sdkman/
         run: |
           wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip


### PR DESCRIPTION
hotfix for SDKman to reference the Cloudfront Distribution, not the S3 bucket directly