### PR TITLE
subtree-sync: mark PR as auto-merge even if conflicts are detected

### DIFF
--- a/.github/workflows/subtree-sync.yml
+++ b/.github/workflows/subtree-sync.yml
@@ -161,7 +161,7 @@ jobs:
             ${{ steps.pull_subtree.outputs.status == 'conflict' && 'Please resolve the conflicts in the files marked with conflict markers before merging this PR.' || '' }}
 
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number && steps.pull_subtree.outputs.status != 'conflict'
+        if: steps.create-pr.outputs.pull-request-number
         run: |
           gh pr merge --auto --merge "${{ steps.create-pr.outputs.pull-request-number }}"
         env:


### PR DESCRIPTION
This is desirable because even with conflicts, we still want to use merge commits, not squash or rebase merges. The developers use squash merges by default, so it is easy for us to accidentally squash merge them, which does not properly resolve the conflict.