### PR TITLE
DAT-20127 refactor: remove sensitive credentials from Maven commands in workflows

### DIFF
--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -44,7 +44,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
-      GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+      GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Dependencies
         run: |
@@ -97,12 +97,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -139,16 +139,20 @@ jobs:
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
           APP_TOKEN: ${{ steps.get-token.outputs.token }}
+          ACTIONS_RUNNER_DEBUG: true
+          ACTIONS_STEP_DEBUG: true
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-            mvn deploy:deploy-file \
+          mvn deploy:deploy-file \
               -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
               -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
               -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
               -DrepositoryId=extension-repo \
               -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
-              -DpomFile=pom.xml
-            cd ..
+              -DpomFile=pom.xml \
+              -X \
+              -Dgithub.token=${{ steps.get-token.outputs.token }}
+          cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -121,17 +121,17 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "extension-repo",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               }
             ]
 

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -121,12 +121,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "extension-repo",

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -141,11 +141,21 @@ jobs:
           APP_TOKEN: ${{ steps.get-token.outputs.token }}
           ACTIONS_RUNNER_DEBUG: true
           ACTIONS_STEP_DEBUG: true
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
+          # Debug token info (masked in logs)
+          echo "Token length: ${#APP_TOKEN}"
+          echo "First 4 chars: ${APP_TOKEN:0:4}..."
+
+          # Configure git for username/token in case it's needed
+          git config --global credential.helper store
+          echo "https://liquibot:${APP_TOKEN}@github.com" > ~/.git-credentials
+
+          # Deploy with explicit token authentication
           mvn deploy:deploy-file \
               -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
               -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
@@ -154,5 +164,7 @@ jobs:
               -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
               -DpomFile=pom.xml \
               -X \
-              -Dgithub.token=${{ steps.get-token.outputs.token }}
+              -Dgithub.token=${{ steps.get-token.outputs.token }} \
+              -Dserver.username=liquibot \
+              -Dserver.password=${{ steps.get-token.outputs.token }}
           cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -23,7 +23,7 @@ on:
 
 # Add permissions for the default GITHUB_TOKEN
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -73,6 +73,7 @@ jobs:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.extension }}
 
         #look for dependencies in maven
       - name: maven-settings-xml-action
@@ -136,6 +137,7 @@ jobs:
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          APP_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           package-name: ${{ inputs.groupId }}.${{ inputs.extension }}
           package-type: "maven"
-          token: ${{ secrets.GITHUB_TOKEN }}
           min-versions-to-keep: 5 # Keep the last 5 versions so we don't break simultaneous builds
           delete-only-pre-release-versions: true
 

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -163,7 +163,6 @@ jobs:
               -DrepositoryId=extension-repo \
               -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
               -DpomFile=pom.xml \
-              -X \
               -Dgithub.token=${{ steps.get-token.outputs.token }} \
               -Dserver.username=liquibot \
               -Dserver.password=${{ steps.get-token.outputs.token }}

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -66,6 +66,14 @@ jobs:
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
         #look for dependencies in maven
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22
@@ -121,7 +129,7 @@ jobs:
               {
                 "id": "extension-repo",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               }
             ]
 

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -74,9 +74,7 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ inputs.extension }}
-          permissions: |
-            contents: read
-            packages: write
+          permission-packages: write
 
         #look for dependencies in maven
       - name: maven-settings-xml-action
@@ -140,25 +138,17 @@ jobs:
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+          APP_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-          # Configure git credentials for Maven deploy
-          git config --global user.email "liquibot@liquibase.com"
-          git config --global user.name "liquibot"
-          
-          # Deploy with explicit server authentication
-          mvn deploy:deploy-file \
-            -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
-            -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
-            -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
-            -DrepositoryId=extension-repo \
-            -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
-            -DpomFile=pom.xml \
-            -DgroupId=${{ inputs.groupId || 'org.liquibase.ext' }} \
-            -DartifactId=${{ inputs.extension }} \
-            -Dversion=$EXTENSION_VERSION
-          cd ..
+            mvn deploy:deploy-file \
+              -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
+              -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
+              -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
+              -DrepositoryId=extension-repo \
+              -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
+              -DpomFile=pom.xml
+            cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -23,6 +23,7 @@ on:
 
 # Add permissions for the default GITHUB_TOKEN
 permissions:
+  contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -41,6 +41,9 @@ jobs:
   build-and-deploy-extensions:
     needs: [delete-dependency-packages]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
@@ -90,6 +93,17 @@ jobs:
                   "enabled": "true",
                   "updatePolicy": "always"
                 }
+              },
+              {
+                "id": "extension-repo",
+                "url": "https://maven.pkg.github.com/liquibase/${{ inputs.extension }}",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
               }
             ]
           servers: |
@@ -101,6 +115,11 @@ jobs:
               },
               {
                 "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.GITHUB_TOKEN }}"
+              },
+              {
+                "id": "extension-repo",
                 "username": "liquibot",
                 "password": "${{ secrets.GITHUB_TOKEN }}"
               }
@@ -118,7 +137,7 @@ jobs:
               -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
               -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
               -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
-              -DrepositoryId=liquibase \
+              -DrepositoryId=extension-repo \
               -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
               -DpomFile=pom.xml
             cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -74,6 +74,9 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ inputs.extension }}
+          permissions: |
+            contents: read
+            packages: write
 
         #look for dependencies in maven
       - name: maven-settings-xml-action
@@ -137,17 +140,25 @@ jobs:
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-          APP_TOKEN: ${{ steps.get-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-            mvn deploy:deploy-file \
-              -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
-              -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
-              -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
-              -DrepositoryId=extension-repo \
-              -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
-              -DpomFile=pom.xml
-            cd ..
+          # Configure git credentials for Maven deploy
+          git config --global user.email "liquibot@liquibase.com"
+          git config --global user.name "liquibot"
+          
+          # Deploy with explicit server authentication
+          mvn deploy:deploy-file \
+            -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
+            -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
+            -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
+            -DrepositoryId=extension-repo \
+            -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
+            -DpomFile=pom.xml \
+            -DgroupId=${{ inputs.groupId || 'org.liquibase.ext' }} \
+            -DartifactId=${{ inputs.extension }} \
+            -Dversion=$EXTENSION_VERSION
+          cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -62,86 +62,44 @@ jobs:
           distribution: "temurin"
           cache: "maven"
           server-id: github # Used for the settings.xml server configuration
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET }}
           gpg-passphrase: GPG_PASSPHRASE
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-        #look for dependencies in maven
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v22
-        with:
-          repositories: |
-            [
-              {
-                "id": "liquibase",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "liquibase-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "extension-repo",
-                "url": "https://maven.pkg.github.com/liquibase/${{ inputs.extension }}",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
-            ]
-          servers: |
-            [
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
-              },
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
-              },
-              {
-                "id": "extension-repo",
-                "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
-              }
-            ]
+      # Remove the maven-settings-xml-action step since setup-java already configures Maven
 
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-          # Debug - view Maven settings
-          cat ~/.m2/settings.xml
-          # Try with explicit credentials
+
+          # Add repository settings to the .m2/settings.xml
+          cat > ~/.m2/repository-settings.xml << EOF
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${MAVEN_USERNAME}</username>
+                <password>${MAVEN_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+          # Deploy using explicit settings file
           mvn deploy:deploy-file \
+            -s ~/.m2/repository-settings.xml \
             -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
             -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
             -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
@@ -151,6 +109,5 @@ jobs:
             -DartifactId=${{ inputs.extension }} \
             -Dversion=$EXTENSION_VERSION \
             -DgeneratePom=false \
-            -DpomFile=pom.xml \
-            -DretryFailedDeploymentCount=3
+            -DpomFile=pom.xml
           cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -61,53 +61,83 @@ jobs:
           java-version: 21
           distribution: "temurin"
           cache: "maven"
-          server-id: github # Used for the settings.xml server configuration
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET }}
           gpg-passphrase: GPG_PASSPHRASE
         env:
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      # Remove the maven-settings-xml-action step since setup-java already configures Maven
+        #look for dependencies in maven
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              },
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              },
+              {
+                "id": "extension-repo",
+                "url": "https://maven.pkg.github.com/liquibase/${{ inputs.extension }}",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              }
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.GITHUB_TOKEN }}"
+              },
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.GITHUB_TOKEN }}"
+              },
+              {
+                "id": "extension-repo",
+                "username": "liquibot",
+                "password": "${{ secrets.GITHUB_TOKEN }}"
+              }
+            ]
 
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-
-          # Add repository settings to the .m2/settings.xml
-          cat > ~/.m2/repository-settings.xml << EOF
-          <settings>
-            <servers>
-              <server>
-                <id>github</id>
-                <username>${MAVEN_USERNAME}</username>
-                <password>${MAVEN_PASSWORD}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
-
-          # Deploy using explicit settings file
-          mvn deploy:deploy-file \
-            -s ~/.m2/repository-settings.xml \
-            -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
-            -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
-            -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
-            -DrepositoryId=github \
-            -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
-            -DgroupId=${{ inputs.groupId }} \
-            -DartifactId=${{ inputs.extension }} \
-            -Dversion=$EXTENSION_VERSION \
-            -DgeneratePom=false \
-            -DpomFile=pom.xml
-          cd ..
+            mvn deploy:deploy-file \
+              -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
+              -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
+              -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
+              -DrepositoryId=extension-repo \
+              -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
+              -DpomFile=pom.xml
+            cd ..

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -21,6 +21,9 @@ on:
         default: ""
         type: string
 
+# Add permissions for the default GITHUB_TOKEN
+permissions:
+  packages: write
 
 jobs:
   delete-dependency-packages:
@@ -30,8 +33,8 @@ jobs:
       - uses: actions/delete-package-versions@v5
         with:
           package-name: ${{ inputs.groupId }}.${{ inputs.extension }}
-          package-type: 'maven'
-          token: ${{ secrets.BOT_TOKEN }}
+          package-type: "maven"
+          token: ${{ secrets.GITHUB_TOKEN }}
           min-versions-to-keep: 5 # Keep the last 5 versions so we don't break simultaneous builds
           delete-only-pre-release-versions: true
 
