### PR TITLE
make java version configurable for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: ''
         type: string
+      javaBuildVersion:
+        description: "Java version to build the project"
+        required: false
+        default: "17"
+        type: string
 
 permissions:
   actions: read
@@ -106,7 +111,7 @@ jobs:
       if: matrix.language == 'java'
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: ${{ inputs.javaBuildVersion }}
         distribution: 'temurin'
         cache: 'maven'
         


### PR DESCRIPTION
this is required to support projects which use a different JDK version (e.g. 21).
the default stays at 17 and thus does not change for any existing consumers.