### PR TITLE
DAT-20673 Secure: Create new package locations

### DIFF
--- a/.github/package-deb-pom-secure.xml
+++ b/.github/package-deb-pom-secure.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>${groupId}</groupId>
+	<artifactId>${artifactId}</artifactId>
+	<version>${revision}</version>
+	<description>Universal pom for liquibase-secure deb packaging</description>
+
+	<properties>
+		<maven.antrun.version>3.1.0</maven.antrun.version>
+		<org.vafer.jdeb.version>1.10</org.vafer.jdeb.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${maven.antrun.version}</version>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<phase>package</phase>
+						<configuration>
+							<target>
+								<untar
+									src="${project.build.directory}/${project.artifactId}-${project.version}.tar.gz"
+									compression="gzip"
+									dest="${project.build.directory}/dist-unpacked" />
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+				<version>${org.vafer.jdeb.version}</version>
+				<executions>
+					<execution>
+						<id>create-deb</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jdeb</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<deb>${project.build.directory}/${project.artifactId}-${project.version}.deb</deb>
+					<controlDir>${project.basedir}/src/${project.artifactId}/deb/control</controlDir>
+					<dataSet>
+						<data>
+							<src>${project.build.directory}/dist-unpacked</src>
+							<type>directory</type>
+							<mapper>
+								<type>perm</type>
+								<prefix>/opt/liquibase</prefix>
+								<filemode>755</filemode>
+							</mapper>
+						</data>
+						<data>
+							<type>link</type>
+							<src>.</src>
+							<linkName>/usr/bin/liquibase</linkName>
+							<linkTarget>/opt/liquibase/liquibase</linkTarget>
+							<symlink>true</symlink>
+						</data>
+					</dataSet>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -151,8 +151,15 @@ jobs:
           mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/control
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postrm
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-          curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom.xml
+          
+          # Download appropriate pom.xml based on formula_name
+          if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
+            curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom-secure.xml
+          else
+            curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom.xml
+          fi
           curl -o $PWD/.github/sign_artifact.sh https://raw.githubusercontent.com/liquibase/build-logic/main/.github/sign_artifact.sh
           chmod +x $PWD/.github/sign_artifact.sh
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -197,7 +197,7 @@ jobs:
           if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
             # Download from S3 for liquibase-secure
             wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
-              ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-pro-${{ inputs.version }}.tar.gz
+              ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-secure-${{ inputs.version }}.tar.gz
           else
             # Download from GitHub for liquibase (community)
             wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
@@ -391,7 +391,7 @@ jobs:
           formula-path: Formula/l/${{ inputs.formula_name }}.rb
           homebrew-tap: Homebrew/homebrew-core
           tag-name: ${{ inputs.version }}
-          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-pro-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
+          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -197,7 +197,7 @@ jobs:
           if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
             # Download from S3 for liquibase-secure
             wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
-              ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-secure-${{ inputs.version }}.tar.gz
+              ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-pro-${{ inputs.version }}.tar.gz
           else
             # Download from GitHub for liquibase (community)
             wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
@@ -391,7 +391,7 @@ jobs:
           formula-path: Formula/l/${{ inputs.formula_name }}.rb
           homebrew-tap: Homebrew/homebrew-core
           tag-name: ${{ inputs.version }}
-          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
+          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-pro-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,16 @@ on:
         description: "ID of the dry-run release"
         required: false
         type: string
+      formula_name:
+        description: "Name of the Homebrew formula (liquibase or liquibase-secure)"
+        required: false
+        type: string
+        default: "liquibase"
+      download_base_url:
+        description: "Base URL for downloading artifacts"
+        required: false
+        type: string
+        default: "https://github.com/liquibase/liquibase/releases/download"
         
   workflow_dispatch:
     inputs:
@@ -61,6 +71,16 @@ on:
         description: "ID of the dry-run release"
         required: false
         type: string
