### PR TITLE
Fix usage of artifact path

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -379,7 +379,6 @@ jobs:
           fi
 
       - name: Build release artifacts
-        working-directory: ${{ inputs.artifactPath }}
         if: ${{ env.ARTIFACT_FOUND == '0' && inputs.dry_run == false }}
         id: build-release-artifacts
         run: |
@@ -398,7 +397,6 @@ jobs:
           mvn clean install -DskipTests -P '${{ inputs.mavenProfiles }}' -DbuildNumber=$LAST_COMMIT_HASH
 
       - name: Build release artifacts (dry-run)
-        working-directory: ${{ inputs.artifactPath }}
         if: ${{ inputs.dry_run == true }}
         id: build-release-artifacts-dry-run
         run: |

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -152,7 +152,6 @@ jobs:
 
       - name: Build and Package
         if: ${{ inputs.dry_run == false }}
-        working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
           mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase
@@ -161,7 +160,6 @@ jobs:
 
       - name: Build and Package (dry-run)
         if: ${{ inputs.dry_run == true }}
-        working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
           mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ inputs.dry_run_version }} -DpushChanges=false -P '${{ inputs.mavenProfiles }}' -DscmServerId=liquibase


### PR DESCRIPTION
This pull request makes minor adjustments to the `.github/workflows/extension-attach-artifact-release.yml` file by removing the `working-directory` property from two job steps. These changes ensures that the job build everything in the default working directory before starting to collect the artifacts.

Working example: https://github.com/liquibase/liquibase-commercial-databricks/actions/runs/15591182850