### PR TITLE
feat: add configurable Java build version to os-extension-test.yml

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -53,6 +53,11 @@ on:
         description: "The version of the dry-run release"
         required: false
         type: string
+      javaBuildVersion:
+        description: "Java version to build the project"
+        required: false
+        default: "17"
+        type: string
     secrets:
       GPG_SECRET:
         description: "GPG_SECRET from the caller workflow"
@@ -75,10 +80,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ inputs.javaBuildVersion }}
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: "temurin"
           cache: "maven"
 
@@ -269,10 +274,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ inputs.javaBuildVersion }}
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ""
         type: string
+      skipSonar:
+        description: "Skip SonarQube analysis"
+        required: false
+        default: false
+        type: boolean
 
 env:
   MAVEN_VERSION: "3.9.5"
@@ -263,7 +268,7 @@ jobs:
             **/target/site/jacoco/jacoco.xml
 
   sonar-pr:
-    if: ${{ !inputs.nightly }}
+    if: ${{ !inputs.skipSonar || !inputs.nightly }}
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: "[11, 17, 21]"
         type: string
+      javaBuildVersion:
+        description: "Java version to build the project"
+        required: false
+        default: "17"
+        type: string
       os:
         description: "Operating system to test"
         required: false
@@ -46,10 +51,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ inputs.javaBuildVersion }}
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -268,7 +268,7 @@ jobs:
             **/target/site/jacoco/jacoco.xml
 
   sonar-pr:
-    if: ${{ !inputs.skipSonar || !inputs.nightly }}
+    if: ${{ !inputs.skipSonar && !inputs.nightly }}
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-pull-request.yml@main
     secrets: inherit


### PR DESCRIPTION
This pull request updates the `.github/workflows/os-extension-test.yml` file to enhance configurability and streamline the CI workflow. Key changes include the addition of new input parameters, dynamic JDK version setup, and conditional execution of SonarQube analysis.

### Enhancements to configurability:

* Added a new input parameter `javaBuildVersion` to allow specifying the Java version dynamically, with a default value of `17`.
* Introduced a `skipSonar` input parameter to enable skipping SonarQube analysis, with a default value of `false`.

### Workflow improvements:

* Updated the JDK setup step to use the `javaBuildVersion` input dynamically instead of hardcoding Java version `17`.
* Modified the `sonar-pr` job condition to respect the new `skipSonar` input, ensuring SonarQube analysis can be skipped when desired.

Working example: https://github.com/liquibase/liquibase-cdi/actions/runs/15423998082?pr=5