+      formula_name:
+        description: "Name of the Homebrew formula (liquibase or liquibase-secure)"
+        required: false
+        type: string
+        default: "liquibase"
+      download_base_url:
+        description: "Base URL for downloading artifacts"
+        required: false
+        type: string
+        default: "https://github.com/liquibase/liquibase/releases/download"
 
 env:
   MAVEN_VERSION: "3.9.5"
@@ -167,8 +187,15 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         run: |
           mkdir -p $PWD/.github/target
-          # Creating deb packages needs to get release assets from somewhere so be sure to follow this pattern in the artifact repo: https://github.com/liquibase/ARTIFACT_ID/releases/download/vVERSION/ARTIFACT_ID-VERSION.tar.gz
-          wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz https://github.com/liquibase/${{ inputs.artifactId }}/releases/download/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+          if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
+            # Download from S3 for liquibase-secure
+            wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
+              ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-secure-${{ inputs.version }}.tar.gz
+          else
+            # Download from GitHub for liquibase (community)
+            wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
+              ${{ inputs.download_base_url }}/v${{ inputs.version }}/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz
+          fi
 
       - name: Download ${{ inputs.artifactId }} dry-run Release
         if: ${{ inputs.dry_run == true }}
@@ -324,14 +351,14 @@ jobs:
           ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
           aws s3 sync $PWD/yum s3://repo.liquibase.com.dry.run/yum
 
-      - name: Check for existing Homebrew formula PR for ${{ inputs.artifactId }}
+      - name: Check for existing Homebrew formula PR for ${{ inputs.formula_name }}
         id: check-brew-pr
         run: |
           # Authenticate GitHub CLI
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
           # Define the PR title
-          pr_title="liquibase ${{ inputs.version }}"
+          pr_title="${{ inputs.formula_name }} ${{ inputs.version }}"
 
           # Search for open pull requests with the specified title in the Homebrew/homebrew-core repo
           pr_title=$(gh pr list --repo Homebrew/homebrew-core --state open --search "$pr_title" --json title --jq ".[] | select(.title == \"$pr_title\") | .title" )
@@ -349,15 +376,15 @@ jobs:
           # Echo it immediately to see the value in logs
           echo "PR_EXISTS is set to $PR_EXISTS"
 
-      - name: Update Homebrew formula for ${{ inputs.artifactId }}
+      - name: Update Homebrew formula for ${{ inputs.formula_name }}
         if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         uses: mislav/bump-homebrew-formula-action@v3
         with:
-          formula-name: liquibase
-          formula-path: Formula/l/liquibase.rb
+          formula-name: ${{ inputs.formula_name }}
+          formula-path: Formula/l/${{ inputs.formula_name }}.rb
           homebrew-tap: Homebrew/homebrew-core
           tag-name: ${{ inputs.version }}
-          download-url: "https://github.com/liquibase/liquibase/releases/download/v${{ inputs.version }}/liquibase-${{ inputs.version }}.tar.gz"
+          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,8 +30,8 @@ on:
         description: "ID of the dry-run release"
         required: false
         type: string
-      formula_name:
-        description: "Name of the Homebrew formula (liquibase or liquibase-secure)"
+      distribution:
+        description: "liquibase or liquibase-secure"
         required: false
         type: string
         default: "liquibase"
@@ -71,8 +71,8 @@ on:
         description: "ID of the dry-run release"
         required: false
         type: string
-      formula_name:
-        description: "Name of the Homebrew formula (liquibase or liquibase-secure)"
+      distribution:
+        description: "liquibase or liquibase-secure"
         required: false
         type: string
         default: "liquibase"
@@ -154,8 +154,8 @@ jobs:
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postrm
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
           
-          # Download appropriate pom.xml based on formula_name
-          if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
+          # Download appropriate pom.xml based on distribution
+          if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
             curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom-secure.xml
           else
             curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom.xml
@@ -194,7 +194,7 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         run: |
           mkdir -p $PWD/.github/target
