### PR TITLE
DAT-19745: add support for obtaining Hashicorp Vault tokens to pro-extension-test.yml

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -68,11 +68,6 @@ on:
         required: false
         default: ""
         type: string
-      vaultToken:
-        description: "Hashicorp Vault token"
-        required: false
-        default: ""
-        type: string
 
     secrets:
       SONAR_TOKEN:
@@ -96,6 +91,10 @@ on:
       LIQUIBASE_AZURE_STORAGE_ACCOUNT:
         description: "Azure Storage Account name for Liquibase."
         required: false
+      VAULT_ROLE_ID:
+        required: false
+      VAULT_SECRET_ID:
+        required: false
 
 permissions:
   contents: write
@@ -114,7 +113,6 @@ env:
   MAVEN_VERSION: "3.9.5"
   LIQUIBASE_VAULT_ADDR: ${{ inputs.vaultAddr }}
   LIQUIBASE_VAULT_NAMESPACE: ${{ inputs.vaultNamespace }}
-  LIQUIBASE_VAULT_TOKEN: ${{ inputs.vaultToken }}
 
 jobs:
   build:
@@ -209,6 +207,16 @@ jobs:
         shell: powershell
         run: |
           ${{ inputs.extraWindowsCommand }}
+
+      - name: Setup Vault token
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ inputs.vaultAddr }}
+          namespace: ${{ inputs.vaultNamespace }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportToken: true
 
       - name: Build and Package latest liquibase version
         if: ${{ inputs.nightly }}
@@ -373,6 +381,16 @@ jobs:
         if: inputs.extraWindowsCommand != '' && runner.os == 'Windows'
         run: |
           ${{ inputs.extraWindowsCommand }}
+
+      - name: Setup Vault token
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ inputs.vaultAddr }}
+          namespace: ${{ inputs.vaultNamespace }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportToken: true
 
       - name: Run Tests
         if: ${{ !inputs.nightly }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -68,6 +68,12 @@ on:
         required: false
         default: ""
         type: string
+      vaultToken:
+        description: "Hashicorp Vault token"
+        required: false
+        default: ""
+        type: string
+
     secrets:
       SONAR_TOKEN:
         description: "SONAR_TOKEN from the caller workflow"
@@ -90,12 +96,6 @@ on:
       LIQUIBASE_AZURE_STORAGE_ACCOUNT:
         description: "Azure Storage Account name for Liquibase."
         required: false
-      VAULT_ROLE_ID:
-        description: "Hashicorp Vault Role ID for authentication"
-        required: false
-      VAULT_SECRET_ID:
-        description: "Hashicorp Vault Secret ID for authentication"
-        required: false
 
 permissions:
   contents: write
@@ -112,6 +112,9 @@ env:
   LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ secrets.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MAVEN_VERSION: "3.9.5"
+  LIQUIBASE_VAULT_ADDR: ${{ inputs.vaultAddr }}
+  LIQUIBASE_VAULT_NAMESPACE: ${{ inputs.vaultNamespace }}
+  LIQUIBASE_VAULT_TOKEN: ${{ inputs.vaultToken }}
 
 jobs:
   build:
@@ -194,18 +197,6 @@ jobs:
         if: inputs.extraCommand != ''
         run: |
           ${{ inputs.extraCommand }}
-
-      - name: Setup Vault token
-        if: ${{ inputs.vaultAddr != '' && runner.os == 'Linux' }}
-        id: vault
-        uses: hashicorp/vault-action@v3
-        with:
-          url: ${{ inputs.vaultAddr }}
-          namespace: ${{ inputs.vaultNamespace }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportToken: true
 
       - name: Run extra Linux command
         if: inputs.extraLinuxCommand != '' && runner.os == 'Linux'
@@ -372,18 +363,6 @@ jobs:
         if: inputs.extraCommand != ''
         run: |
           ${{ inputs.extraCommand }}
-
-      - name: Setup Hashicorp Vault token
-        if: ${{ inputs.vaultAddr != '' && runner.os == 'Linux' }}
-        id: vault
-        uses: hashicorp/vault-action@v3
-        with:
-          url: ${{ inputs.vaultAddr }}
-          namespace: ${{ inputs.vaultNamespace }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportToken: true
 
       - name: Run extra Linux command
         if: inputs.extraLinuxCommand != '' && runner.os == 'Linux'

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -58,6 +58,16 @@ on:
         required: false
         default: false
         type: boolean
+      vaultAddr:
+        description: "Hashicorp Vault server address"
+        required: false
+        default: ""
+        type: string
+      vaultNamespace:
+        description: "Hashicorp Vault namespace"
+        required: false
+        default: ""
+        type: string
     secrets:
       SONAR_TOKEN:
         description: "SONAR_TOKEN from the caller workflow"
@@ -79,6 +89,12 @@ on:
         required: false
       LIQUIBASE_AZURE_STORAGE_ACCOUNT:
         description: "Azure Storage Account name for Liquibase."
+        required: false
+      VAULT_ROLE_ID:
+        description: "Hashicorp Vault Role ID for authentication"
+        required: false
+      VAULT_SECRET_ID:
+        description: "Hashicorp Vault Secret ID for authentication"
         required: false
 
 permissions:
@@ -178,6 +194,18 @@ jobs:
         if: inputs.extraCommand != ''
         run: |
           ${{ inputs.extraCommand }}
+
+      - name: Setup Vault token
+        if: ${{ inputs.vaultAddr != '' && runner.os == 'Linux' }}
+        id: vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ inputs.vaultAddr }}
+          namespace: ${{ inputs.vaultNamespace }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportToken: true
 
       - name: Run extra Linux command
         if: inputs.extraLinuxCommand != '' && runner.os == 'Linux'
@@ -344,6 +372,18 @@ jobs:
         if: inputs.extraCommand != ''
         run: |
           ${{ inputs.extraCommand }}
+
+      - name: Setup Hashicorp Vault token
+        if: ${{ inputs.vaultAddr != '' && runner.os == 'Linux' }}
+        id: vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ inputs.vaultAddr }}
+          namespace: ${{ inputs.vaultNamespace }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportToken: true
 
       - name: Run extra Linux command
         if: inputs.extraLinuxCommand != '' && runner.os == 'Linux'

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -92,8 +92,10 @@ on:
         description: "Azure Storage Account name for Liquibase."
         required: false
       VAULT_ROLE_ID:
+        description: "Role ID for HashiCorp Vault authentication."
         required: false
       VAULT_SECRET_ID:
+        description: "Secret ID for HashiCorp Vault authentication."
         required: false
 
 permissions:

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -208,8 +208,9 @@ jobs:
         run: |
           ${{ inputs.extraWindowsCommand }}
 
-      - name: Setup Vault token
+      - name: Setup Hashicorp Vault token
         uses: hashicorp/vault-action@v3
+        if: ${{ inputs.vaultAddr != '' && inputs.vaultNamespace != '' }}
         with:
           url: ${{ inputs.vaultAddr }}
           namespace: ${{ inputs.vaultNamespace }}
@@ -382,8 +383,9 @@ jobs:
         run: |
           ${{ inputs.extraWindowsCommand }}
 
-      - name: Setup Vault token
+      - name: Setup Hashicorp Vault token
         uses: hashicorp/vault-action@v3
+        if: ${{ inputs.vaultAddr != '' && inputs.vaultNamespace != '' }}
         with:
           url: ${{ inputs.vaultAddr }}
           namespace: ${{ inputs.vaultNamespace }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/pro-extension-test.yml` file to integrate HashiCorp Vault for managing secrets. The changes introduce new inputs, environment variables, and job steps to support Vault-based authentication and token setup.

### Integration of HashiCorp Vault:

* Added new inputs `vaultAddr` and `vaultNamespace` to specify the Vault server address and namespace, respectively. These inputs are optional and have default empty values.
* Introduced two new secrets, `VAULT_ROLE_ID` and `VAULT_SECRET_ID`, for AppRole-based authentication with Vault.
* Set new environment variables `LIQUIBASE_VAULT_ADDR` and `LIQUIBASE_VAULT_NAMESPACE` based on the provided inputs.
* Added a job step to set up a Vault token using the `hashicorp/vault-action@v3` GitHub Action. This step is conditional on the presence of `vaultAddr` and `vaultNamespace`. It uses the AppRole method with `VAULT_ROLE_ID` and `VAULT_SECRET_ID` secrets to authenticate and export the token. [[1]](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cR211-R221) [[2]](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cR386-R396)