### PR TITLE
Fix pom-release-published permissions

### DIFF
--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -11,8 +11,10 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   id-token: write
+  packages: write
 
 jobs:
   release:


### PR DESCRIPTION
This pull request modifies the permissions in the `.github/workflows/pom-release-published.yml` file to enable writing to additional resources. The most important change is the addition of write permissions for pull requests and packages, alongside the existing permissions.

### Workflow permission updates:
* [`.github/workflows/pom-release-published.yml`](diffhunk://#diff-0b75ccc3be2300e7895c8c12486b67886f04ebc17b58ffd0d9a7de0bf7046c3fL14-R17): Updated permissions to include `pull-requests: write` and `packages: write`, and changed `contents` permission from `read` to `write`.