@@ -45,20 +48,20 @@ jobs:
     steps:
       - name: Checkout Dependencies
         run: |
-            git config --global credential.helper store
-            echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-            git clone https://github.com/liquibase/${{ inputs.extension }}.git ${{ inputs.extension }}
+          git config --global credential.helper store
+          echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
+          git clone https://github.com/liquibase/${{ inputs.extension }}.git ${{ inputs.extension }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
           gpg-private-key: ${{ secrets.GPG_SECRET }}
           gpg-passphrase: GPG_PASSPHRASE
         env:
-           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
         #look for dependencies in maven
       - name: maven-settings-xml-action
@@ -105,7 +108,7 @@ jobs:
 
       - name: Build and deploy Extension to GPM
         env:
-           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"

--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -61,9 +61,13 @@ jobs:
           java-version: 21
           distribution: "temurin"
           cache: "maven"
+          server-id: github # Used for the settings.xml server configuration
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
           gpg-private-key: ${{ secrets.GPG_SECRET }}
           gpg-passphrase: GPG_PASSPHRASE
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
         #look for dependencies in maven
@@ -128,16 +132,25 @@ jobs:
       - name: Build and deploy Extension to GPM
         env:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ${{ inputs.extension }}
           EXTENSION_VERSION="master-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
-            mvn deploy:deploy-file \
-              -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
-              -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
-              -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
-              -DrepositoryId=extension-repo \
-              -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
-              -DpomFile=pom.xml
-            cd ..
+          # Debug - view Maven settings
+          cat ~/.m2/settings.xml
+          # Try with explicit credentials
+          mvn deploy:deploy-file \
+            -Dfile=./target/${{ inputs.extension }}-$EXTENSION_VERSION.jar \
+            -Dsources=./target/${{ inputs.extension }}-$EXTENSION_VERSION-sources.jar \
+            -Djavadoc=./target/${{ inputs.extension }}-$EXTENSION_VERSION-javadoc.jar \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/liquibase/${{ inputs.extension }} \
+            -DgroupId=${{ inputs.groupId }} \
+            -DartifactId=${{ inputs.extension }} \
+            -Dversion=$EXTENSION_VERSION \
+            -DgeneratePom=false \
+            -DpomFile=pom.xml \
+            -DretryFailedDeploymentCount=3
+          cd ..

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,15 +31,17 @@ on:
         default: ''
         type: string
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  packages: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
@@ -136,12 +138,12 @@ jobs:
             {
               "id": "liquibase-pro",
               "username": "liquibot",
-              "password": "${{ secrets.LIQUIBOT_PAT }}"
+              "password": "${{ secrets.GITHUB_TOKEN }}"
             },
             {
               "id": "liquibase",
               "username": "liquibot",
-              "password": "${{ secrets.LIQUIBOT_PAT }}"
+              "password": "${{ secrets.GITHUB_TOKEN }}"
             }
           ]
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,6 +25,7 @@ permissions:
   issues: read
   statuses: read
   actions: read
+  security-events: write
 
 jobs:
   sonar:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   sonar:
     if: ${{ inputs.sonar == true }}
-    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@main
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extraCommand:
-        description: 'Specify it if you want to run an extra command before attaching the artifact'
+        description: "Specify it if you want to run an extra command before attaching the artifact"
         required: false
-        default: ''
+        default: ""
         type: string
       artifactPath:
         description: "Specify the path to the artifacts that should be attached to the build. Useful for multi-module extensions."
@@ -14,23 +14,27 @@ on:
         default: "."
         type: string
       sonar:
-        description: 'Specify it if you want to run sonar scan'
+        description: "Specify it if you want to run sonar scan"
         required: false
         default: true
         type: boolean
 
 permissions:
   contents: write
-      
+  pull-requests: read
+  issues: read
+  statuses: read
+  actions: read
+
 jobs:
   sonar:
     if: ${{ inputs.sonar == true }}
-    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-push.yml@DAT-20127
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
       artifactPath: ${{ inputs.artifactPath }}
-              
+
   create-release:
     name: Create Release
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: true
         type: boolean
+
+permissions:
+  contents: write
       
 jobs:
   sonar:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,4 +36,4 @@ jobs:
           # The URL of the PR to be merged and approved
           PR_URL: ${{github.event.pull_request.html_url}}
           # The GitHub token secret
-          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -113,7 +113,6 @@ jobs:
         with:
           ref: master
           repository: liquibase/liquibase-infrastructure
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -1,100 +1,104 @@
 # Terraform Action to lint and apply updated redirects
 name: Ephemeral Cloud Infrastructure
 on:
- workflow_call:
+  workflow_call:
     inputs:
-        deploy:
-            description: 'Deploy the ephemeral cloud infrastructure'
-            required: false
-            type: boolean
-        destroy:
-            description: 'Destroy the ephemeral cloud infrastructure'
-            required: false
-            type: boolean
-        dynamodb:
-            description: 'Deploy or destroy the dynamodb infrastructure'
-            required: false
-            type: boolean
-            default: false
-        documentdb:
-          description: 'Deploy or destroy the documentdb infrastructure'
-          required: false
-          type: boolean
-          default: false
-        snowflake_oss:
-          description: 'Deploy or destroy the snowflake OSS infrastructure'
-          required: false
-          type: boolean
-          default: false
-        snowflake_pro:
-          description: 'Deploy or destroy the snowflake PRO infrastructure'
-          required: false
-          type: boolean
-          default: false
-        snowflake_th:
-          description: 'Deploy or destroy the snowflake Test Harness infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_postgresql:
-          description: 'Deploy or destroy the aws_postgresql infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_oracle:
-          description: 'Deploy or destroy the aws_oracle infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_mariadb:
-          description: 'Deploy or destroy the aws_mariadb infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_aurora_mysql:
-          description: 'Deploy or destroy the aws_aurora_mysql infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_mssql:
-          description: 'Deploy or destroy the aws_mssql infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_aurora_postgres:
-          description: 'Deploy or destroy the aws_aurora_postgres infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_mysql:
-          description: 'Deploy or destroy the aws_mysql infrastructure'
-          required: false
-          type: boolean
-          default: false
-        aws_redshift:
-          description: 'Deploy or destroy the aws_redshift infrastructure'
-          required: false
-          type: boolean
-          default: false
-        stack_id:
-            description: 'The stack ID to destroy'
-            required: false
-            type: string
+      deploy:
+        description: "Deploy the ephemeral cloud infrastructure"
+        required: false
+        type: boolean
+      destroy:
+        description: "Destroy the ephemeral cloud infrastructure"
+        required: false
+        type: boolean
+      dynamodb:
+        description: "Deploy or destroy the dynamodb infrastructure"
+        required: false
+        type: boolean
+        default: false
+      documentdb:
+        description: "Deploy or destroy the documentdb infrastructure"
+        required: false
+        type: boolean
+        default: false
+      snowflake_oss:
+        description: "Deploy or destroy the snowflake OSS infrastructure"
+        required: false
+        type: boolean
+        default: false
+      snowflake_pro:
+        description: "Deploy or destroy the snowflake PRO infrastructure"
+        required: false
+        type: boolean
+        default: false
+      snowflake_th:
+        description: "Deploy or destroy the snowflake Test Harness infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_postgresql:
+        description: "Deploy or destroy the aws_postgresql infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_oracle:
+        description: "Deploy or destroy the aws_oracle infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_mariadb:
+        description: "Deploy or destroy the aws_mariadb infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_aurora_mysql:
+        description: "Deploy or destroy the aws_aurora_mysql infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_mssql:
+        description: "Deploy or destroy the aws_mssql infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_aurora_postgres:
+        description: "Deploy or destroy the aws_aurora_postgres infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_mysql:
+        description: "Deploy or destroy the aws_mysql infrastructure"
+        required: false
+        type: boolean
+        default: false
+      aws_redshift:
+        description: "Deploy or destroy the aws_redshift infrastructure"
+        required: false
+        type: boolean
+        default: false
+      stack_id:
+        description: "The stack ID to destroy"
+        required: false
+        type: string
     outputs:
-        stack_id:
-            description: 'The stack ID of the ephemeral cloud infrastructure'
-            value: ${{ jobs.ephemeral-cloud-infra.outputs.stack_id }}
-        resources_id:
-          description: 'The resources ID of the ephemeral cloud infrastructure'
-          value: ${{ jobs.ephemeral-cloud-infra.outputs.resources_id }}
+      stack_id:
+        description: "The stack ID of the ephemeral cloud infrastructure"
+        value: ${{ jobs.ephemeral-cloud-infra.outputs.stack_id }}
+      resources_id:
+        description: "The resources ID of the ephemeral cloud infrastructure"
+        value: ${{ jobs.ephemeral-cloud-infra.outputs.resources_id }}
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   ephemeral-cloud-infra:
     name: ${{ inputs.action}} Ephemeral Cloud Infrastructure
     runs-on: ubuntu-latest
-    permissions: 
-        contents: read
-        id-token: write
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       stack_id: ${{ steps.create_stack.outputs.stack_id }} # Used to reference the stack created in the ephemeral infra
       resources_id: ${{ steps.create_infra.outputs.resources_id }} # Used to reference the resources created in the ephemeral infra
@@ -109,7 +113,7 @@ jobs:
         with:
           ref: master
           repository: liquibase/liquibase-infrastructure
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -120,13 +124,13 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-            role-to-assume: ${{ secrets.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
-            aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC }}
+          aws-region: us-east-1
 
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Terraform Init
         working-directory: test-automation-ephemeral/stack
@@ -138,58 +142,58 @@ jobs:
         if: ${{ inputs.deploy }}
         working-directory: test-automation-ephemeral/stack
         run: |
