### PR TITLE
DAT-20257 fix Dependabot CLI

### DIFF
--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -78,15 +78,17 @@ jobs:
           repositories: ${{ matrix.repository }}
           
       - name: Install Dependabot CLI
+        env:
+          GH_TOKEN: ${{ github.steps.get-token.outputs.token }}
         run: |
-          #https://github.com/dependabot/cli
-          wget https://github.com/dependabot/cli/releases/download/v1.39.0/dependabot-v1.39.0-linux-amd64.tar.gz
-          tar xvzf dependabot-v1.39.0-linux-amd64.tar.gz
-          sudo mv dependabot /usr/local/bin/
+          gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
+          tar xzvf *.tar.gz >/dev/null 2>&1
+          chmod +x ./dependabot
+          ./dependabot --version
 
       - name: Run dependabot on extension
         env:
-          GH_TOKEN: ${{ steps.get-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           echo "Running Dependabot on repository: ${{ matrix.repository }}"
           dependabot update maven "liquibase/${{ matrix.repository }}"

--- a/.github/workflows/os-extension-automated-release.yml
+++ b/.github/workflows/os-extension-automated-release.yml
@@ -68,6 +68,15 @@ jobs:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repository }}
+          
       - name: Install Dependabot CLI
         run: |
           #https://github.com/dependabot/cli
@@ -76,6 +85,8 @@ jobs:
           sudo mv dependabot /usr/local/bin/
 
       - name: Run dependabot on extension
+        env:
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           echo "Running Dependabot on repository: ${{ matrix.repository }}"
           dependabot update maven "liquibase/${{ matrix.repository }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/os-extension-automated-release.yml` file to improve the Dependabot CLI installation process and fix an environment variable name. 

### Workflow improvements:

* **Dependabot CLI installation process updated**: The installation now uses `gh release download` to fetch the latest release of the Dependabot CLI instead of manually downloading and extracting a specific version. This ensures the workflow always uses the latest version of the CLI.

* **Environment variable name corrected**: The `GH_TOKEN` environment variable was replaced with `GITHUB_TOKEN` in the step that runs Dependabot, aligning with GitHub's standard naming convention.