### PR TITLE
DAT-20504: feat: add setup action for Google credentials retrieval and authentication

### DIFF
--- a/.github/actions/setup-google-credentails/action.yml
+++ b/.github/actions/setup-google-credentails/action.yml
@@ -1,0 +1,28 @@
+name: 'Setup Google Credentials'
+description: 'Get Google credentials from vault and configure authentication'
+inputs:
+  aws-region:
+    description: 'AWS region for vault access'
+    required: false
+    default: 'us-east-1'
+  vault-secret-id:
+    description: 'Vault secret ID'
+    required: false
+    default: '/vault/liquibase'
+runs:
+  using: 'composite'
+  steps:
+    - name: Get Google credentials from vault
+      id: vault-secrets-google-creds-no-json
+      shell: bash
+      run: |
+        GOOGLE_CREDENTIALS=$(aws secretsmanager get-secret-value --secret-id "${{ inputs.vault-secret-id }}" --region "${{ inputs.aws-region }}" --query 'SecretString' --output text | jq -r '.GOOGLE_CREDENTIALS')
+        echo "GOOGLE_CREDENTIALS=$GOOGLE_CREDENTIALS" >> $GITHUB_ENV
+    
+    - name: configure auth
+      id: auth
+      uses: "google-github-actions/auth@v2"
+      env:
+        GOOGLE_IMPERSONATE_SERVICE_ACCOUNT: ${{ env.GOOGLE_IMPERSONATE_SERVICE_ACCOUNT }}
+      with:
+        credentials_json: ${{ env.GOOGLE_CREDENTIALS }}


### PR DESCRIPTION
This pull request introduces a new GitHub Action to set up Google credentials for authentication. The action retrieves credentials from AWS Secrets Manager and configures them for use in workflows.

### New GitHub Action: Setup Google Credentials

* **Action Definition**: Added a new composite action in `.github/actions/setup-google-credentails/action.yml` named `Setup Google Credentials`. This action retrieves Google credentials from AWS Secrets Manager and configures authentication for workflows.
* **Inputs**:
  - [`aws-region`](diffhunk://#diff-40c2702a270ac9333e598b682c09d06d31439868953da5007477ff88c68c97d1R1-R28): Optional input with a default value of `us-east-1` to specify the AWS region for vault access.
  - [`vault-secret-id`](diffhunk://#diff-40c2702a270ac9333e598b682c09d06d31439868953da5007477ff88c68c97d1R1-R28): Optional input with a default value of `/vault/liquibase` to specify the Vault secret ID.
* **Steps**:
  - Retrieves Google credentials from AWS Secrets Manager using the provided inputs and stores them in the environment variable `GOOGLE_CREDENTIALS`.
  - Configures authentication using the `google-github-actions/auth@v2` action with the retrieved credentials.