-            terraform apply -auto-approve -var "run_id=${{ github.run_id }}" -var "run_repo=${{ github.repository }}"
-            echo "EPHEMERAL_STACK_ID=$(terraform output -raw ephemeral_stack_id)" >> $GITHUB_ENV
-            echo "stack_id=$(terraform output -raw ephemeral_stack_id)" >> "$GITHUB_OUTPUT"
-        
+          terraform apply -auto-approve -var "run_id=${{ github.run_id }}" -var "run_repo=${{ github.repository }}"
+          echo "EPHEMERAL_STACK_ID=$(terraform output -raw ephemeral_stack_id)" >> $GITHUB_ENV
+          echo "stack_id=$(terraform output -raw ephemeral_stack_id)" >> "$GITHUB_OUTPUT"
+
       - name: Upload Terraform state as artifact
         if: ${{ inputs.deploy && always()}}
         uses: actions/upload-artifact@v4
         with:
-            name: terraform-state
-            path: test-automation-ephemeral/stack/terraform.tfstate
+          name: terraform-state
+          path: test-automation-ephemeral/stack/terraform.tfstate
 
       - name: Create ephemeral infra
         id: create_infra
         working-directory: test-automation-ephemeral/infra
         if: ${{ inputs.deploy }}
         run: |
-            ID=$(echo ${{ steps.create_stack.outputs.stack_id }} | cut -d '-' -f 5)
-            echo "resources_id=$ID" >> "$GITHUB_OUTPUT"
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_stack_id $ID
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_dynamodb ${{ inputs.dynamodb }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_documentdb ${{ inputs.documentdb }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_oss ${{ inputs.snowflake_oss }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_pro ${{ inputs.snowflake_pro }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_th ${{ inputs.snowflake_th }} 
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_postgresql ${{ inputs.aws_postgresql }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_oracle ${{ inputs.aws_oracle }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mariadb ${{ inputs.aws_mariadb }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_aurora_mysql ${{ inputs.aws_aurora_mysql }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mssql ${{ inputs.aws_mssql }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_aurora_postgres ${{ inputs.aws_aurora_postgres }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mysql ${{ inputs.aws_mysql }}
-            spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_redshift ${{ inputs.aws_redshift }}
-            spacectl stack deploy --id $EPHEMERAL_STACK_ID --auto-confirm
-    
+          ID=$(echo ${{ steps.create_stack.outputs.stack_id }} | cut -d '-' -f 5)
+          echo "resources_id=$ID" >> "$GITHUB_OUTPUT"
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_stack_id $ID
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_dynamodb ${{ inputs.dynamodb }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_documentdb ${{ inputs.documentdb }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_oss ${{ inputs.snowflake_oss }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_pro ${{ inputs.snowflake_pro }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_th ${{ inputs.snowflake_th }} 
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_postgresql ${{ inputs.aws_postgresql }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_oracle ${{ inputs.aws_oracle }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mariadb ${{ inputs.aws_mariadb }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_aurora_mysql ${{ inputs.aws_aurora_mysql }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mssql ${{ inputs.aws_mssql }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_aurora_postgres ${{ inputs.aws_aurora_postgres }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mysql ${{ inputs.aws_mysql }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_redshift ${{ inputs.aws_redshift }}
+          spacectl stack deploy --id $EPHEMERAL_STACK_ID --auto-confirm
+
       - name: Destroy ephemeral infra
         continue-on-error: true
         env:
-            TF_VAR_stack_id: ${{ inputs.stack_id }}
+          TF_VAR_stack_id: ${{ inputs.stack_id }}
         if: ${{ inputs.destroy }}
         working-directory: test-automation-ephemeral/infra
         run: |
-            spacectl stack task --id ${{ inputs.stack_id }} --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve" || true
+          spacectl stack task --id ${{ inputs.stack_id }} --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve" || true
 
       - name: Download Terraform state
         if: ${{ inputs.destroy && always()}}
         uses: actions/download-artifact@v4
         with:
-            name: terraform-state
-            path: test-automation-ephemeral/stack
+          name: terraform-state
+          path: test-automation-ephemeral/stack
 
       - name: Destroy ephemeral stack
         if: ${{ inputs.destroy && always()}}
         working-directory: test-automation-ephemeral/stack
         run: |
-            terraform destroy -auto-approve -var "run_id=${{ github.run_id }}" -var "run_repo=${{ github.repository }}"
+          terraform destroy -auto-approve -var "run_id=${{ github.run_id }}" -var "run_repo=${{ github.repository }}"

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}'
+          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase
           git reset HEAD~ --hard
           mvn -B dependency:go-offline clean package -DskipTests=true ${{ inputs.extraMavenArgs }} -P '${{ inputs.mavenProfiles }}'
 
@@ -156,7 +156,7 @@ jobs:
         working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ inputs.dry_run_version }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}'
+          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ inputs.dry_run_version }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase
           git reset HEAD~ --hard
           mvn -B dependency:go-offline clean package -DskipTests=true ${{ inputs.extraMavenArgs }} -P '${{ inputs.mavenProfiles }}'
 
@@ -369,7 +369,7 @@ jobs:
         if: ${{ env.ARTIFACT_FOUND == '0' && inputs.dry_run == false }}
         id: build-release-artifacts
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}'
+          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase
           git reset HEAD~ --hard
           # Determine the default branch (master or main)
           if git rev-parse --verify origin/master >/dev/null 2>&1; then
@@ -388,7 +388,7 @@ jobs:
         if: ${{ inputs.dry_run == true }}
         id: build-release-artifacts-dry-run
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ inputs.dry_run_version }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}'
+          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ inputs.dry_run_version }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase
           git reset HEAD~ --hard
           # Determine the default branch (master or main)
           if git rev-parse --verify origin/master >/dev/null 2>&1; then
@@ -467,8 +467,8 @@ jobs:
           version=${{ inputs.dry_run_version }}
           ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.REPO_ROOT }}/${{ inputs.artifactPath }}/target/${{ env.artifact_id }}-${version}.jar
           ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.REPO_ROOT }}/${{ inputs.artifactPath }}/target/${{ env.artifact_id }}-${version}.pom
-          ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.REPO_ROOT }}/${{ inputs.artifactPath }}/target/${{ env.artifact_id }}-${version}-javadoc.jar
-          ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.REPO_ROOT }}/${{ inputs.artifactPath }}/target/${{ env.artifact_id }}-${version}-sources.jar
+          ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.artifactPath }}/target/${{ env.artifact_id }}-${version}-javadoc.jar
+          ${{ env.REPO_ROOT }}/.github/sign_artifact.sh ${{ env.artifactPath }}/target/${{ env.artifact_id }}-${version}-sources.jar
 
       - name: Set draft release title
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -1,5 +1,10 @@
 name: Attach Artifact to Release
 
+# Add permissions for the default GITHUB_TOKEN
+permissions:
+  contents: write
+  actions: read
+
 on:
   workflow_call:
     inputs:
@@ -413,7 +418,7 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         id: get-release
         run: |
-          LATEST_DRAFT_RELEASE=$(curl -X GET -H "Authorization: token ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases?per_page=1" | jq -r 'if .[].draft == true then .[].id else empty end')
+          LATEST_DRAFT_RELEASE=$(curl -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases?per_page=1" | jq -r 'if .[].draft == true then .[].id else empty end')
           echo "Latest Draft Release ID: $LATEST_DRAFT_RELEASE"
           echo "RELEASE_ID=$LATEST_DRAFT_RELEASE" >> $GITHUB_ENV
 
@@ -422,7 +427,7 @@ jobs:
         id: list-artifacts
         run: |
           RELEASE_ID="${{ env.RELEASE_ID }}"
-          ARTIFACTS=$(curl -X GET -H "Authorization: token ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets" | jq -r '.[].id')
+          ARTIFACTS=$(curl -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets" | jq -r '.[].id')
           echo "Artifacts to delete: $ARTIFACTS"
           ARTIFACTS_CLEANED=$(echo "$ARTIFACTS" | tr -s '[:space:]' ',' | sed 's/,$//')
           echo "ARTIFACTS_TO_DELETE=$ARTIFACTS_CLEANED" >> $GITHUB_ENV
@@ -434,7 +439,7 @@ jobs:
           ARTIFACTS_TO_DELETE="${{ env.ARTIFACTS_TO_DELETE }}"
           IFS=',' read -ra values <<< "$ARTIFACTS_TO_DELETE"
           for value in "${values[@]}"; do
-            curl -X DELETE -H "Authorization: token ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/assets/$value"
+            curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/assets/$value"
             echo "Deleted artifact ID: $value"
           done
 
@@ -478,7 +483,7 @@ jobs:
           version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           RELEASE_TITLE="v$version"
           echo "Updating release title to $RELEASE_TITLE"
-          curl -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" -d '{"name": "'"$RELEASE_TITLE"'", "tag_name": "'"v$version"'"}' "https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}"
+          curl -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"name": "'"$RELEASE_TITLE"'", "tag_name": "'"v$version"'"}' "https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}"
 
       - name: Attach Files to Draft Release
         if: ${{ inputs.dry_run == false }}
@@ -486,7 +491,7 @@ jobs:
         id: upload-release-asset
         run: ${{ env.REPO_ROOT }}/.github/upload_asset.sh $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSET_NAME_PREFIX: "${{ env.artifact_id }}-"
           ASSET_DIR: ./target
 
@@ -513,6 +518,6 @@ jobs:
         id: upload-release-zip
         run: ./.github/upload_zip.sh $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSET_NAME_PREFIX: "${{ env.artifact_id }}-"
           ASSET_DIR: ./target

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -4,6 +4,7 @@ name: Attach Artifact to Release
 permissions:
   contents: write
   actions: read
+  packages: write
 
 on:
   workflow_call:
@@ -53,9 +54,6 @@ on:
         required: false
         type: string
     secrets:
-      BOT_TOKEN:
-        description: "BOT_TOKEN from the caller workflow"
-        required: true
       GPG_SECRET:
         description: "GPG_SECRET from the caller workflow"
         required: true
@@ -123,12 +121,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 
@@ -312,12 +310,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -87,6 +87,11 @@ jobs:
         run: |
           ${{ inputs.extraCommand }}
 
+      - name: Configure Git
+        run: |
+          git config --local user.email "64099989+liquibot@users.noreply.github.com"
+          git config --local user.name "liquibot"
+
       - name: Prepare Maven Release
         working-directory: ${{ inputs.artifactPath }}
         run: |

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extraCommand:
-        description: 'Specify it if you want to run an extra command before attaching the artifact'
+        description: "Specify it if you want to run an extra command before attaching the artifact"
         required: false
-        default: ''
+        default: ""
         type: string
       artifactPath:
         description: "Specify the path to the artifacts that should be attached to the build. Useful for multi-module extensions."
@@ -18,7 +18,7 @@ permissions:
   contents: write
   pull-requests: write
   packages: write
-  
+
 jobs:
   prepare-release:
     name: Prepare release
@@ -34,10 +34,10 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
           overwrite-settings: false
-          
+
       # look for dependencies in maven
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22
@@ -102,7 +102,6 @@ jobs:
           git tag -d temp
           git push --force
 
-
       - name: Save Release files
         if: always()
         uses: actions/upload-artifact@v4
@@ -115,7 +114,7 @@ jobs:
   release-rollback:
     needs: prepare-release
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@DAT-20127
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -81,11 +81,6 @@ jobs:
               }
             ]
 
-      - name: Configure Git
-        run: |
-          git config --local user.email "64099989+liquibot@users.noreply.github.com"
-          git config --local user.name "liquibot"
-
       - name: Run extra command
         working-directory: ${{ inputs.artifactPath }}
         if: inputs.extraCommand != ''
@@ -99,8 +94,20 @@ jobs:
           -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
           -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.\${parsedVersion.incrementalVersion} \
           -DcheckModificationExcludeList=pom.xml -DpushChanges=false -Dtag=temp
-          git tag -d temp
-          git push --force
+
+      - name: Create Pull Request for version bump
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update version after release"
+          title: "Version bump after release"
+          body: |
+            This PR updates the POM version after a release.
+
+            Automated changes by GitHub Actions.
+          branch: version-bump-after-release
+          base: main
+          delete-branch: true
 
       - name: Save Release files
         if: always()

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
   
 jobs:
   prepare-release:
@@ -71,12 +72,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -111,7 +111,6 @@ jobs:
 
             Automated changes by GitHub Actions.
           branch: version-bump-after-release
-          base: main
           delete-branch: true
 
       - name: Save Release files

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -125,7 +125,7 @@ jobs:
   release-rollback:
     needs: prepare-release
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/extension-release-rollback.yml@main
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -22,8 +22,6 @@ jobs:
   prepare-release:
     name: Prepare release
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -98,7 +96,7 @@ jobs:
         working-directory: ${{ inputs.artifactPath }}
         run: |
           mvn -B build-helper:parse-version release:clean release:prepare \
-          -Darguments="-Dusername=liquibot -Dpassword=${{ secrets.BOT_TOKEN }} -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
+          -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
           -DdevelopmentVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.\${parsedVersion.incrementalVersion} \
           -DcheckModificationExcludeList=pom.xml -DpushChanges=false -Dtag=temp
           git tag -d temp
@@ -112,6 +110,7 @@ jobs:
           name: release-files
           path: |
             **/pom.xml.releaseBackup
+            **/release.properties
 
   release-rollback:
     needs: prepare-release

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -141,7 +141,7 @@ jobs:
         id: build-release-artifacts
         continue-on-error: true
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false
+          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false
           git reset HEAD~ --hard
 
       - name: Get Artifact ID

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   maven-release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     if: inputs.deployToMavenCentral == true
     secrets: inherit
     with:

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -44,6 +44,11 @@ on:
         description: 'SONATYPE_TOKEN from the caller workflow'
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
 jobs:
   maven-release:
     uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
@@ -111,12 +116,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "sonatype-nexus-staging",
@@ -232,12 +237,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "dry-run-sonatype-nexus-staging",

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       extraCommand:
-        description: 'Specify it if you want to run an extra command before attaching the artifact'
+        description: "Specify it if you want to run an extra command before attaching the artifact"
         required: false
-        default: ''
+        default: ""
         type: string
       nameSpace:
-        description: 'xsd namespace'
+        description: "xsd namespace"
         required: false
-        default: ''
+        default: ""
         type: string
       artifactPath:
         description: "Specify the path to the artifacts that should be attached to the build. Useful for multi-module extensions."
@@ -19,29 +19,29 @@ on:
         default: "."
         type: string
       deployToMavenCentral:
-        description: 'Specify it if you want to deploy to maven'
+        description: "Specify it if you want to deploy to maven"
         required: false
         default: true
         type: boolean
       dry_run:
-        description: 'Specify it if you want to run a dry run'
+        description: "Specify it if you want to run a dry run"
         required: false
         default: false
         type: boolean
       dry_run_version:
-        description: 'The version of the dry-run release'
+        description: "The version of the dry-run release"
         required: false
         type: string
       dry_run_release_id:
-        description: 'The release id of the dry-run release'
+        description: "The release id of the dry-run release"
         required: false
         type: string
     secrets:
       SONATYPE_USERNAME:
-        description: 'SONATYPE_USERNAME from the caller workflow'
+        description: "SONATYPE_USERNAME from the caller workflow"
         required: true
       SONATYPE_TOKEN:
-        description: 'SONATYPE_TOKEN from the caller workflow'
+        description: "SONATYPE_TOKEN from the caller workflow"
         required: true
 
 permissions:
@@ -51,13 +51,13 @@ permissions:
 
 jobs:
   maven-release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@DAT-20127
     if: inputs.deployToMavenCentral == true
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
       artifactPath: ${{ inputs.artifactPath }}
-      
+
   release:
     if: inputs.deployToMavenCentral == true
     runs-on: ubuntu-latest
@@ -68,9 +68,9 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
       # look for dependencies in maven
       - name: maven-settings-xml-action
@@ -189,9 +189,9 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
 
       # look for dependencies in maven
       - name: maven-settings-xml-action
@@ -285,7 +285,7 @@ jobs:
                       -Djavadoc=${{ env.artifact_id }}-${version}-javadoc.jar \
                       -Dfiles=${{ env.artifact_id }}-${version}.jar.asc,${{ env.artifact_id }}-${version}-sources.jar.asc,${{ env.artifact_id }}-${version}-javadoc.jar.asc,${{ env.artifact_id }}-${version}.pom.asc \
                       -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
-                      -Dclassifiers=,sources,javadoc,                  
+                      -Dclassifiers=,sources,javadoc,
 
   deploy_xsd:
     if: inputs.nameSpace != '' && inputs.deployToMavenCentral == true && inputs.dry_run == false
@@ -302,7 +302,6 @@ jobs:
           # Relative path under $GITHUB_WORKSPACE to place the repository
           path: ${{ github.event.repository.name }}
           repository: "liquibase/${{ github.event.repository.name }}"
-
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -330,5 +329,5 @@ jobs:
               sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/${{ inputs.nameSpace }}\/${entry}\">${entry}<\/a><\/li>\n<\/ul>/" index-file/index.htm
             fi
           done
-          
+
           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/${{ inputs.nameSpace }}/ --only-show-errors

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -78,12 +78,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -23,14 +23,14 @@ jobs:
     name: Release rollback
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -103,6 +103,6 @@ jobs:
         working-directory: ${{ inputs.artifactPath }}
         run: |
           mvn -B versions:revert release:rollback \
-          -Darguments="-Dusername=liquibot -Dpassword=${{ secrets.BOT_TOKEN }} -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
+          -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
           -DconnectionUrl=scm:git:https://github.com/${{ github.repository }}.git \
           -DcheckModificationExcludeList=** -DignoreSnapshots=true

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,6 +8,10 @@ on:
         description: 'Supply the DaticalDb-installer version variable which is used during its report generation to be stored in the s3 bucket. eg 8.7.352'
         required: false
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   wait-for-fossa-report-generation:
     runs-on: ubuntu-latest
@@ -170,4 +174,4 @@ jobs:
           repository: Datical/datical-service
           event-type: trigger-fossa-report-generation
           client-payload: '{"ref": "master", "version_number_for_report_generation": "${{ github.event.inputs.version_number_for_report_generation }}"}'
-          
+

--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -43,7 +43,10 @@ jobs:
   # run only on workflow_call event
   fossa-scan:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     if: github.event_name != 'repository_dispatch' && github.event_name != 'workflow_dispatch'
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
@@ -167,7 +170,9 @@ jobs:
   # run only on repository_dispatch event and workflow_dispatch event
   generate-oss-pro-sbom-reports: 
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      id-token: write
     if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
 
     env:

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: write
   security-events: read
+  packages: write
 
 jobs:
   check-security-vulnerabilities:
@@ -125,12 +126,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -1,17 +1,21 @@
-name: Automated OS Extension Release 
+name: Automated OS Extension Release
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Version to release (4.26.0, 4.26.1, etc.))'
+        description: "Version to release (4.26.0, 4.26.1, etc.))"
         required: true
         type: string
       repositories:
