### PR TITLE
chore: remove unnecessary secret inputs from multiple workflows

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -64,13 +64,6 @@ on:
         required: false
         default: "17"
         type: string
-    secrets:
-      GPG_SECRET:
-        description: "GPG_SECRET from the caller workflow"
-        required: true
-      GPG_PASSPHRASE:
-        description: "GPG_PASSPHRASE from the caller workflow"
-        required: true
 
 jobs:
   build-multi-architecture:

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -41,13 +41,6 @@ on:
         description: "The release id of the dry-run release"
         required: false
         type: string
-    secrets:
-      SONATYPE_USERNAME:
-        description: "SONATYPE_USERNAME from the caller workflow"
-        required: true
-      SONATYPE_TOKEN:
-        description: "SONATYPE_TOKEN from the caller workflow"
-        required: true
 
 permissions:
   contents: write

--- a/.github/workflows/lth-docker.yml
+++ b/.github/workflows/lth-docker.yml
@@ -2,10 +2,6 @@ name: Liquibase Test Harness on Docker-Based Databases
 
 on:
   workflow_call:
-    secrets:
-        PRO_LICENSE_KEY:
-            description: 'Liquibase Pro license key'
-            required: false
 permissions:
   checks: write
   id-token: write

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,16 +30,7 @@ on:
         description: "ID of the dry-run release"
         required: false
         type: string
-    secrets:
-      GPG_SECRET:
-        description: "GPG_SECRET from the caller workflow"
-        required: true
-      GPG_PASSPHRASE:
-        description: "GPG_PASSPHRASE from the caller workflow"
-        required: true
-      GPG_SECRET_KEY_ID:
-        description: "GPG_SECRET_KEY_ID from the caller workflow"
-        required: true
+        
   workflow_dispatch:
     inputs:
       groupId:

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -2,13 +2,6 @@ name: Release POM to Sonatype
 
 on:
   workflow_call:
-    secrets:
-      SONATYPE_USERNAME:
-        description: "SONATYPE_USERNAME from the caller workflow"
-        required: true
-      SONATYPE_TOKEN:
-        description: "SONATYPE_TOKEN from the caller workflow"
-        required: true
 
 permissions:
   contents: write

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -60,16 +60,6 @@ on:
         required: true
         description: "Branch to check out"
         type: string
-    secrets:
-      SONAR_TOKEN:
-        description: "SONAR_TOKEN from the caller workflow"
-        required: true
-      PRO_LICENSE_KEY:
-        description: "PRO_LICENSE_KEY from the caller workflow"
-        required: true
-      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA:
-        description: "OIDC Role from the caller workflow"
-        required: true
 
 permissions:
   id-token: write

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -69,35 +69,6 @@ on:
         default: ""
         type: string
 
-    secrets:
-      SONAR_TOKEN:
-        description: "SONAR_TOKEN from the caller workflow"
-        required: true
-      PRO_LICENSE_KEY:
-        description: "PRO_LICENSE_KEY from the caller workflow"
-        required: true
-      AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA:
-        description: "OIDC Role from the caller workflow"
-        required: true
-      AZURE_TENANT_ID:
-        description: "Azure Active Directory (AD) tenant ID."
-        required: false
-      AZURE_CLIENT_SECRET:
-        description: "Secret key for Azure authentication."
-        required: false
-      AZURE_CLIENT_ID:
-        description: "Client ID for Azure service authentication."
-        required: false
-      LIQUIBASE_AZURE_STORAGE_ACCOUNT:
-        description: "Azure Storage Account name for Liquibase."
-        required: false
-      VAULT_ROLE_ID:
-        description: "Role ID for HashiCorp Vault authentication."
-        required: false
-      VAULT_SECRET_ID:
-        description: "Secret ID for HashiCorp Vault authentication."
-        required: false
-
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -13,10 +13,6 @@ on:
         required: false
         default: "."
         type: string
-    secrets:
-      SONAR_TOKEN:
-        description: 'SONAR_TOKEN from the caller workflow'
-        required: true
         
 permissions:
   contents: read

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -13,10 +13,6 @@ on:
         required: false
         default: "."
         type: string
-    secrets:
-      SONAR_TOKEN:
-        description: "SONAR_TOKEN from the caller workflow"
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,7 +1,6 @@
 name: SonarQube Scan
 on:
   workflow_call:
-    secrets:
       SONAR_TOKEN:
         required: true
 

--- a/.github/workflows/subtree-sync.yml
+++ b/.github/workflows/subtree-sync.yml
@@ -35,10 +35,6 @@ on:
         description: 'Environment variable name containing the Slack webhook URL'
         required: true
         type: string
-    secrets:
-      LIQUIBASE_VAULT_OIDC_ROLE_ARN:
-        description: 'AWS role ARN for vault access'
-        required: true
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to remove the declaration of required secrets from the `workflow_call` inputs section. Instead, secrets are now expected to be managed and passed directly by the caller workflows, which simplifies the workflow definitions and centralizes secret management.

The most important changes are:

**Workflow secrets input removal:**

* Removed the declaration of required secrets (such as `SONAR_TOKEN`, `PRO_LICENSE_KEY`, `GPG_SECRET`, `GPG_PASSPHRASE`, `SONATYPE_USERNAME`, `SONATYPE_TOKEN`, and various Azure/Vault secrets) from the `workflow_call` section across multiple workflow files, including `.github/workflows/extension-attach-artifact-release.yml`, `.github/workflows/extension-release-published.yml`, `.github/workflows/lth-docker.yml`, `.github/workflows/package.yml`, `.github/workflows/pom-release-published.yml`, `.github/workflows/pro-extension-build-for-liquibase.yml`, `.github/workflows/pro-extension-test.yml`, `.github/workflows/sonar-pull-request.yml`, `.github/workflows/sonar-push.yml`, `.github/workflows/sonar.yml`, and `.github/workflows/subtree-sync.yml`. [[1]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L67-L73) [[2]](diffhunk://#diff-8f35892fff793298c429a326782b9912e79873322b834b9f18da1b918718e39aL44-L50) [[3]](diffhunk://#diff-0e3de85fc2fec8799f143d9a65a52a010ab79f04ca86ddf7390f2d733c8d9c8cL5-L8) [[4]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L33-R33) [[5]](diffhunk://#diff-0b75ccc3be2300e7895c8c12486b67886f04ebc17b58ffd0d9a7de0bf7046c3fL5-L11) [[6]](diffhunk://#diff-9eec69f0f4f0aacb606223573d800b57cda8cb2051cc31142884952127675838L63-L72) [[7]](diffhunk://#diff-ae1893afdebf217a3d21c6073d1a9d3b3ea3792ecd74048de56ff0dba952ec8cL72-L100) [[8]](diffhunk://#diff-fc000050ca00a39fcce28bc1e5b62492255b4c9cb8b333da82c2202975892a43L16-L19) [[9]](diffhunk://#diff-3cf0243751c2d2f0a56ede5613cabea668e70c7469a6c7374147704cd4078726L16-L19) [[10]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L4) [[11]](diffhunk://#diff-25d5c33a9c6a7952656826ab05a3b742c72aab2934d5d95858f0d38cd2355b48L38-L41)

**Permissions unchanged:**

* All workflows retain their permissions blocks, ensuring no change to the access levels required for job execution. (applies to all references above)

These changes make the workflows easier to maintain and reduce duplication, since secrets are now managed in one place rather than being declared in every workflow that uses them.