### PR TITLE
DAT-20394: Add artifactId input to workflow and update artifact ID retrieval logic

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: "."
         type: string
+      artifactId:
+        description: "Specify the artifact ID to be used in the release"
+        required: false
+        default: ""
+        type: string  
       combineJars:
         description: "Specify it if you want to combine jars into one"
         required: false
@@ -171,7 +176,12 @@ jobs:
         id: get-artifact-id
         shell: bash
         run: |
-          artifact_id=$(mvn help:evaluate "-Dexpression=project.artifactId" -q -DforceStdout)
+          # If artifactId is provided as input, use it; otherwise, evaluate from pom.xml
+          if [ -n "${{ inputs.artifactId }}" ]; then
+            artifact_id="${{ inputs.artifactId }}"
+          else
+            artifact_id=$(mvn help:evaluate "-Dexpression=project.artifactId" -q -DforceStdout)
+          fi
           echo "artifact_id=$artifact_id" >> $GITHUB_OUTPUT
 
       - name: Get Artifact Version
@@ -347,7 +357,15 @@ jobs:
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id
-        run: echo "artifact_id=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          # If artifactId is provided as input, use it; otherwise, evaluate from pom.xml
+          if [ -n "${{ inputs.artifactId }}" ]; then
+            artifact_id="${{ inputs.artifactId }}"
+          else
+            artifact_id=$(mvn help:evaluate "-Dexpression=project.artifactId" -q -DforceStdout)
+          fi
+          echo "artifact_id=$artifact_id" >> $GITHUB_ENV
 
       - name: Run extra command
         if: inputs.extraCommand


### PR DESCRIPTION
This pull request updates the `.github/workflows/extension-attach-artifact-release.yml` file to enhance flexibility in handling artifact IDs during the release process. The changes introduce an optional `artifactId` input parameter, which allows users to specify the artifact ID directly or fall back to deriving it from the `pom.xml` file. 

- The issue I am running into is with respect to artifactId: https://github.com/liquibase/liquibase-commercial-databricks/actions/runs/15879629601/job/44776180840#step:20:25 .  
<img width="1367" alt="Screenshot 2025-06-27 at 11 20 55 AM" src="https://github.com/user-attachments/assets/59f31659-818d-48cc-b551-129d2d23cc83" />

- The build is taking the artifactId from the parent [liquibase-commercial-databricks](https://github.com/liquibase/liquibase-commercial-databricks/blob/4560c3ecd27866aadb844284e3ecbb2c424f4c15/pom.xml#L12) but we want the artifactId from inside of the module under [liquibase-commercial-databricks/liquibase-commercial-databricks](https://github.com/liquibase/liquibase-commercial-databricks/blob/4560c3ecd27866aadb844284e3ecbb2c424f4c15/liquibase-commercial-databricks/pom.xml#L11).  

- When I ran the build locally, the target file is getting generated inside liquibase-commercial-databricks/liquibase-commercial-databricks

<img width="1674" alt="Screenshot 2025-06-26 at 3 59 15 PM" src="https://github.com/user-attachments/assets/a0be8e7e-805a-489b-872f-8f2c8844c3b1" />



- Check Jira comment to see more details on the issue :  https://datical.atlassian.net/browse/DAT-20394?focusedCommentId=166527

### Workflow Enhancements:

* **Added `artifactId` input parameter:** Introduced a new optional input parameter `artifactId` in the workflow configuration to allow users to specify the artifact ID explicitly. If left empty, the artifact ID is automatically derived from the `pom.xml` file. (`[.github/workflows/extension-attach-artifact-release.ymlR42-R46](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9R42-R46)`)
* **Conditional artifact ID evaluation:** Updated the script in the `get-artifact-id` job to conditionally use the provided `artifactId` input or evaluate the artifact ID from the `pom.xml` file. This logic ensures flexibility in artifact ID handling. (`[[1]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9R179-R184)`, `[[2]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L350-R368)`)