-        description: 'Comma separated list of repositories to release'
+        description: "Comma separated list of repositories to release"
         required: false
         default: '["liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-parent-pom"]'
         type: string
+
+permissions:
+  contents: write
+  security-events: read
 
 jobs:
   check-security-vulnerabilities:
@@ -28,23 +32,23 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
-    - name: Security
-      run: |
-        security_fail=false
-        echo "Checking repository: ${{ matrix.repository }}"
-        security_url="https://api.github.com/repos/liquibase/${{ matrix.repository }}/dependabot/alerts?state=open"
-        response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" $security_url | jq length)
-        echo "Open Alerts: $response"
-        if [[ $response == "0" ]]; then
-          echo "Security vulnerabilities for ${{ matrix.repository }} are addressed."
-        else
-          echo "Security vulnerabilities for ${{ matrix.repository }} are not addressed."
-          security_fail=true
-        fi
-        if [[ $security_fail == true ]]; then
-          echo "Security vulnerabilities are not addressed for ${{ matrix.repository }}"
-          exit 1
-        fi
+      - name: Security
+        run: |
+          security_fail=false
+          echo "Checking repository: ${{ matrix.repository }}"
+          security_url="https://api.github.com/repos/liquibase/${{ matrix.repository }}/dependabot/alerts?state=open"
+          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $security_url | jq length)
+          echo "Open Alerts: $response"
+          if [[ $response == "0" ]]; then
+            echo "Security vulnerabilities for ${{ matrix.repository }} are addressed."
+          else
+            echo "Security vulnerabilities for ${{ matrix.repository }} are not addressed."
+            security_fail=true
+          fi
+          if [[ $security_fail == true ]]; then
+            echo "Security vulnerabilities are not addressed for ${{ matrix.repository }}"
+            exit 1
+          fi
 
   run-extensions-dependabot:
     needs: check-security-vulnerabilities
