### PR TITLE
os-extension-test: use `javaBuildVersion` for sonar scan

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -324,3 +324,4 @@ jobs:
     secrets: inherit
     with:
       extraCommand: ${{ inputs.extraCommand }}
+      javaBuildVersion: ${{ inputs.javaBuildVersion }}

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "."
         type: string
+      javaBuildVersion:
+        description: "Java version to build the project"
+        required: false
+        default: "17"
+        type: string
         
 permissions:
   contents: read
@@ -46,7 +51,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: ${{ inputs.javaBuildVersion }}
           distribution: 'temurin'
           cache: 'maven'
           
@@ -114,7 +119,7 @@ jobs:
       - name: Download unit tests report
         uses: actions/download-artifact@v4
         with:
-          name: test-reports-jdk-17-ubuntu-latest
+          name: test-reports-jdk-${{ inputs.javaBuildVersion }}-ubuntu-latest
 
       - name: Sonar Scan
         working-directory: ${{ inputs.artifactPath }}


### PR DESCRIPTION
so far the sonar scan expects JDK 17 builds to be present. however, if a different java version (e.g. 21) is set, this will not be present.

this does not change the behaviour for consumers which do not set `javaBuildVersion`, however it does change the behaviour for those which set it to something other than 17.