### PR TITLE
🔧 DAT-20204: use GitHub App token to access private infra repo

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -108,6 +108,20 @@ jobs:
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
 
     steps:
+      - name: Get GitHub App token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-repositories: read
+          permission-contents: read
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          token: ${{ steps.get-token.outputs.token }}
       - name: Checkout liquibase-infrastructure
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -109,6 +109,7 @@ jobs:
 
     steps:
       - name: Get GitHub App token
+        id: get-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
@@ -117,16 +118,12 @@ jobs:
           permission-repositories: read
           permission-contents: read
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repository }}
-          token: ${{ steps.get-token.outputs.token }}
       - name: Checkout liquibase-infrastructure
         uses: actions/checkout@v4
         with:
           ref: master
           repository: liquibase/liquibase-infrastructure
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
This pull request updates the `.github/workflows/ephemeral-cloud-infra.yml` file to enhance security and streamline access to repository contents. The most significant change involves integrating a GitHub App token for authentication.

### Workflow enhancements:
* Added a step to generate a GitHub App token using the `actions/create-github-app-token@v2` action. This step retrieves the token with specified permissions (`read` for repositories and contents) using secrets for the app ID and private key.
* Updated the `Checkout liquibase-infrastructure` step to use the generated GitHub App token for authentication, improving security and aligning with best practices.