### PR TITLE
Add configurable Java version input for extension build

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "."
         type: string
+      java:
+        description: "Java version to use when building the extension"
+        required: false
+        default: "17"
+        type: string
       deployToMavenCentral:
         description: "Specify it if you want to deploy to maven"
         required: false
@@ -68,7 +73,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: ${{ inputs.java }}
           distribution: "temurin"
           cache: "maven"
 
@@ -205,7 +210,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: ${{ inputs.java }}
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -18,7 +18,7 @@ on:
         required: false
         default: "."
         type: string
-      java:
+      javaBuildVersion:
         description: "Java version to use when building the extension"
         required: false
         default: "17"
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ inputs.java }}
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: "temurin"
           cache: "maven"
 
@@ -210,7 +210,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ inputs.java }}
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: "temurin"
           cache: "maven"
 


### PR DESCRIPTION
This pull request introduces a feature that allows users to configure the Java version used during the extension build process. This enhancement increases flexibility and compatibility with different Java environments. 

