### PR TITLE
fix: reduce fossa_ai.yml permissions to minimum required

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -22,7 +22,10 @@ on:
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read        # For code checkout
+      pull-requests: write  # For adding/removing PR labels
+      actions: write        # For uploading artifacts
     env:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 


### PR DESCRIPTION
## Summary
- Replace overly permissive `write-all` with specific minimal permissions
- Follows the principle of least privilege to reduce security risk

## Problem
The `fossa_ai.yml` workflow currently uses `permissions: write-all`, which grants unnecessary broad permissions. This is causing issues when the workflow is called from other repositories that have more restrictive permissions (see https://github.com/liquibase/liquibase/actions/runs/15489176223).

## Solution
Updated the workflow to use only the minimal permissions actually needed:
- `contents: read` - for code checkout
- `pull-requests: write` - for adding/removing PR labels
- `actions: write` - for uploading artifacts

## Test plan
- [ ] Verify the workflow still functions correctly with these reduced permissions
- [ ] Confirm it resolves the permission error in calling workflows

🤖 Generated with [Claude Code](https://claude.ai/code)