@@ -54,18 +58,18 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
-    - name: Install Dependabot CLI
-      run: |
-        #https://github.com/dependabot/cli
-        wget https://github.com/dependabot/cli/releases/download/v1.39.0/dependabot-v1.39.0-linux-amd64.tar.gz
-        tar xvzf dependabot-v1.39.0-linux-amd64.tar.gz
-        sudo mv dependabot /usr/local/bin/
+      - name: Install Dependabot CLI
+        run: |
+          #https://github.com/dependabot/cli
+          wget https://github.com/dependabot/cli/releases/download/v1.39.0/dependabot-v1.39.0-linux-amd64.tar.gz
+          tar xvzf dependabot-v1.39.0-linux-amd64.tar.gz
+          sudo mv dependabot /usr/local/bin/
 
-    - name: Run dependabot on extension
-      run: |
-        echo "Running Dependabot on repository: ${{ matrix.repository }}"
-        dependabot update maven "liquibase/${{ matrix.repository }}"
-        
+      - name: Run dependabot on extension
+        run: |
+          echo "Running Dependabot on repository: ${{ matrix.repository }}"
+          dependabot update maven "liquibase/${{ matrix.repository }}"
+
   update-pom:
     needs: check-security-vulnerabilities
     runs-on: ubuntu-latest
@@ -73,81 +77,81 @@ jobs:
     strategy:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        repository: "liquibase/${{ matrix.repository }}"
-        token: ${{ secrets.BOT_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: "liquibase/${{ matrix.repository }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Git
-      run: |
-        git config --unset-all http.https://github.com/.extraheader
-        git config --local user.email "64099989+liquibot@users.noreply.github.com"
-        git config --local user.name "liquibot"
+      - name: Set up Git
+        run: |
+          git config --unset-all http.https://github.com/.extraheader
+          git config --local user.email "64099989+liquibot@users.noreply.github.com"
+          git config --local user.name "liquibot"
 
-    # look for dependencies in maven
-    - name: maven-settings-xml-action
-      uses: whelk-io/maven-settings-xml-action@v22
-      with:
-        repositories: |
-          [
-            {
-              "id": "liquibase",
-              "url": "https://maven.pkg.github.com/liquibase/liquibase",
-              "releases": {
-                "enabled": "true"
+      # look for dependencies in maven
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
               },
-              "snapshots": {
-                "enabled": "true",
-                "updatePolicy": "always"
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
               }
-            },
-            {
-              "id": "liquibase-pro",
-              "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-              "releases": {
-                "enabled": "true"
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT }}"
               },
-              "snapshots": {
-                "enabled": "true",
-                "updatePolicy": "always"
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT }}"
               }
-            }
-          ]
-        servers: |
-          [
-            {
-              "id": "liquibase-pro",
-              "username": "liquibot",
-              "password": "${{ secrets.LIQUIBOT_PAT }}"
-            },
-            {
-              "id": "liquibase",
-              "username": "liquibot",
-              "password": "${{ secrets.LIQUIBOT_PAT }}"
-            }
-          ]
+            ]
 
-    - name: Update extension version to next SNAPSHOT
-      if: ${{ matrix.repository != 'liquibase-parent-pom' }}
-      run: mvn versions:set -DnewVersion=${{ inputs.version }}-SNAPSHOT
+      - name: Update extension version to next SNAPSHOT
+        if: ${{ matrix.repository != 'liquibase-parent-pom' }}
+        run: mvn versions:set -DnewVersion=${{ inputs.version }}-SNAPSHOT
 
-    - name: Update pom.xml
-      env:
-        GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-      run: |
-        sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>${{ inputs.version }}<\/liquibase.version>/" pom.xml
-        git add pom.xml
-        # Check if there are changes before committing
-        if git diff-index --quiet HEAD --; then
-          echo "No changes to commit."
-        else
-          git commit -m "Update liquibase.version to ${{ inputs.version }}"
-          git remote set-url origin https://liquibot:${{ secrets.BOT_TOKEN }}@github.com/liquibase/${{ matrix.repository }}.git
-          git push
-        fi
+      - name: Update pom.xml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>${{ inputs.version }}<\/liquibase.version>/" pom.xml
+          git add pom.xml
+          # Check if there are changes before committing
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update liquibase.version to ${{ inputs.version }}"
+            git remote set-url origin https://liquibot:${{ secrets.GITHUB_TOKEN }}@github.com/liquibase/${{ matrix.repository }}.git
+            git push
+          fi
 
   release-draft-releases:
     # 1. Initialize a flag to track if the specified version is found.
@@ -161,13 +165,13 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
-    - name: Check for Artifact in Draft Releases
-      run: |
+      - name: Check for Artifact in Draft Releases
+        run: |
           sleep 180
           published_drafts_file=published_drafts.txt
           found=false
           echo "Checking repository: ${{ matrix.repository }}"
-          assets=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '.[] | select(.draft == true)' | jq -r '.assets[]')
+          assets=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '.[] | select(.draft == true)' | jq -r '.assets[]')
           echo "Assets: $assets"
           # check if assests are empty
           if [ -z "$assets" ]; then
@@ -181,15 +185,15 @@ jobs:
             fi
             if [ "$found" = true ] ; then
               # Get the draft release ID
-              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '[.[] | select(.draft == true)] | sort_by(.created_at) | last | .id')
+              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '[.[] | select(.draft == true)] | sort_by(.created_at) | last | .id')
               echo "Newest Draft release ID: $RELEASE_ID"
               RELEASE_TITLE="v${{ inputs.version }}"
               # Update the release title
               # echo "Updating release title to $RELEASE_TITLE... for ${{ matrix.repository }}"
-              # curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" -d '{"name": "'"$RELEASE_TITLE"'"}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
+              # curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"name": "'"$RELEASE_TITLE"'"}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
               # Publish the draft release as the latest release
               echo "Publishing the draft release as the latest release to https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
-              curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" -d '{"draft": false}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
+              curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"draft": false}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
               echo "Draft release published as the latest release for ${{ matrix.repository }}"
               echo "${{ matrix.repository }}: v${{ inputs.version }}" >> $published_drafts_file
             else

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -260,7 +260,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -34,7 +34,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   packages: read
 
 jobs:

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -32,6 +32,11 @@ on:
 env:
   MAVEN_VERSION: "3.9.5"
 
+permissions:
+  contents: read
+  pull-requests: read
+  packages: read
+
 jobs:
   build:
     name: Build & Package
@@ -87,12 +92,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 
@@ -203,12 +208,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
             

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -216,7 +216,7 @@ jobs:
                 "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
-            
+
       - uses: actions/download-artifact@v4
         with:
           name: ${{needs.build.outputs.artifact_id}}-artifacts
@@ -260,7 +260,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@DAT-20127
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/owasp-scanner.yml
+++ b/.github/workflows/owasp-scanner.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+permissions:
+      contents: read
+      packages: read
 
 jobs:
   scan:
@@ -76,12 +79,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -203,7 +203,7 @@ jobs:
           cd createrepo_c
           mkdir build
           cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO
           make -j
           cp src/createrepo_c  /opt/createrepo
           cd ../../..
@@ -228,7 +228,7 @@ jobs:
           cd createrepo_c
           mkdir build
           cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO
           make -j
           cp src/createrepo_c  /opt/createrepo
           cd ../../..

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,6 +74,11 @@ on:
 env:
   MAVEN_VERSION: "3.9.5"
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   upload_packages:
     name: Upload ${{ inputs.artifactId }} packages
@@ -141,7 +146,7 @@ jobs:
           releaseId: "${{ inputs.dry_run_release_id }}"
           fileName: "*"
           out-file-path: ".github/target/"
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ inputs.artifactId }} deb package
         run: |
@@ -262,7 +267,7 @@ jobs:
 
             Created by https://github.com/mislav/bump-homebrew-formula-action
         env:
-          COMMITTER_TOKEN: ${{ secrets.BOT_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -146,7 +146,6 @@ jobs:
           releaseId: "${{ inputs.dry_run_release_id }}"
           fileName: "*"
           out-file-path: ".github/target/"
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ inputs.artifactId }} deb package
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,7 +87,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v1
@@ -197,15 +196,28 @@ jobs:
         run: |
           sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
           ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-          mkdir createrepo_folder
+          mkdir -p createrepo_folder
           cd createrepo_folder
           git clone https://github.com/rpm-software-management/createrepo_c
           cd createrepo_c
-          mkdir build
+          mkdir -p build
           cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO
-          make -j
-          cp src/createrepo_c  /opt/createrepo
+          # Modified CMake command with additional flags to properly disable documentation
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO -DDISABLE_DOCUMENTATION_TARGET=ON || echo "CMake configuration failed but continuing..."
+          make -j || echo "Build failed but continuing..."
+
+          # Check if createrepo_c was built, otherwise try to find system createrepo
+          if [ -f src/createrepo_c ]; then
+            cp src/createrepo_c /opt/createrepo
+          elif command -v createrepo &> /dev/null; then
+            echo "Using system createrepo instead"
+            ln -sf $(which createrepo) /opt/createrepo
+          else
+            echo "Installing createrepo from package manager as fallback"
+            sudo apt-get install -y createrepo
+            ln -sf $(which createrepo) /opt/createrepo
+          fi
+
           cd ../../..
           mkdir -p $PWD/yum/noarch
           aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
@@ -222,15 +234,28 @@ jobs:
           mv "$original_file" "$new_name"
           sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
           ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
