### PR TITLE
🔧 DAT-20257: fix os-extension-automated-release with Github App token

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -183,8 +183,8 @@ jobs:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          permission-contents: read
-          permission-releases: write
+          repositories: ${{ matrix.repository }}
+          permission-contents: write
           
       - name: Check for Artifact in Draft Releases
         run: |

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -33,12 +33,22 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository }}
+          permission-security-events: read
+          
       - name: Security
         run: |
           security_fail=false
           echo "Checking repository: ${{ matrix.repository }}"
           security_url="https://api.github.com/repos/liquibase/${{ matrix.repository }}/dependabot/alerts?state=open"
-          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $security_url | jq length)
+          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" $security_url | jq length)
           echo "Open Alerts: $response"
           if [[ $response == "0" ]]; then
             echo "Security vulnerabilities for ${{ matrix.repository }} are addressed."
@@ -166,13 +176,23 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-releases: write
+          
       - name: Check for Artifact in Draft Releases
         run: |
           sleep 180
           published_drafts_file=published_drafts.txt
           found=false
           echo "Checking repository: ${{ matrix.repository }}"
-          assets=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '.[] | select(.draft == true)' | jq -r '.assets[]')
+          assets=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '.[] | select(.draft == true)' | jq -r '.assets[]')
           echo "Assets: $assets"
           # check if assests are empty
           if [ -z "$assets" ]; then
@@ -186,15 +206,15 @@ jobs:
             fi
             if [ "$found" = true ] ; then
               # Get the draft release ID
-              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '[.[] | select(.draft == true)] | sort_by(.created_at) | last | .id')
+              RELEASE_ID=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases" | jq -r '[.[] | select(.draft == true)] | sort_by(.created_at) | last | .id')
               echo "Newest Draft release ID: $RELEASE_ID"
               RELEASE_TITLE="v${{ inputs.version }}"
               # Update the release title
               # echo "Updating release title to $RELEASE_TITLE... for ${{ matrix.repository }}"
-              # curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"name": "'"$RELEASE_TITLE"'"}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
+              # curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" -d '{"name": "'"$RELEASE_TITLE"'"}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
               # Publish the draft release as the latest release
               echo "Publishing the draft release as the latest release to https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
-              curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -d '{"draft": false}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
+              curl -s -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" -d '{"draft": false}' "https://api.github.com/repos/liquibase/${{ matrix.repository }}/releases/$RELEASE_ID"
               echo "Draft release published as the latest release for ${{ matrix.repository }}"
               echo "${{ matrix.repository }}: v${{ inputs.version }}" >> $published_drafts_file
             else


### PR DESCRIPTION
This pull request updates the `.github/workflows/os-extension-automated-release.yml` file to replace the use of the default GitHub token with a GitHub App token for enhanced security and permissions management. The changes ensure that API calls in the workflow use the GitHub App token instead of the default `GITHUB_TOKEN`.

### Key Changes:

#### Authentication Updates:
* Added a new step to generate a GitHub App token (`actions/create-github-app-token@v2`) with the required permissions (`permission-security-events`, `permission-contents`, and `permission-releases`) for interacting with repositories. [[1]](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R36-R51) [[2]](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R179-R195)
* Updated all API calls in the workflow to use the generated GitHub App token (`${{ steps.get-token.outputs.token }}`) instead of the default `GITHUB_TOKEN`. This applies to:
  - Security vulnerability checks.
  - Draft release artifact checks.
  - Draft release publishing and updates.