### PR TITLE
fix: update dependabot automerge to use squash merging (DAT-20469)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: |
           # Command to merge the PR
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
           # Command to approve the PR with a custom message
           gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
         env:


### PR DESCRIPTION
## Summary
- Updates dependabot-automerge workflow to use `--squash` instead of `--merge`
- Enables auto-merge functionality while maintaining clean git history
- Addresses DAT-20469 dependabot workflow failures

## Changes Made
- Modified `.github/workflows/dependabot-automerge.yml` line 32
- Changed from `gh pr merge --auto --merge "$PR_URL"`
- Changed to `gh pr merge --auto --squash "$PR_URL"`

## Why This Change?
The current workflow fails because the liquibase repository has `allow_merge_commit = false`. Using `--squash` instead maintains the team's preference for clean git history while enabling the auto-merge functionality needed for DAT-20410's dependabot efficiency improvements.

## Testing
- Workflow syntax is valid
- Change aligns with Steven Massaro's feedback in DAT-20469
- Requires corresponding Terraform changes in liquibase-infrastructure

🤖 Generated with [Claude Code](https://claude.ai/code)