-          if [ "${{ inputs.formula_name }}" = "liquibase-secure" ]; then
+          if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
             # Download from S3 for liquibase-secure
             wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
               ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-secure-${{ inputs.version }}.tar.gz
@@ -358,14 +358,14 @@ jobs:
           ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
           aws s3 sync $PWD/yum s3://repo.liquibase.com.dry.run/yum
 
-      - name: Check for existing Homebrew formula PR for ${{ inputs.formula_name }}
+      - name: Check for existing Homebrew formula PR for ${{ inputs.distribution }}
         id: check-brew-pr
         run: |
           # Authenticate GitHub CLI
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
           # Define the PR title
-          pr_title="${{ inputs.formula_name }} ${{ inputs.version }}"
+          pr_title="${{ inputs.distribution }} ${{ inputs.version }}"
 
           # Search for open pull requests with the specified title in the Homebrew/homebrew-core repo
           pr_title=$(gh pr list --repo Homebrew/homebrew-core --state open --search "$pr_title" --json title --jq ".[] | select(.title == \"$pr_title\") | .title" )
@@ -383,15 +383,15 @@ jobs:
           # Echo it immediately to see the value in logs
           echo "PR_EXISTS is set to $PR_EXISTS"
 
-      - name: Update Homebrew formula for ${{ inputs.formula_name }}
+      - name: Update Homebrew formula for ${{ inputs.distribution }}
         if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         uses: mislav/bump-homebrew-formula-action@v3
         with:
-          formula-name: ${{ inputs.formula_name }}
-          formula-path: Formula/l/${{ inputs.formula_name }}.rb
+          formula-name: ${{ inputs.distribution }}
+          formula-path: Formula/l/${{ inputs.distribution }}.rb
           homebrew-tap: Homebrew/homebrew-core
           tag-name: ${{ inputs.version }}
-          download-url: ${{ inputs.formula_name == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
+          download-url: ${{ inputs.distribution == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/src/liquibase-secure/deb/control/control
+++ b/src/liquibase-secure/deb/control/control
@@ -1,0 +1,10 @@
+Package: liquibase-secure
+Version: [[version]]
+Section: misc
+Priority: optional
+Architecture: all
+Depends:
+Maintainer: Liquibase <support@liquibase.com>
+Description: Liquibase Secure Debian Installer
+Distribution: development
+Conflicts: liquibase

--- a/src/liquibase-secure/deb/control/postinst
+++ b/src/liquibase-secure/deb/control/postinst
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Define LIQUIBASE_HOME for liquibase-secure
+LIQUIBASE_HOME="/opt/liquibase"

--- a/src/liquibase-secure/deb/control/postrm
+++ b/src/liquibase-secure/deb/control/postrm
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# unset LIQUIBASE_HOME
+unset LIQUIBASE_HOME


### PR DESCRIPTION
This pull request updates the `.github/workflows/package.yml` workflow to support publishing both the community (`liquibase`) and secure (`liquibase-secure`) Homebrew formulas, with improved flexibility for artifact download sources. The changes make the workflow configurable for the formula name and download URL, allowing it to handle different release and packaging requirements for each formula.

**Homebrew formula support and configuration:**

* Added new workflow inputs: `formula_name` (to specify which Homebrew formula to update) and `download_base_url` (to specify the base URL for downloading release artifacts). Defaults are set for both inputs. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R33-R42) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R74-R83)
* Updated artifact download logic to select the correct source based on the formula being built: uses S3 for `liquibase-secure` and GitHub releases for `liquibase`.

**Homebrew formula update and PR logic:**

* Changed Homebrew formula PR check and update steps to use `formula_name` instead of hardcoded values, ensuring the correct formula is targeted for each run.
* Updated the Homebrew formula update step to dynamically set the formula name, formula path, and download URL, handling both `liquibase` and `liquibase-secure` cases.