### PR TITLE
DAT-20250 DevOps: delete individual checks artifacts after multiplatform artifact is created

### DIFF
--- a/.github/workflows/cleanup-individual-artifacts.yml
+++ b/.github/workflows/cleanup-individual-artifacts.yml
@@ -16,21 +16,12 @@ jobs:
   cleanup-individual-artifacts:
     name: Cleanup Individual OS Artifacts
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Delete Ubuntu Artifacts
+      - name: Delete ${{ matrix.os }} Artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: ${{ inputs.artifact_id }}-ubuntu-latest-${{ inputs.artifact_version }}-artifacts
-          failOnError: false
-
-      - name: Delete macOS Artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: ${{ inputs.artifact_id }}-macos-latest-${{ inputs.artifact_version }}-artifacts
-          failOnError: false
-
-      - name: Delete Windows Artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: ${{ inputs.artifact_id }}-windows-latest-${{ inputs.artifact_version }}-artifacts
+          name: ${{ inputs.artifact_id }}-${{ matrix.os }}-${{ inputs.artifact_version }}-artifacts
           failOnError: false

--- a/.github/workflows/cleanup-individual-artifacts.yml
+++ b/.github/workflows/cleanup-individual-artifacts.yml
@@ -1,0 +1,36 @@
+name: Cleanup Individual OS Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: "The artifact ID to cleanup"
+        required: true
+        type: string
+      artifact_version:
+        description: "The artifact version to cleanup"
+        required: true
+        type: string
+
+jobs:
+  cleanup-individual-artifacts:
+    name: Cleanup Individual OS Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Ubuntu Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: ${{ inputs.artifact_id }}-ubuntu-latest-${{ inputs.artifact_version }}-artifacts
+          failOnError: false
+
+      - name: Delete macOS Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: ${{ inputs.artifact_id }}-macos-latest-${{ inputs.artifact_version }}-artifacts
+          failOnError: false
+
+      - name: Delete Windows Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: ${{ inputs.artifact_id }}-windows-latest-${{ inputs.artifact_version }}-artifacts
+          failOnError: false

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -259,7 +259,7 @@ jobs:
   cleanup-individual-artifacts:
     needs: [build-multi-architecture, combineJars]
     if: ${{ inputs.combineJars && always() }}
-    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@main
     with:
       artifact_id: ${{needs.build-multi-architecture.outputs.artifact_id}}
       artifact_version: ${{needs.build-multi-architecture.outputs.artifact_version}}

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -256,6 +256,14 @@ jobs:
             /tmp/combined/${{needs.build-multi-architecture.outputs.artifact_id}}-${{needs.build-multi-architecture.outputs.artifact_version}}-javadoc.jar
             /tmp/combined/${{needs.build-multi-architecture.outputs.artifact_id}}-${{needs.build-multi-architecture.outputs.artifact_version}}.pom
 
+  cleanup-individual-artifacts:
+    needs: [build-multi-architecture, combineJars]
+    if: ${{ inputs.combineJars && always() }}
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    with:
+      artifact_id: ${{needs.build-multi-architecture.outputs.artifact_id}}
+      artifact_version: ${{needs.build-multi-architecture.outputs.artifact_version}}
+
   attach-to-release:
     if: always()
     name: Attach Artifact to Release

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -312,7 +312,7 @@ jobs:
   cleanup-individual-artifacts:
     needs: [build, combineJars]
     if: ${{ inputs.combineJars && always() }}
-    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@main
     with:
       artifact_id: ${{needs.build.outputs.artifact_id}}
       artifact_version: ${{ inputs.version }}

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -308,3 +308,11 @@ jobs:
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{ inputs.version }}-sources.jar
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{ inputs.version }}-javadoc.jar
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{ inputs.version }}.pom
+
+  cleanup-individual-artifacts:
+    needs: [build, combineJars]
+    if: ${{ inputs.combineJars && always() }}
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    with:
+      artifact_id: ${{needs.build.outputs.artifact_id}}
+      artifact_version: ${{ inputs.version }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -498,6 +498,14 @@ jobs:
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{needs.build.outputs.artifact_version}}-javadoc.jar
             /tmp/combined/${{needs.build.outputs.artifact_id}}-${{needs.build.outputs.artifact_version}}.pom
 
+  cleanup-individual-artifacts:
+    needs: [build, combineJars]
+    if: ${{ inputs.combineJars && always() }}
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    with:
+      artifact_id: ${{needs.build.outputs.artifact_id}}
+      artifact_version: ${{needs.build.outputs.artifact_version}}
+
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -501,7 +501,7 @@ jobs:
   cleanup-individual-artifacts:
     needs: [build, combineJars]
     if: ${{ inputs.combineJars && always() }}
-    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@DAT-20250
+    uses: liquibase/build-logic/.github/workflows/cleanup-individual-artifacts.yml@main
     with:
       artifact_id: ${{needs.build.outputs.artifact_id}}
       artifact_version: ${{needs.build.outputs.artifact_version}}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Please review the below table of reusable workflows and their descriptions:
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `build-artifact.yml`                    | Runs maven build and saves artifacts                                                                                    |
 | `build-extension-jar.yml`               | Builds and deploys extension JARs to GitHub Package Manager                                                             |
+| `cleanup-individual-artifacts.yml`      | Cleans up individual OS-specific artifacts across multiple operating systems                                            |
 | `codeql.yml`                            | Runs CodeQL scanning                                                                                                    |
 | `create-release.yml`                    | Runs Release Drafter to auto create draft release notes                                                                 |
 | `dependabot-automerge.yml`              | Automatically merges Dependabot PRs for minor and patch updates                                                         |


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Actions workflow for cleaning up individual OS-specific artifacts and integrates it into multiple existing workflows. The changes aim to streamline artifact cleanup and reduce unnecessary storage usage.

### Addition of a reusable workflow for artifact cleanup:
* [`.github/workflows/cleanup-individual-artifacts.yml`](diffhunk://#diff-c1c297045036892cf6d46e2f4678bef3a456994067f6402fecea8e6353f9de8fR1-R36): Added a new reusable workflow named "Cleanup Individual OS Artifacts" that deletes OS-specific artifacts (`ubuntu-latest`, `macos-latest`, and `windows-latest`) using the `geekyeggo/delete-artifact@v5` action. It accepts `artifact_id` and `artifact_version` as inputs.

### Integration of the cleanup workflow into existing workflows:
* [`.github/workflows/extension-attach-artifact-release.yml`](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9R259-R266): Integrated the `cleanup-individual-artifacts` job into the workflow, ensuring it runs after the `build-multi-architecture` and `combineJars` jobs if `combineJars` is enabled.
* [`.github/workflows/pro-extension-build-for-liquibase.yml`](diffhunk://#diff-9eec69f0f4f0aacb606223573d800b57cda8cb2051cc31142884952127675838R311-R318): Added the `cleanup-individual-artifacts` job, making it dependent on the `build` and `combineJars` jobs, conditional on `combineJars` being enabled.
* [`.github/workflows/pro-extension-test.yml`](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cR501-R508): Included the `cleanup-individual-artifacts` job, configured to run after the `build` and `combineJars` jobs, with a condition based on the `combineJars` input.