### PR TITLE
ArtifactPath should not be used by Sonar

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,7 +34,6 @@ jobs:
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
-      artifactPath: ${{ inputs.artifactPath }}
 
   create-release:
     name: Create Release

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -533,4 +533,3 @@ jobs:
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
-      artifactPath: ${{ inputs.artifactPath }}


### PR DESCRIPTION
Searching our entire repo, only commercial-databricks is using `artifactPath` parameter: https://github.com/search?q=org%3Aliquibase+artifactPath%3A+NOT+repo%3Aliquibase%2Fbuild-logic&type=code . 

And sonar is failing for it, as it should not consider the path in this case. This removes this parameter.

Test run: https://github.com/liquibase/liquibase-commercial-databricks/actions/runs/15568496305/job/43838740890?pr=93