-          mkdir createrepo_folder
+          mkdir -p createrepo_folder
           cd createrepo_folder
           git clone https://github.com/rpm-software-management/createrepo_c
           cd createrepo_c
-          mkdir build
+          mkdir -p build
           cd build
-          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO
-          make -j
-          cp src/createrepo_c  /opt/createrepo
+          # Modified CMake command with additional flags to properly disable documentation
+          cmake .. -DWITH_ZCHUNK=NO -DWITH_LIBMODULEMD=NO -DENABLE_DRPM=NO -DENABLE_PYTHON=NO -DENABLE_DOCS=NO -DDISABLE_DOCUMENTATION_TARGET=ON || echo "CMake configuration failed but continuing..."
+          make -j || echo "Build failed but continuing..."
+
+          # Check if createrepo_c was built, otherwise try to find system createrepo
+          if [ -f src/createrepo_c ]; then
+            cp src/createrepo_c /opt/createrepo
+          elif command -v createrepo &> /dev/null; then
+            echo "Using system createrepo instead"
+            ln -sf $(which createrepo) /opt/createrepo
+          else
+            echo "Installing createrepo from package manager as fallback"
+            sudo apt-get install -y createrepo
+            ln -sf $(which createrepo) /opt/createrepo
+          fi
+
           cd ../../..
           mkdir -p $PWD/yum/noarch
           aws s3 ls s3://repo.liquibase.com.dry.run/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com.dry.run/yum/noarch/{} $PWD/yum/noarch

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,6 +87,17 @@ jobs:
       id-token: write
       contents: read
     steps:
+
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-actions: write
+
       - uses: actions/checkout@v4
 
       - name: Set up Java
@@ -146,6 +157,7 @@ jobs:
           releaseId: "${{ inputs.dry_run_release_id }}"
           fileName: "*"
           out-file-path: ".github/target/"
+          token: "${{ steps.get-token.outputs.token }}"
 
       - name: Build ${{ inputs.artifactId }} deb package
         run: |

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -10,6 +10,9 @@ on:
         description: "SONATYPE_TOKEN from the caller workflow"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -69,5 +69,5 @@ jobs:
 
   maven-release:
     needs: release
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@DAT-20127
     secrets: inherit

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     secrets:
       SONATYPE_USERNAME:
-        description: 'SONATYPE_USERNAME from the caller workflow'
+        description: "SONATYPE_USERNAME from the caller workflow"
         required: true
       SONATYPE_TOKEN:
-        description: 'SONATYPE_TOKEN from the caller workflow'
+        description: "SONATYPE_TOKEN from the caller workflow"
         required: true
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
           server-id: sonatype-nexus-staging
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -34,7 +34,7 @@ jobs:
       - name: Build release artifacts
         id: build-release-artifacts
         run: |
-          mvn -B release:clean release:prepare -Darguments="-Dusername=liquibot -Dpassword=$GITHUB_TOKEN -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false
+          mvn -B release:clean release:prepare -Darguments="-DscmServerId=liquibase -Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false
           git reset HEAD~ --hard
 
       - name: Get Artifact ID
@@ -68,4 +68,3 @@ jobs:
     needs: release
     uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     secrets: inherit
-    

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -69,5 +69,5 @@ jobs:
 
   maven-release:
     needs: release
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     secrets: inherit

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -92,11 +92,23 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-packages: write
+
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.branch }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -232,9 +244,20 @@ jobs:
     name: Combine Jars
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-packages: write
+
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Download Ubuntu Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -236,7 +235,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Ubuntu Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -162,12 +162,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               }
             ]
 

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -151,12 +151,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -162,12 +162,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               }
             ]
 

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -50,15 +50,15 @@ on:
         type: boolean
       repository:
         required: true
-        description: 'Repository to check out'
+        description: "Repository to check out"
         type: string
       version:
         required: true
-        description: 'Version to publish'
+        description: "Version to publish"
         type: string
       branch:
         required: true
-        description: 'Branch to check out'
+        description: "Branch to check out"
         type: string
     secrets:
       SONAR_TOKEN:
@@ -70,6 +70,11 @@ on:
       AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA:
         description: "OIDC Role from the caller workflow"
         required: true
+
+permissions:
+  contents: read
+  id-token: write
+
 env:
   AWS_REGION: us-east-1
   LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
@@ -92,7 +97,7 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.branch }}
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -228,11 +233,10 @@ jobs:
     name: Combine Jars
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Ubuntu Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
@@ -246,7 +246,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -85,6 +85,7 @@ permissions:
   contents: write
   id-token: write
   packages: read
+  pull-requests: write
 
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -81,6 +81,10 @@ on:
         description: "Azure Storage Account name for Liquibase."
         required: false
 
+permissions:
+  contents: write
+  id-token: write
+  packages: read
 
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -80,7 +80,8 @@ on:
       LIQUIBASE_AZURE_STORAGE_ACCOUNT:
         description: "Azure Storage Account name for Liquibase."
         required: false
-  
+
+
 env:
   AWS_REGION: us-east-1
   LIQUIBASE_PRO_LICENSE_KEY: ${{ secrets.PRO_LICENSE_KEY }}
@@ -101,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
-      contents: read
+      contents: write  # Updated from 'read' to 'write' to allow tag operations
     steps:
       - uses: actions/checkout@v4
         with:
@@ -159,12 +160,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 
@@ -320,12 +321,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
-      contents: write  # Updated from 'read' to 'write' to allow tag operations
+      contents: write # Updated from 'read' to 'write' to allow tag operations
     steps:
       - uses: actions/checkout@v4
         with:
@@ -189,7 +189,7 @@ jobs:
         shell: powershell
         run: |
           ${{ inputs.extraWindowsCommand }}
-          
+
       - name: Build and Package latest liquibase version
         if: ${{ inputs.nightly }}
         shell: bash
@@ -243,7 +243,7 @@ jobs:
         with:
           name: ${{ steps.get-artifact-id.outputs.artifact_id }}-${{ matrix.os }}-${{ steps.get-artifact-version.outputs.artifact_version }}-events
           path: ${{ github.event_path }}
-          
+
       - name: Save Artifacts for Ubuntu Latest to be used for GPM publishing
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
@@ -285,7 +285,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
           aws-region: us-east-1
-          
+
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
@@ -363,7 +363,7 @@ jobs:
           else
             mvn -B test -P '${{ inputs.mavenProfiles }}'
           fi
-  
+
       - name: Run Tests
         if: ${{ inputs.nightly }}
         shell: bash
@@ -397,12 +397,11 @@ jobs:
             **/target/site/jacoco/jacoco.xml
 
   combineJars:
-    needs: [ build, unit-test ]
+    needs: [build, unit-test]
     if: ${{ inputs.combineJars }}
     name: Combine Jars
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
@@ -460,7 +459,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@DAT-20127
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -460,7 +460,7 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -22,10 +22,16 @@ on:
         description: "Branch to check out"
         type: string
 
+permissions:
+  contents: write
+  packages: write
+  actions: read
+  id-token: write
+
 jobs:
   build:
     name: Build Extension
-    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@main
+    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@DAT-20127
     secrets: inherit
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'
@@ -34,24 +40,31 @@ jobs:
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
-      
+
   publish-main-snapshots-to-gpm:
     name: Publish to GPM
     runs-on: ubuntu-latest
     needs: [build]
-    permissions:
-      contents: read
-      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
-      GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+      GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-packages: write
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Download Multiplatform Artifacts
         uses: actions/download-artifact@v4
@@ -97,6 +110,17 @@ jobs:
                   "enabled": "true",
                   "updatePolicy": "always"
                 }
+              },
+              {
+                "id": "extension-repo",
+                "url": "https://maven.pkg.github.com/${{ inputs.repository }}",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
               }
             ]
           servers: |
@@ -104,12 +128,17 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
+              },
+              {
+                "id": "github",
+                "username": "liquibot",
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 
@@ -122,7 +151,7 @@ jobs:
           -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=liquibase \
+          -DrepositoryId=github \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
-          -Dusername=liquibot \
-          -Dpassword=${{ env.GIT_PASSWORD }}   
+          -Dserver.username=liquibot \
+          -Dserver.password=${{ steps.get-token.outputs.token }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -152,4 +152,6 @@ jobs:
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
           -DrepositoryId=github \
-          -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks
+          -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
+          -Dusername=liquibot \
+          -Dpassword=${{ env.GIT_PASSWORD }}  

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -50,7 +50,6 @@ jobs:
       GIT_USERNAME: "liquibot"
       GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
-
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v1
@@ -153,4 +152,4 @@ jobs:
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
           -DrepositoryId=github \
-          -Durl=https://maven.pkg.github.com/liquibase-checks
+          -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -128,17 +128,17 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ secrets.BOT_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ secrets.BOT_TOKEN }}"
               },
               {
                 "id": "github",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ secrets.BOT_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Multiplatform Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -118,12 +118,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.PUBLISH_TO_GPM_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.PUBLISH_TO_GPM_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token}}"
               }
             ]
 
@@ -139,3 +139,4 @@ jobs:
           -DrepositoryId=liquibase \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
           -DscmServerId=liquibase
+          -Dtoken=${{ steps.get-token.outputs.token }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -114,7 +114,7 @@ jobs:
               },
               {
                 "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/${{ inputs.repository }}",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-checks",
                 "releases": {
                   "enabled": "true"
                 },
@@ -147,10 +147,10 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           mvn deploy:deploy-file \
-          -Dfile="./artifacts/${{ inputs.repository }}-${{ inputs.version }}.jar" \
+          -Dfile="./artifacts/liquibase-checks-${{ inputs.version }}.jar" \
           -DgroupId=org.liquibase.ext \
-          -DartifactId=${{ inputs.repository }} \
+          -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=${{ inputs.repository }} \
-          -Durl=https://maven.pkg.github.com/${{ inputs.repository }}
+          -DrepositoryId=github \
+          -Durl=https://maven.pkg.github.com/liquibase-checks

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
-      GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
     steps:
       - name: Get GitHub App token
         id: get-token
@@ -128,17 +128,17 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.BOT_TOKEN }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.BOT_TOKEN }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "github",
                 "username": "liquibot",
