### PR TITLE
DAT-20257 🔧 (os-extension-automated-release.yml): add GitHub App token retrieval for Dependabot updates

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -76,6 +76,7 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repository }}
+          
       - name: Install Dependabot CLI
         run: |
           #https://github.com/dependabot/cli

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -76,7 +76,6 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ matrix.repository }}
-          
       - name: Install Dependabot CLI
         run: |
           #https://github.com/dependabot/cli

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -68,6 +68,15 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository }}
+          
       - name: Install Dependabot CLI
         run: |
           #https://github.com/dependabot/cli
@@ -76,6 +85,8 @@ jobs:
           sudo mv dependabot /usr/local/bin/
 
       - name: Run dependabot on extension
+        env:
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           echo "Running Dependabot on repository: ${{ matrix.repository }}"
           dependabot update maven "liquibase/${{ matrix.repository }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/os-extension-automated-release.yml` file to integrate GitHub App authentication into the workflow. The changes ensure secure access to repositories using a GitHub App token and enable Dependabot to run with the appropriate permissions.

### GitHub App Integration:
* Added a step to generate a GitHub App token using the `actions/create-github-app-token@v2` action. This step retrieves the token based on the app ID, private key, repository owner, and target repository. (`[.github/workflows/os-extension-automated-release.ymlR71-R79](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R71-R79)`)

### Dependabot Configuration:
* Updated the Dependabot step to use the GitHub App token by setting the `GH_TOKEN` environment variable with the token generated in the previous step. (`[.github/workflows/os-extension-automated-release.ymlR88-R89](diffhunk://#diff-968011793292fda6afa390798b1dc766d4d0a935081ccc4949a4458c7952e206R88-R89)`)