### PR TITLE
🔧 restructure the dry run for SDKMAN

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -427,13 +427,32 @@ jobs:
           https://vendors.sdkman.io/announce/struct
           echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
+      - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
+        if: ${{ inputs.dry_run == true }}
+        env:
+          SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
+          SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
+          S3_BUCKET: s3://repo.liquibase.com.dry.run/sdkman/
+        run: |
+          mkdir -p liquibase-$VERSION/bin/internal
+          unzip .github/target/liquibase-$VERSION.zip -d liquibase-$VERSION
+          rm -rf liquibase-$VERSION.zip
+          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
+          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
+          # Upload the release to S3
+          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
+          echo "Uploaded liquibase-$VERSION.zip to s3"
+          
   # create a placeholder branch to check if tracking branch exists for this version
   # Branch is created when package is submitted to Homebrew and SDKMAN
   # Branch is deleted when package becomes available on Homebrew and SDKMAN
   create-placeholder-branch:
     runs-on: ubuntu-latest
     needs: upload_packages
-    if: ${{ inputs.dry_run == true }}
+    if: ${{ inputs.dry_run == false }}
     steps:
       - name: Get GitHub App token
         id: get-token
@@ -460,25 +479,6 @@ jobs:
           git push origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}
           echo "This is a placeholder branch for oss sdkman package v.${{ inputs.version }}. If this branch is open, it means the sdkman package is not yet approved" > README.md
           echo "This is a placeholder branch for oss homebrew package v.${{ inputs.version }}. If this branch is open, it means the homebrew package is not yet approved" > README.md
-
-      - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
-        if: ${{ inputs.dry_run == true }}
-        env:
-          SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
-          SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
-          S3_BUCKET: s3://repo.liquibase.com.dry.run/sdkman/
-        run: |
-          mkdir -p liquibase-$VERSION/bin/internal
-          unzip .github/target/liquibase-$VERSION.zip -d liquibase-$VERSION
-          rm -rf liquibase-$VERSION.zip
-          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
-          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
-          # Upload the release to S3
-          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
-          echo "Uploaded liquibase-$VERSION.zip to s3"
 
   upload_windows_package:
     uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master


### PR DESCRIPTION
This pull request modifies the `.github/workflows/package.yml` file to improve the handling of SDKMAN version updates during dry-run and non-dry-run scenarios. The changes primarily involve restructuring the workflow logic and relocating a step for better clarity and functionality.

### Workflow improvements:

* Added a new step for updating the SDKMAN version during a dry-run, ensuring it is executed only when the `dry_run` input is `true`. This step includes preparing and uploading the release to an S3 bucket. (`[.github/workflows/package.ymlR430-R455](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R430-R455)`)
* Removed the previously misplaced SDKMAN version update step from the `create-placeholder-branch` job, which was incorrectly conditioned on the `dry_run` input. (`[.github/workflows/package.ymlL464-L482](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L464-L482)`)