-                "password": "${{ secrets.BOT_TOKEN }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               }
             ]
 
@@ -151,7 +151,7 @@ jobs:
           -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=github \
+          -DrepositoryId=liquibase \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
-          -Dserver.username=liquibot \
-          -Dserver.password=${{ secrets.BOT_TOKEN }}
+          -Dusername=liquibot \
+          -Dpassword=${{ env.GIT_PASSWORD }} 

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -50,6 +50,7 @@ jobs:
       GIT_USERNAME: "liquibot"
       GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
+
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v1
@@ -117,12 +118,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.PUBLISH_TO_GPM_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.PUBLISH_TO_GPM_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Publish to GitHub Packages
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          mvn deploy:deploy-file -X \
+          mvn deploy:deploy-file \
           -Dfile="./artifacts/liquibase-checks-${{ inputs.version }}.jar" \
           -DgroupId=org.liquibase.ext \
           -DartifactId=liquibase-checks \
@@ -154,4 +154,4 @@ jobs:
           -DrepositoryId=github \
           -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
           -Dusername=liquibot \
-          -Dpassword=${{ SECRETS.BOT_TOKEN }} \
+          -Dpassword=${{ secrets.BOT_TOKEN }} \

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -151,7 +151,7 @@ jobs:
           -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=liquibase \
-          -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
+          -DrepositoryId=github \
+          -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
           -Dusername=liquibot \
-          -Dpassword=${{ env.GIT_PASSWORD }}  
+          -Dpassword=${{ env.GIT_PASSWORD }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -111,6 +111,17 @@ jobs:
                   "enabled": "true",
                   "updatePolicy": "always"
                 }
+              },
+              {
+                "id": "github",
+                "url": "https://maven.pkg.github.com/liquibase/${{ inputs.repository }}",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
               }
             ]
           servers: |
@@ -124,6 +135,11 @@ jobs:
                 "id": "liquibase-pro",
                 "username": "liquibot",
                 "password": "${{ steps.get-token.outputs.token}}"
+              },
+              {
+                "id": "github",
+                "username": "liquibot",
+                "password": "${{ steps.get-token.outputs.token}}"
               }
             ]
 
@@ -131,12 +147,10 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           mvn deploy:deploy-file \
-          -Dfile="./artifacts/liquibase-checks-${{ inputs.version }}.jar" \
+          -Dfile="./artifacts/${{ inputs.repository }}-${{ inputs.version }}.jar" \
           -DgroupId=org.liquibase.ext \
-          -DartifactId=liquibase-checks \
+          -DartifactId=${{ inputs.repository }} \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=liquibase \
-          -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
-          -DscmServerId=liquibase
-          -Dtoken=${{ steps.get-token.outputs.token }}
+          -DrepositoryId=${{ inputs.repository }} \
+          -Durl=https://maven.pkg.github.com/${{ inputs.repository }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -23,13 +23,13 @@ on:
         type: string
 
 permissions:
-  contents: write  # Updated from 'read' to 'write' to allow tag operations
+  contents: write # Updated from 'read' to 'write' to allow tag operations
   packages: write
 
 jobs:
   build:
     name: Build Extension
-    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@main
+    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@DAT-20127
     secrets: inherit
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -23,8 +23,10 @@ on:
         type: string
 
 permissions:
-  contents: write # Updated from 'read' to 'write' to allow tag operations
+  contents: write
   packages: write
+  actions: read
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -50,10 +50,21 @@ jobs:
       GIT_USERNAME: "liquibot"
       GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-packages: write
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Download Multiplatform Artifacts
         uses: actions/download-artifact@v4
@@ -106,12 +117,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               }
             ]
 

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -154,4 +154,4 @@ jobs:
           -DrepositoryId=github \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
           -Dserver.username=liquibot \
-          -Dserver.password=${{ steps.get-token.outputs.token }}
+          -Dserver.password=${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -22,16 +22,10 @@ on:
         description: "Branch to check out"
         type: string
 
-permissions:
-  contents: write
-  packages: write
-  actions: read
-  id-token: write
-
 jobs:
   build:
     name: Build Extension
-    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@main
     secrets: inherit
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'
@@ -40,31 +34,24 @@ jobs:
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
-
+      
   publish-main-snapshots-to-gpm:
     name: Publish to GPM
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: read
+      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
-      GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
     steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: read
-          permission-packages: write
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
-          token: ${{ steps.get-token.outputs.token }}
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Download Multiplatform Artifacts
         uses: actions/download-artifact@v4
@@ -110,17 +97,6 @@ jobs:
                   "enabled": "true",
                   "updatePolicy": "always"
                 }
-              },
-              {
-                "id": "github",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-checks",
-                "releases": {
-                  "enabled": "true"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
               }
             ]
           servers: |
@@ -128,17 +104,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
-              },
-              {
-                "id": "github",
-                "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
               }
             ]
 
@@ -151,7 +122,7 @@ jobs:
           -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=github \
-          -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
+          -DrepositoryId=liquibase \
+          -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
           -Dusername=liquibot \
-          -Dpassword=${{ secrets.BOT_TOKEN }} \
+          -Dpassword=${{ env.GIT_PASSWORD }}   

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -22,6 +22,9 @@ on:
         description: "Branch to check out"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Extension
@@ -34,7 +37,7 @@ jobs:
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
       branch: ${{ inputs.branch }}
-      
+
   publish-main-snapshots-to-gpm:
     name: Publish to GPM
     runs-on: ubuntu-latest
@@ -51,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository }}
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Multiplatform Artifacts
         uses: actions/download-artifact@v4
@@ -124,6 +127,4 @@ jobs:
           -Dpackaging=jar \
           -DrepositoryId=liquibase \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
-          -Dusername=liquibot \
-          -Dpassword=${{ env.GIT_PASSWORD }}   
-
+          -DscmServerId=liquibase

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -151,7 +151,7 @@ jobs:
           -DartifactId=liquibase-checks \
           -Dversion=${{ inputs.version }} \
           -Dpackaging=jar \
-          -DrepositoryId=github \
+          -DrepositoryId=liquibase \
           -Durl=https://maven.pkg.github.com/${{ inputs.repository }} \
           -Dusername=liquibot \
           -Dpassword=${{ env.GIT_PASSWORD }}  

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -128,24 +128,24 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token}}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "github",
                 "username": "liquibot",
-                "password": "${{ steps.get-token.outputs.token}}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 
       - name: Publish to GitHub Packages
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          mvn deploy:deploy-file \
+          mvn deploy:deploy-file -X \
           -Dfile="./artifacts/liquibase-checks-${{ inputs.version }}.jar" \
           -DgroupId=org.liquibase.ext \
           -DartifactId=liquibase-checks \

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -154,4 +154,4 @@ jobs:
           -DrepositoryId=github \
           -Durl=https://maven.pkg.github.com/liquibase/liquibase-checks \
           -Dusername=liquibot \
-          -Dpassword=${{ env.GIT_PASSWORD }}
+          -Dpassword=${{ SECRETS.BOT_TOKEN }} \

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   build:
     name: Build Extension
-    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@DAT-20127
+    uses: liquibase/build-logic/.github/workflows/pro-extension-build-for-liquibase.yml@main
     secrets: inherit
     with:
       os: '["ubuntu-latest", "macos-latest", "windows-latest"]'
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -23,7 +23,8 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write  # Updated from 'read' to 'write' to allow tag operations
+  packages: write
 
 jobs:
   build:
@@ -42,13 +43,10 @@ jobs:
     name: Publish to GPM
     runs-on: ubuntu-latest
     needs: [build]
-    permissions:
-      contents: read
-      packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
-      GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+      GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -107,12 +105,12 @@ jobs:
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [ test-failure ]
 
+permissions:
+  contents: read
+
 jobs:
     slack-notification:
         runs-on: ubuntu-latest

--- a/.github/workflows/sonar-jest-coverage.yml
+++ b/.github/workflows/sonar-jest-coverage.yml
@@ -3,6 +3,9 @@ name: Sonar Scan for jest
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     name: SonarCloud
@@ -18,7 +21,7 @@ jobs:
       - name: Set up npm registry and authentication
         run: |
           npm config set @liquibase:registry https://npm.pkg.github.com
-          npm config set //npm.pkg.github.com/:_authToken ${{ secrets.NPM_TOKEN }}
+          npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -18,6 +18,10 @@ on:
         description: 'SONAR_TOKEN from the caller workflow'
         required: true
         
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   sonar-pr:
     name: Sonar Scan
@@ -71,12 +75,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
             

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       extraCommand:
-        description: 'Specify it if you want to run an extra command before attaching the artifact'
+        description: "Specify it if you want to run an extra command before attaching the artifact"
         required: false
-        default: ''
+        default: ""
         type: string
       artifactPath:
         description: "Specify the path to the artifacts that should be attached to the build. Useful for multi-module extensions."
@@ -15,8 +15,13 @@ on:
         type: string
     secrets:
       SONAR_TOKEN:
-        description: 'SONAR_TOKEN from the caller workflow'
+        description: "SONAR_TOKEN from the caller workflow"
         required: true
+
+permissions:
+  actions: read # Required for downloading artifacts
+  contents: read # Required for checkout
+  security-events: write # Required for SonarCloud integrations
 
 jobs:
   sonar-push:
@@ -29,15 +34,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-          
+          distribution: "temurin"
+          cache: "maven"
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:
@@ -60,13 +65,13 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v7
         with:
-          github_token: ${{secrets.BOT_TOKEN}}
+          github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: test.yml
           name: test-reports-jdk-17-ubuntu-latest
           repo: ${{ github.repository }}
           if_no_artifact_found: warn
           workflow_conclusion: ""
-          
+
       # look for dependencies in maven
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -106,12 +106,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  actions: read # Required to access workflow runs and artifacts
 
 jobs:
   sonar-push:

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -19,9 +19,8 @@ on:
         required: true
 
 permissions:
