### PR TITLE
DAT-20186: Update generate-upload-enterprise-3p-fossa-report.yml

### DIFF
--- a/.github/workflows/generate-upload-enterprise-3p-fossa-report.yml
+++ b/.github/workflows/generate-upload-enterprise-3p-fossa-report.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # Required for OIDC to assume the role
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/generate-upload-enterprise-3p-fossa-report.yml` file by adding the `id-token: write` permission under `permissions`. This is necessary to enable OpenID Connect (OIDC) for assuming a role.