### PR TITLE
🔧 (package.yml): update deb-s3 upload commands to include visibility option for improved package management

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -173,7 +173,7 @@ jobs:
           echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
           export GPG_TTY=$(tty)
           echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
       - name: Upload ${{ inputs.artifactId }} dry-run deb package
         if: ${{ inputs.dry_run == true }}
@@ -183,7 +183,7 @@ jobs:
           echo "${{ secrets.GPG_SECRET }}" | gpg --batch --import --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}"
           export GPG_TTY=$(tty)
           echo '${{ secrets.GPG_PASSPHRASE }}' > pass.txt
-          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com.dry.run $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          deb-s3 upload --preserve-versions --sign "${{ secrets.GPG_SECRET_KEY_ID }}" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file pass.txt \-\-yes \-\-quiet" --bucket repo.liquibase.com.dry.run --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
 
       - name: Convert deb to rpm
         run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/package.yml` file to enhance the configuration of the `deb-s3 upload` command by adding a new `--visibility=nil` option. This change ensures that the visibility of uploaded packages is explicitly set to `nil`, which may address specific requirements for package visibility during the upload process.

### Workflow Configuration Updates:

* Added the `--visibility=nil` option to the `deb-s3 upload` command in the main package upload step to explicitly set the visibility of uploaded `.deb` packages. (`.github/workflows/package.yml`, [.github/workflows/package.ymlL176-R176](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L176-R176))
* Added the `--visibility=nil` option to the `deb-s3 upload` command in the dry-run package upload step to ensure consistent visibility settings for test uploads. (`.github/workflows/package.yml`, [.github/workflows/package.ymlL186-R186](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L186-R186))