-  actions: read # Required for downloading artifacts
-  contents: read # Required for checkout
-  security-events: write # Required for SonarCloud integrations
+  contents: read
+  security-events: write
 
 jobs:
   sonar-push:

--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -48,6 +48,10 @@ on:
         required: false
         default: mysql
 
+permissions:
+  contents: read
+  pull-requests: write
+  
 env:
   MAVEN_VERSION: '3.9.5'
 
@@ -111,12 +115,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.LIQUIBOT_PAT }}"
+                "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,41 @@ The Maven release plugin must be configured to allow extensions update `pom.xml`
 </build>
 ```
 
+### Version Bumping after Release
+
+When releasing extensions, a Pull Request is automatically created to update the version in the `pom.xml` files instead of directly committing to the main branch. This approach provides the following benefits:
+
+1. Improved security by requiring reviews before version changes are merged
+2. Better traceability of version bumps through the PR history
+3. Opportunity for validation before finalizing the version change
+
+The PR creation is handled by the `extension-release-prepare.yml` workflow:
+
+```yml
+- name: Create Pull Request for version bump
+  uses: peter-evans/create-pull-request@v7.0.8
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    commit-message: "chore: update version after release"
+    title: "Version bump after release"
+    body: |
+      This PR updates the POM version after a release.
+      
+      Automated changes by GitHub Actions.
+    branch: version-bump-after-release
+    base: main
+    delete-branch: true
+```
+
+These version bump PRs are automatically merged through a nightly scheduled workflow in the `liquibase-infrastructure` repository. This workflow:
+
+1. Runs on a daily schedule (midnight UTC) or can be triggered manually
+2. Identifies all repositories with the `extension` topic
+3. Finds open PRs with the exact title "Version bump after release"
+4. Merges these PRs using the squash strategy
+
+This automation ensures that version bumps are consistently applied across all extension repositories without requiring manual intervention, while still maintaining the security benefits of the PR-based approach.
+
 ## Liquibase Test Harness
 
 | Workflow         | Description                                            |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ The PR creation is handled by the `extension-release-prepare.yml` workflow:
       
       Automated changes by GitHub Actions.
     branch: version-bump-after-release
-    base: main
     delete-branch: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The PR creation is handled by the `extension-release-prepare.yml` workflow:
     delete-branch: true
 ```
 
-These version bump PRs are automatically merged through a nightly scheduled workflow in the `liquibase-infrastructure` repository. This workflow:
+These version bump PRs are automatically merged through a nightly scheduled workflow (`auto_merge_release_prs.yml`) in the `liquibase-infrastructure` repository. This workflow:
 
 1. Runs on a daily schedule (midnight UTC) or can be triggered manually
 2. Identifies all repositories with the `extension` topic

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ For operations that require cross-repository access or elevated permissions with
 ```yml
 - name: Get GitHub App token
   id: get-token
-  uses: actions/create-github-app-token@v1
+  uses: actions/create-github-app-token@v2
   with:
     app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
     private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -68,17 +68,30 @@ Please review the below table of reusable workflows and their descriptions:
 | Workflow                                | Description                                                                                                             |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `build-artifact.yml`                    | Runs maven build and saves artifacts                                                                                    |
+| `build-extension-jar.yml`               | Builds and deploys extension JARs to GitHub Package Manager                                                             |
 | `codeql.yml`                            | Runs CodeQL scanning                                                                                                    |
 | `create-release.yml`                    | Runs Release Drafter to auto create draft release notes                                                                 |
+| `dependabot-automerge.yml`              | Automatically merges Dependabot PRs for minor and patch updates                                                         |
 | `ephemeral-cloud-infra.yml`             | Creates/Destroys test automation cloud infrastructure                                                                   |
 | `extension-attach-artifact-release.yml` | Attaches a tested artifact to the draft release. Receives a `zip` input to upload generated zip files                   |
+| `extension-release-prepare.yml`         | Prepares extension release artifacts                                                                                    |
 | `extension-release-published.yml`       | Publishes a release to Maven Central                                                                                    |
+| `extension-release-rollback.yml`        | Rolls back a failed extension release                                                                                   |
 | `extension-update-version.yml`          | Updates release and development `pom.xml` versions                                                                      |
+| `fossa.yml`                             | Runs FOSSA license compliance checks and uploads reports                                                                |
+| `fossa_ai.yml`                          | Scans code for AI-generated content and runs FOSSA license compliance                                                   |
+| `generate-upload-fossa-report.yml`      | Generates and uploads license reports to FOSSA                                                                          |
+| `lth-docker.yml`                        | Runs Liquibase Test Harness on Docker-based databases                                                                   |
 | `os-extension-automated-release.yml`    | Publishes draft releases and closes Nexus staging repositories. Details [here](./doc/os-extension-automated-release.md) |
 | `os-extension-test.yml`                 | Unit tests across build matrix on previously built artifact                                                             |
+| `owasp-scanner.yml`                     | Runs vulnerability scans using OWASP dependency checker                                                                 |
+| `package.yml`                           | Creates and distributes Linux packages (deb, rpm) and updates platform-specific repositories                            |
 | `package-deb.yml`                       | Creates and uploads deb packages                                                                                        |
 | `pom-release-published.yml`             | Publishes a release pom to Maven Central                                                                                |
+| `pro-extension-build-for-liquibase.yml` | Builds and tests Pro extensions specifically for Liquibase                                                              |
 | `pro-extension-test.yml`                | Same as OS job, but with additional Pro-only vars such as License Key                                                   |
+| `publish-for-liquibase.yml`             | Publishes extensions for Liquibase consumption                                                                          |
+| `slack-notification.yml`                | Sends notifications to Slack when tests fail                                                                            |
 | `sonar-pull-request.yml`                | Code Coverage Scan for PRs. Requires branch name parameter                                                              |
 | `sonar-test-scan.yml`                   | Code Coverage Scan for unit and integration tests                                                                       |
 | `sonar-push.yml`                        | Same as PR job, but for pushes to main. Does not require branch name parameter                                          |
@@ -207,7 +220,7 @@ The PR creation is handled by the `extension-release-prepare.yml` workflow:
     title: "Version bump after release"
     body: |
       This PR updates the POM version after a release.
-      
+
       Automated changes by GitHub Actions.
     branch: version-bump-after-release
     delete-branch: true
@@ -488,8 +501,9 @@ Here the modules we want to generate and aggregate test reports must be specifie
 
 When you want to release new version of `build-logic`, it is important to update all the occurrences of previous version eg: `main` with the new version eg : `main` in all the files. As, the code for the new version internally refers to the old version.
 
-_____________________________________________________________________________________________________________________________________________________________________________
-### 📓  Fossa Report Generation for Enterprise
+---
+
+### 📓 Fossa Report Generation for Enterprise
 
 1. AWS s3 bucket under `liquibase-prod` `s3://liquibaseorg-origin/enterprise_fossa_report/`
 2. Manually run the workflow under `fossa.yml` from this repository under `./github/workflows/fossa.yml`.Supply the DaticalDb-installer version variable which is used during its report generation to be stored in the s3 bucket. eg 8.7.352'
@@ -513,7 +527,6 @@ ________________________________________________________________________________
 8. If we plan on sending this report to the users it will be on some page like we have for OSS -> https://www.liquibase.com/eula and they will have access to only the URI’s we mention. As to to the liquibase users, DevOps team can add them to permission set to have access to those reports.
 
 ![](./doc/img/permission-set-enterprise-fossa-report.png)
-
 
 ### 🪣 Store SBOM for LB and LB Pro on every release
 

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ GitHub automatically provides a `GITHUB_TOKEN` secret that's available during wo
 
 - Automatically rotated for each job
 - Limited to the repository where the workflow runs
-- Permissions can be explicitly scoped using the `permissions` key
+- [Permissions can be explicitly scoped](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication) using the `permissions` key
 
 ```yml
 permissions:
@@ -585,7 +585,7 @@ For operations that require cross-repository access or elevated permissions with
 - Fine-grained permissions control
 - No personal credentials involved
 - Short-lived by default (can be configured)
-- Auditable through GitHub App activity
+- [Auditable through GitHub App activity](https://github.com/enterprises/liquibase/settings/audit-log?q=action%3Aoauth_application.generate_client_secret++). (Search filter: `action:oauth_application`)
 
 #### Example:
 


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve security by removing hardcoded credentials and refines the release process by adding new files to the artifact path. The most important changes include removing the use of `secrets.BOT_TOKEN` and adding `release.properties` to the release files.

### Security improvements:
* [`.github/workflows/extension-release-prepare.yml`](diffhunk://#diff-44f871857d0892b2cdf6de28995341916f0cbe2bcc66f0412df9399c6d0f81f3L25-L26): Removed the `GITHUB_TOKEN` environment variable and references to `${{ secrets.BOT_TOKEN }}` in Maven commands to improve security. [[1]](diffhunk://#diff-44f871857d0892b2cdf6de28995341916f0cbe2bcc66f0412df9399c6d0f81f3L25-L26) [[2]](diffhunk://#diff-44f871857d0892b2cdf6de28995341916f0cbe2bcc66f0412df9399c6d0f81f3L101-R99)
* [`.github/workflows/extension-release-published.yml`](diffhunk://#diff-8f35892fff793298c429a326782b9912e79873322b834b9f18da1b918718e39aL144-R144): Removed the `-Dusername` and `-Dpassword` arguments with `$GITHUB_TOKEN` from the Maven command to eliminate hardcoded credentials.
* [`.github/workflows/extension-release-rollback.yml`](diffhunk://#diff-4dcc51af006dfe0e1de046063373f2af5b5711639c2b2a2f729e3f9154dd9e98L106-R106): Removed references to `${{ secrets.BOT_TOKEN }}` in Maven commands to ensure sensitive information is not exposed.

### Release process refinements:
* [`.github/workflows/extension-release-prepare.yml`](diffhunk://#diff-44f871857d0892b2cdf6de28995341916f0cbe2bcc66f0412df9399c6d0f81f3R113): Added `release.properties` to the list of files included in the release artifacts, ensuring all necessary files are captured.