### PR TITLE
DAT-20257 fix permissions for updating POMs

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -48,7 +48,7 @@ jobs:
           security_fail=false
           echo "Checking repository: ${{ matrix.repository }}"
           security_url="https://api.github.com/repos/liquibase/${{ matrix.repository }}/dependabot/alerts?state=open"
-          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" $security_url | jq length)
+          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" $security_url | jq '[.[] | select(.state == "open")] | length')
           echo "Open Alerts: $response"
           if [[ $response == "0" ]]; then
             echo "Security vulnerabilities for ${{ matrix.repository }} are addressed."

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -89,11 +89,20 @@ jobs:
         repository: ${{ fromJson(inputs.repositories) }}
 
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           repository: "liquibase/${{ matrix.repository }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Set up Git
         run: |
@@ -149,8 +158,6 @@ jobs:
         run: mvn versions:set -DnewVersion=${{ inputs.version }}-SNAPSHOT
 
       - name: Update pom.xml
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>${{ inputs.version }}<\/liquibase.version>/" pom.xml
           git add pom.xml
@@ -159,7 +166,7 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "Update liquibase.version to ${{ inputs.version }}"
-            git remote set-url origin https://liquibot:${{ secrets.GITHUB_TOKEN }}@github.com/liquibase/${{ matrix.repository }}.git
+            git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/${{ matrix.repository }}.git
             git push
           fi
 

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -40,7 +40,7 @@ jobs:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          permission-security-events: read
+          repositories: ${{ matrix.repository }}
           
       - name: Security
         run: |

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -40,7 +40,6 @@ jobs:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ matrix.repository }}
           permission-security-events: read
           
       - name: Security
@@ -48,7 +47,7 @@ jobs:
           security_fail=false
           echo "Checking repository: ${{ matrix.repository }}"
           security_url="https://api.github.com/repos/liquibase/${{ matrix.repository }}/dependabot/alerts?state=open"
-          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" $security_url | jq '[.[] | select(.state == "open")] | length')
+          response=$(curl -s -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer ${{ steps.get-token.outputs.token }}" $security_url | jq length)
           echo "Open Alerts: $response"
           if [[ $response == "0" ]]; then
             echo "Security vulnerabilities for ${{ matrix.repository }} are addressed."


### PR DESCRIPTION
This pull request updates the `.github/workflows/os-extension-automated-release.yml` file to improve security by replacing the use of the default `GITHUB_TOKEN` with a GitHub App token. This ensures more granular permissions and better control over repository access. The most important changes include adding a step to generate the GitHub App token, updating token references in various steps, and removing unnecessary environment variables.

### Security Improvements:

* Added a new step to generate a GitHub App token using the `actions/create-github-app-token@v2` action. This token is configured with the necessary permissions and replaces the default `GITHUB_TOKEN`. (`[.github/workflows/os-extension-automated-release.ymlR92-R105](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R92-R105)`)
* Updated the `Checkout repository` step to use the newly generated GitHub App token instead of the default `GITHUB_TOKEN`. (`[.github/workflows/os-extension-automated-release.ymlR92-R105](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R92-R105)`)
* Updated the `git remote set-url` command to use the GitHub App token for authentication when pushing changes. (`[.github/workflows/os-extension-automated-release.ymlL163-R169](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206L163-R169)`)

### Cleanup:

* Removed the `permission-security-events: read` line from the configuration, which is no longer needed. (`[.github/workflows/os-extension-automated-release.ymlL44](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206L44)`)
* Removed the `GH_TOKEN` environment variable from the `Update pom.xml` step, as it is replaced by the GitHub App token. (`[.github/workflows/os-extension-automated-release.ymlL153-L154](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206L153-L154)`)