### PR TITLE
`os-extension-test`: add option to run integration tests

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      runIntegrationTests:
+        description: "Specify it if you want to run the integration tests in addition to the normal tests"
+        required: false
+        default: false
+        type: boolean
 
 env:
   MAVEN_VERSION: "3.9.5"
@@ -281,6 +286,14 @@ jobs:
         if: ${{ inputs.nightly }}
         run: mvn -B test -P 'coverage' ${{ inputs.extraMavenArgs }} "-Dliquibase.version=master-SNAPSHOT"
 
+      - name: Run Integration Tests
+        if: ${{ !inputs.nightly && inputs.runIntegrationTests }}
+        run: mvn -B integration-test -P 'coverage' ${{ inputs.extraMavenArgs }}
+
+      - name: Run Integration Tests
+        if: ${{ inputs.nightly && inputs.runIntegrationTests }}
+        run: mvn -B integration-test -P 'coverage' ${{ inputs.extraMavenArgs }} "-Dliquibase.version=master-SNAPSHOT"
+
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
         uses: rtCamp/action-slack-notify@v2
@@ -301,6 +314,7 @@ jobs:
           name: test-reports-jdk-${{ matrix.java }}-${{ matrix.os }}
           path: |
             **/target/surefire-reports
+            **/target/failsafe-reports
             **/target/site/jacoco/jacoco.xml
 
   sonar-pr:


### PR DESCRIPTION
so far, only unit tests are run. while it'd be great to just run integration tests for all open source extensions this is a breaking change in case some extension did not configure the failsafe plugin correctly (unlikely) or has failing integration tests. thus this is introduced as a new optional feature. if/when most/all plugins have explicitly enabled this the default should be switched to `true`. the template plugin repo should be updated to enable this so that new plugins start with running integration tests.

maven integration tests generate reports in the same format as unit tests which are however stored in `failsafe-reports`. thus these also need to be picked up for further processing by Sonar.

this also resolves that the build so far failed if _no_ unit test was present (the subsequent workflow requires a test result to be present), but integration tests were present and could've been used by the rest of the build.

this is a partial solution for #261, however it is _not_ a complete solution:
* it is only for the open source extensions
* it is not enabled by default

at the very least the first point needs to be resolved before #261 can be closed; IMHO it should also be enabled by default before it can be considered fully resolved.