### PR TITLE
fix-databricks-release

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   maven-release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@fix-databricks-release
     if: inputs.deployToMavenCentral == true
     secrets: inherit
     with:

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -336,11 +336,13 @@ jobs:
           aws-region: us-east-1
 
       - name: Upload to s3
+        working-directory: ${{ inputs.artifactPath }}
         # aws s3 sync syncs directories and S3 prefixes.
         run: |
           aws s3 sync ${{ github.event.repository.name }}/src/main/resources/www.liquibase.org/xml/ns/${{ inputs.nameSpace }}/ s3://liquibaseorg-origin/xml/ns/${{ inputs.nameSpace }}/ --content-type application/octet-stream --only-show-errors
 
       - name: Index.htm file upload
+        working-directory: ${{ inputs.artifactPath }}
         # List all xsd and htm files in repository. Copy index.htm to temporary folder
         # Add links for all xsd files to index.htm file (except liquibase-${{ inputs.nameSpace }}-latest.xsd and index.htm)
         # Sync index.htm with the s3

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -61,7 +61,6 @@ jobs:
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
-      artifactPath: ${{ inputs.artifactPath }}
       javaBuildVersion: ${{ inputs.javaBuildVersion }}
 
   release:

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   maven-release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@fix-databricks-release
+    uses: liquibase/build-logic/.github/workflows/extension-release-prepare.yml@main
     if: inputs.deployToMavenCentral == true
     secrets: inherit
     with:


### PR DESCRIPTION

`working-directory` parameter is used only by commercial versions of databricks and mongodb . That's the first time we used them and we faced some release issues, that were fixed in this branch. 

Successful execution is here: https://github.com/liquibase/liquibase-commercial-databricks/actions/runs/16326434130