### PR TITLE
DAT-20527 DAT-20430: Fix label issue and prioritize PR link in Slack notifications

### DIFF
--- a/.github/workflows/subtree-sync.yml
+++ b/.github/workflows/subtree-sync.yml
@@ -151,7 +151,7 @@ jobs:
           commit-message: "Sync ${{ inputs.remote_name }} subtree"
           branch: ${{ inputs.pr_branch_name }}
           title: ${{ steps.pull_subtree.outputs.status == 'conflict' && format('⚠️ {0} (conflicts need resolution)', inputs.pr_title) || inputs.pr_title }}
-          labels: ${{ steps.pull_subtree.outputs.status == 'conflict' && format('{0},merge-conflicts', inputs.pr_labels) || inputs.pr_labels }}
+          labels: ${{ inputs.pr_labels }}
           body: |
             ${{ steps.pull_subtree.outputs.status == 'conflict' && '⚠️ **This PR contains merge conflicts that must be resolved manually before merging.**' || '' }}
             
@@ -174,8 +174,7 @@ jobs:
           SLACK_COLOR: ${{ steps.pull_subtree.outputs.status == 'conflict' && 'warning' || 'danger' }}
           SLACK_MESSAGE: |
             ${{ steps.pull_subtree.outputs.status == 'conflict' && '⚠️ Subtree sync created PR with conflicts that need manual resolution' || '❌ Subtree sync failed' }}
-            View workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            ${{ steps.create-pr.outputs.pull-request-number && format('PR: {0}/{1}/pull/{2}', github.server_url, github.repository, steps.create-pr.outputs.pull-request-number) || '' }}
+            ${{ steps.create-pr.outputs.pull-request-number && format('PR: {0}/{1}/pull/{2}', github.server_url, github.repository, steps.create-pr.outputs.pull-request-number) || format('Workflow: {0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
             <!here>
           SLACK_TITLE: "${{ github.repository }} - Subtree Sync ${{ steps.pull_subtree.outputs.status == 'conflict' && 'Conflicts' || 'Failed' }}"
           SLACK_USERNAME: liquibot


### PR DESCRIPTION
## Summary
Critical fixes for the subtree sync workflow based on testing and senior engineer feedback.

## Changes Made

### 1. Fix Label Issue
- **Problem**: liquibase-pro has `add_labels=false` in terraform, "merge-conflicts" label doesn't exist
- **Solution**: Remove merge-conflicts label dependency, use only configured `pr_labels` input
- **Result**: Workflow won't fail due to missing labels

### 2. Prioritize PR Link in Slack Notifications  
- **Request**: Senior engineers want PR link as primary focus, not workflow link
- **Solution**: Show "PR: [link]" when PR exists, "Workflow: [link]" only as fallback
- **Result**: Easier navigation to PRs that need attention

## Addresses
- **DAT-20527**: PRO OSS Subtree sync fails silently when there are merge conflicts
- **DAT-20430**: Add slack notifications for failures on subtree sync jobs

## Testing
- Workflow failed previously due to label creation permissions
- These fixes resolve the immediate blockers
- Ready for testing with liquibase-pro

## Related PRs
- liquibase-pro: https://github.com/liquibase/liquibase-pro/pull/2545

🤖 Generated with [Claude Code](https://claude.ai/code)