### PR TITLE
DAT-20252 : use permission-pull-requests: write for Github App Permissions 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -96,6 +96,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: read
           permission-actions: write
+          permission-pull-requests: read
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -96,7 +96,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: read
           permission-actions: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,7 +93,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: read
           permission-actions: write
-          permission-pull-requests: write
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,9 +83,6 @@ jobs:
   upload_packages:
     name: Upload ${{ inputs.artifactId }} packages
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Get GitHub App token
         id: get-token


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by removing unused permissions from the `upload_packages` job.

Workflow configuration changes:

* [`.github/workflows/package.yml`](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L86-L88): Removed the `id-token: write` and `contents: read` permissions from the `upload_packages` job, as they are no longer needed.