### PR TITLE
DAT-20673 Secure: Create new package Location - fixes after testing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -566,6 +566,11 @@ jobs:
           repository: liquibase/liquibase
           token: ${{ steps.get-token.outputs.token }}
 
+      - name: Configure Git
+        run: |
+          git config --local user.email "64099989+liquibot@users.noreply.github.com"
+          git config --local user.name "liquibot"
+
       - name: Create placeholder branches for SDKMAN and Homebrew
         id: create-placeholder-branch
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -569,7 +569,7 @@ jobs:
   #     dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
 
   upload_ansible_role:
-    uses: liquibase/liquibase-ansible/.github/workflows/deploy-role.yml@main
+    uses: liquibase/liquibase-ansible/.github/workflows/deploy-role.yml@DAT-20702
     secrets: inherit
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -291,12 +291,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y alien
           sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          # Find the actual generated RPM file (alien may change naming)
+          RPM_FILE=$(ls -1 *.rpm 2>/dev/null | head -1)
+          if [ -n "$RPM_FILE" ]; then
+            echo "Generated RPM: $RPM_FILE"
+            echo "RPM_FILENAME=$RPM_FILE" >> $GITHUB_ENV
+          else
+            echo "Error: No RPM file found after conversion"
+            exit 1
+          fi
 
       - name: Upload ${{ inputs.artifactId }} rpm package
         if: ${{ inputs.dry_run == false }}
         run: |
           sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          ./.github/sign_artifact.sh "${{ env.RPM_FILENAME }}"
           mkdir -p createrepo_folder
           cd createrepo_folder
           git clone https://github.com/rpm-software-management/createrepo_c
@@ -322,7 +331,10 @@ jobs:
           cd ../../..
           mkdir -p $PWD/yum/noarch
           aws s3 ls s3://repo.liquibase.com/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com/yum/noarch/{} $PWD/yum/noarch
-          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          mv "${{ env.RPM_FILENAME }}" $PWD/yum/noarch/
+          if [ -f "${{ env.RPM_FILENAME }}.asc" ]; then
+            mv "${{ env.RPM_FILENAME }}.asc" $PWD/yum/noarch/
+          fi
           /opt/createrepo -dp $PWD/yum/noarch
           ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
           aws s3 sync $PWD/yum s3://repo.liquibase.com/yum
@@ -330,11 +342,10 @@ jobs:
       - name: Upload ${{ inputs.artifactId }} dry-run rpm package
         if: ${{ inputs.dry_run == true }}
         run: |
-          original_file=$(basename "$(find . -maxdepth 1 -name "*.rpm")")
-          new_name=$(echo "$original_file" | sed 's/+/-/g')
-          mv "$original_file" "$new_name"
+          # Use the RPM filename from the previous step
+          echo "Using RPM file: ${{ env.RPM_FILENAME }}"
           sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
-          ./.github/sign_artifact.sh ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch.rpm
+          ./.github/sign_artifact.sh "${{ env.RPM_FILENAME }}"
           mkdir -p createrepo_folder
           cd createrepo_folder
           git clone https://github.com/rpm-software-management/createrepo_c
@@ -360,7 +371,10 @@ jobs:
           cd ../../..
           mkdir -p $PWD/yum/noarch
           aws s3 ls s3://repo.liquibase.com.dry.run/yum/noarch/ | grep -E '\.rpm$' | awk '{print $4}' | xargs -I {} aws s3 cp s3://repo.liquibase.com.dry.run/yum/noarch/{} $PWD/yum/noarch
-          mv ${{ inputs.artifactId }}-${{ inputs.version }}-1.noarch* $PWD/yum/noarch
+          mv "${{ env.RPM_FILENAME }}" $PWD/yum/noarch/
+          if [ -f "${{ env.RPM_FILENAME }}.asc" ]; then
+            mv "${{ env.RPM_FILENAME }}.asc" $PWD/yum/noarch/
+          fi
           /opt/createrepo -dp $PWD/yum/noarch
           ./.github/sign_artifact.sh $PWD/yum/noarch/repodata/repomd.xml
           aws s3 sync $PWD/yum s3://repo.liquibase.com.dry.run/yum

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
         default: "https://github.com/liquibase/liquibase/releases/download"
-        
+
   workflow_dispatch:
     inputs:
       groupId:
@@ -89,9 +89,9 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
-  issues: write       # Required for creating/updating issues
-  packages: write     # Required for package operations
-  actions: write      # Required for workflow operations
+  issues: write # Required for creating/updating issues
+  packages: write # Required for package operations
+  actions: write # Required for workflow operations
 
 jobs:
   upload_packages:
@@ -153,7 +153,7 @@ jobs:
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postinst
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postrm
           curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
-          
+
           # Download appropriate pom.xml based on distribution
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
             curl -o $PWD/.github/package-deb-pom.xml https://raw.githubusercontent.com/liquibase/build-logic/main/.github/package-deb-pom-secure.xml
@@ -235,18 +235,18 @@ jobs:
           # Debug: List available GPG keys
           echo "Available GPG keys:"
           gpg --list-secret-keys --keyid-format LONG
-          
+
           # Get the actual key ID from the imported key
           ACTUAL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "sec" | head -1 | sed 's/.*\/\([A-F0-9]\{16\}\).*/\1/')
           echo "Using key ID: $ACTUAL_KEY_ID"
-          
+
           # Create temporary passphrase file securely (not logged)
           TEMP_PASSPHRASE_FILE=$(mktemp)
           echo "${{ env.GPG_PASSPHRASE }}" > "$TEMP_PASSPHRASE_FILE"
           chmod 600 "$TEMP_PASSPHRASE_FILE"
-          
+
           deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
-          
+
           # Securely clean up passphrase file
           rm -f "$TEMP_PASSPHRASE_FILE"
 
@@ -264,18 +264,18 @@ jobs:
           # Debug: List available GPG keys
           echo "Available GPG keys:"
           gpg --list-secret-keys --keyid-format LONG
-          
+
           # Get the actual key ID from the imported key
           ACTUAL_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "sec" | head -1 | sed 's/.*\/\([A-F0-9]\{16\}\).*/\1/')
           echo "Using key ID: $ACTUAL_KEY_ID"
-          
+
           # Create temporary passphrase file securely (not logged)
           TEMP_PASSPHRASE_FILE=$(mktemp)
           echo "${{ env.GPG_PASSPHRASE }}" > "$TEMP_PASSPHRASE_FILE"
           chmod 600 "$TEMP_PASSPHRASE_FILE"
-          
+
           deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com.dry.run --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
-          
+
           # Securely clean up passphrase file
           rm -f "$TEMP_PASSPHRASE_FILE"
 
@@ -408,12 +408,12 @@ jobs:
       #   run: |
       #     # Wait briefly for PR to be created
       #     sleep 30
-          
+
       #     # Search for the PR
       #     PR_DATA=$(gh api graphql -f query='
       #     query($search_query: String!) {
-      #       search(query: $search_query, type: ISSUE, first: 1) { 
-      #         nodes {               
+      #       search(query: $search_query, type: ISSUE, first: 1) {
+      #         nodes {
       #           ... on PullRequest {
       #             url,
       #             number
@@ -421,7 +421,7 @@ jobs:
       #         }
       #       }
       #     }' -f search_query="is:pr is:open repo:Homebrew/homebrew-core liquibase ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
-          
+
       #     if [ ! -z "$PR_DATA" ]; then
       #       echo "HOMEBREW_PR_URL=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT
       #       echo "HOMEBREW_PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')" >> $GITHUB_OUTPUT
@@ -429,7 +429,7 @@ jobs:
       #     fi
       #   env:
       #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            
+
       # - name: Update SDKMAN version for ${{ inputs.artifactId }}
       #   if: ${{ inputs.dry_run == false }}
       #   env:
@@ -495,7 +495,7 @@ jobs:
       #     # Upload the release to S3
       #     aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
       #     echo "Uploaded liquibase-$VERSION.zip to s3"
-          
+
   # create a placeholder branch to check if tracking branch exists for this version
   # Branch is created when package is submitted to Homebrew and SDKMAN
   # Branch is deleted when package becomes available on Homebrew and SDKMAN
@@ -531,13 +531,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: liquibase/liquibase
-          token: ${{ steps.get-token.outputs.token }} 
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Create placeholder branches for SDKMAN and Homebrew
         id: create-placeholder-branch
         run: |
           git fetch origin
-          
+
           # Create SDKMAN tracking branch if it doesn't exist
           if ! git ls-remote --exit-code --heads origin ci-oss-sdkman-package-check; then
             git checkout -b ci-oss-sdkman-package-check
@@ -548,7 +548,7 @@ jobs:
           else
             echo "SDKMAN tracking branch already exists, skipping creation"
           fi
-          
+
           # Create Homebrew tracking branch if it doesn't exist and PR number is available
           if [[ -n "${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}" ]] && ! git ls-remote --exit-code --heads origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}; then
             git checkout -b ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}
@@ -575,3 +575,4 @@ jobs:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}
       dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url }}
+      distribution: ${{ inputs.distribution }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -147,19 +147,24 @@ jobs:
       - name: Get Reusable Files
         run: |
           # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
-          # Determine the correct source directory based on distribution
+          # Determine the correct source directory and package name based on distribution
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
             SRC_DIR="liquibase-secure"
+            PACKAGE_NAME="liquibase-secure"
           else
             SRC_DIR="${{ inputs.artifactId }}"
+            PACKAGE_NAME="${{ inputs.artifactId }}"
           fi
           
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
-          mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/control
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postinst
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postrm
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/main/archive/${SRC_DIR}-env.sh
+          # Export for use in later steps
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+          
+          mkdir -p $PWD/.github/src/$PACKAGE_NAME/deb/control
+          mkdir -p $PWD/.github/src/$PACKAGE_NAME/main/archive
+          curl -o $PWD/.github/src/$PACKAGE_NAME/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/control
+          curl -o $PWD/.github/src/$PACKAGE_NAME/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postinst
+          curl -o $PWD/.github/src/$PACKAGE_NAME/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postrm
+          curl -o $PWD/.github/src/$PACKAGE_NAME/main/archive/$PACKAGE_NAME-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/main/archive/${SRC_DIR}-env.sh
 
           # Download appropriate pom.xml based on distribution
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
@@ -203,7 +208,7 @@ jobs:
           mkdir -p $PWD/.github/target
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
             # Download from S3 for liquibase-secure
-            wget -q -O $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
+            wget -q -O $PWD/.github/target/liquibase-secure-${{ inputs.version }}.tar.gz \
               ${{ inputs.download_base_url }}/${{ inputs.version }}/liquibase-secure-${{ inputs.version }}.tar.gz
           else
             # Download from GitHub for liquibase (community)
@@ -223,7 +228,7 @@ jobs:
 
       - name: Build ${{ inputs.artifactId }} deb package
         run: |
-          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ inputs.artifactId }} -Drevision=${{ inputs.version }} -DskipTests
+          mvn package -f $PWD/.github/package-deb-pom.xml -DgroupId=${{ inputs.groupId }} -DartifactId=${{ env.PACKAGE_NAME }} -Drevision=${{ inputs.version }} -DskipTests
 
       - name: Install deb-s3 gem
         run: gem install deb-s3
@@ -252,7 +257,7 @@ jobs:
           echo "${{ env.GPG_PASSPHRASE }}" > "$TEMP_PASSPHRASE_FILE"
           chmod 600 "$TEMP_PASSPHRASE_FILE"
 
-          deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com --visibility=nil $PWD/.github/target/${{ env.PACKAGE_NAME }}-${{ inputs.version }}.deb
 
           # Securely clean up passphrase file
           rm -f "$TEMP_PASSPHRASE_FILE"
@@ -281,7 +286,7 @@ jobs:
           echo "${{ env.GPG_PASSPHRASE }}" > "$TEMP_PASSPHRASE_FILE"
           chmod 600 "$TEMP_PASSPHRASE_FILE"
 
-          deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com.dry.run --visibility=nil $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          deb-s3 upload --preserve-versions --sign "$ACTUAL_KEY_ID" --gpg-options "\-\-pinentry-mode loopback \-\-batch \-\-passphrase\-file $TEMP_PASSPHRASE_FILE \-\-yes \-\-quiet" --bucket repo.liquibase.com.dry.run --visibility=nil $PWD/.github/target/${{ env.PACKAGE_NAME }}-${{ inputs.version }}.deb
 
           # Securely clean up passphrase file
           rm -f "$TEMP_PASSPHRASE_FILE"
@@ -290,11 +295,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y alien
-          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.deb
+          sudo alien --to-rpm --keep-version $PWD/.github/target/${{ env.PACKAGE_NAME }}-${{ inputs.version }}.deb
           # Find the actual generated RPM file (alien may change naming)
           RPM_FILE=$(ls -1 *.rpm 2>/dev/null | head -1)
           if [ -n "$RPM_FILE" ]; then
             echo "Generated RPM: $RPM_FILE"
+            # For liquibase-secure, ensure the RPM has the correct name format
+            EXPECTED_RPM="${{ env.PACKAGE_NAME }}-${{ inputs.version }}-1.noarch.rpm"
+            if [ "$RPM_FILE" != "$EXPECTED_RPM" ]; then
+              echo "Renaming $RPM_FILE to $EXPECTED_RPM"
+              mv "$RPM_FILE" "$EXPECTED_RPM"
+              RPM_FILE="$EXPECTED_RPM"
+            fi
             echo "RPM_FILENAME=$RPM_FILE" >> $GITHUB_ENV
           else
             echo "Error: No RPM file found after conversion"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -147,12 +147,19 @@ jobs:
       - name: Get Reusable Files
         run: |
           # Under the src folder is where specific packages files live. The GitHub action inputs will modify the universal package-deb-pom.xml to tell the process which assets to use during the packaging step
+          # Determine the correct source directory based on distribution
+          if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
+            SRC_DIR="liquibase-secure"
+          else
+            SRC_DIR="${{ inputs.artifactId }}"
+          fi
+          
           mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/deb/control
           mkdir -p $PWD/.github/src/${{ inputs.artifactId }}/main/archive
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/control
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postinst
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/deb/control/postrm
-          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/control https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/control
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postinst https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postinst
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/deb/control/postrm https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/deb/control/postrm
+          curl -o $PWD/.github/src/${{ inputs.artifactId }}/main/archive/${{ inputs.artifactId }}-env.sh https://raw.githubusercontent.com/liquibase/build-logic/main/src/${SRC_DIR}/main/archive/${SRC_DIR}-env.sh
 
           # Download appropriate pom.xml based on distribution
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -383,118 +383,118 @@ jobs:
           # Echo it immediately to see the value in logs
           echo "PR_EXISTS is set to $PR_EXISTS"
 
-      - name: Update Homebrew formula for ${{ inputs.distribution }}
-        if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
-        uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-name: ${{ inputs.distribution }}
-          formula-path: Formula/l/${{ inputs.distribution }}.rb
-          homebrew-tap: Homebrew/homebrew-core
-          tag-name: ${{ inputs.version }}
-          download-url: ${{ inputs.distribution == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
-          commit-message: |
-            {{formulaName}} {{version}}
+      # - name: Update Homebrew formula for ${{ inputs.distribution }}
+      #   if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+      #   uses: mislav/bump-homebrew-formula-action@v3
+      #   with:
+      #     formula-name: ${{ inputs.distribution }}
+      #     formula-path: Formula/l/${{ inputs.distribution }}.rb
+      #     homebrew-tap: Homebrew/homebrew-core
+      #     tag-name: ${{ inputs.version }}
+      #     download-url: ${{ inputs.distribution == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/v{1}/{2}-{1}.tar.gz', inputs.download_base_url, inputs.version, inputs.artifactId) }}
+      #     commit-message: |
+      #       {{formulaName}} {{version}}
 
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+      #       Created by https://github.com/mislav/bump-homebrew-formula-action
+      #   env:
+      #     COMMITTER_TOKEN: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
       # This step captures the PR details after it has been created
       # and stores the PR number and URL in GitHub outputs for later use.
       # This is useful for tracking the PR status and creating a tracking issue.
-      - name: Capture Homebrew PR Details
-        if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
-        id: capture-pr
-        run: |
-          # Wait briefly for PR to be created
-          sleep 30
+      # - name: Capture Homebrew PR Details
+      #   if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+      #   id: capture-pr
+      #   run: |
+      #     # Wait briefly for PR to be created
+      #     sleep 30
           
-          # Search for the PR
-          PR_DATA=$(gh api graphql -f query='
-          query($search_query: String!) {
-            search(query: $search_query, type: ISSUE, first: 1) { 
-              nodes {               
-                ... on PullRequest {
-                  url,
-                  number
-                }
-              }
-            }
-          }' -f search_query="is:pr is:open repo:Homebrew/homebrew-core liquibase ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
+      #     # Search for the PR
+      #     PR_DATA=$(gh api graphql -f query='
+      #     query($search_query: String!) {
+      #       search(query: $search_query, type: ISSUE, first: 1) { 
+      #         nodes {               
+      #           ... on PullRequest {
+      #             url,
+      #             number
+      #           }
+      #         }
+      #       }
+      #     }' -f search_query="is:pr is:open repo:Homebrew/homebrew-core liquibase ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
           
-          if [ ! -z "$PR_DATA" ]; then
-            echo "HOMEBREW_PR_URL=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT
-            echo "HOMEBREW_PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')" >> $GITHUB_OUTPUT
-            echo "Found Homebrew PR #$(echo "$PR_DATA" | jq -r '.url')"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     if [ ! -z "$PR_DATA" ]; then
+      #       echo "HOMEBREW_PR_URL=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT
+      #       echo "HOMEBREW_PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')" >> $GITHUB_OUTPUT
+      #       echo "Found Homebrew PR #$(echo "$PR_DATA" | jq -r '.url')"
+      #     fi
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             
-      - name: Update SDKMAN version for ${{ inputs.artifactId }}
-        if: ${{ inputs.dry_run == false }}
-        env:
-          SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
-          SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://repo.liquibase.com/sdkman
-          S3_BUCKET: s3://repo.liquibase.com/sdkman/
-        run: |
-          wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
-          mkdir -p liquibase-$VERSION/bin/internal
-          unzip liquibase-$VERSION.zip -d liquibase-$VERSION
-          rm -rf liquibase-$VERSION.zip
-          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
-          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
-          # Upload the release to S3
-          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
-          echo "Uploaded liquibase-$VERSION.zip to s3"
-          # Send the release to SDKMAN
-          curl -s -X POST \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
-          https://vendors.sdkman.io/release
-          echo "Sent liquibase-$VERSION.zip to SDKMAN"
-          # Set the default version for SDKMAN
-          curl -s -X PUT \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
-          https://vendors.sdkman.io/default
-          echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
-          # Announce the release to SDKMAN
-          curl -s -X POST \
-          -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
-          -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
-          https://vendors.sdkman.io/announce/struct
-          echo "Announced liquibase-$VERSION.zip to SDKMAN"
+      # - name: Update SDKMAN version for ${{ inputs.artifactId }}
+      #   if: ${{ inputs.dry_run == false }}
+      #   env:
+      #     SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
+      #     SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
+      #     VERSION: ${{ inputs.version }}
+      #     S3_WEB_URL: https://repo.liquibase.com/sdkman
+      #     S3_BUCKET: s3://repo.liquibase.com/sdkman/
+      #   run: |
+      #     wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
+      #     mkdir -p liquibase-$VERSION/bin/internal
+      #     unzip liquibase-$VERSION.zip -d liquibase-$VERSION
+      #     rm -rf liquibase-$VERSION.zip
+      #     mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+      #     mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
+      #     zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
+      #     # Upload the release to S3
+      #     aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
+      #     echo "Uploaded liquibase-$VERSION.zip to s3"
+      #     # Send the release to SDKMAN
+      #     curl -s -X POST \
+      #     -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+      #     -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+      #     -H "Content-Type: application/json" \
+      #     -H "Accept: application/json" \
+      #     -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
+      #     https://vendors.sdkman.io/release
+      #     echo "Sent liquibase-$VERSION.zip to SDKMAN"
+      #     # Set the default version for SDKMAN
+      #     curl -s -X PUT \
+      #     -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+      #     -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+      #     -H "Content-Type: application/json" \
+      #     -H "Accept: application/json" \
+      #     -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
+      #     https://vendors.sdkman.io/default
+      #     echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
+      #     # Announce the release to SDKMAN
+      #     curl -s -X POST \
+      #     -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
+      #     -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
+      #     -H "Content-Type: application/json" \
+      #     -H "Accept: application/json" \
+      #     -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
+      #     https://vendors.sdkman.io/announce/struct
+      #     echo "Announced liquibase-$VERSION.zip to SDKMAN"
 
-      - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
-        if: ${{ inputs.dry_run == true }}
-        env:
-          SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
-          SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
-          S3_BUCKET: s3://repo.liquibase.com.dry.run/sdkman/
-        run: |
-          mkdir -p liquibase-$VERSION/bin/internal
-          unzip .github/target/liquibase-$VERSION.zip -d liquibase-$VERSION
-          rm -rf liquibase-$VERSION.zip
-          mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
-          mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
-          # Upload the release to S3
-          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
-          echo "Uploaded liquibase-$VERSION.zip to s3"
+      # - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
+      #   if: ${{ inputs.dry_run == true }}
+      #   env:
+      #     SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
+      #     SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
+      #     VERSION: ${{ inputs.version }}
+      #     S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
+      #     S3_BUCKET: s3://repo.liquibase.com.dry.run/sdkman/
+      #   run: |
+      #     mkdir -p liquibase-$VERSION/bin/internal
+      #     unzip .github/target/liquibase-$VERSION.zip -d liquibase-$VERSION
+      #     rm -rf liquibase-$VERSION.zip
+      #     mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
+      #     mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
+      #     zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
+      #     # Upload the release to S3
+      #     aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
+      #     echo "Uploaded liquibase-$VERSION.zip to s3"
           
   # create a placeholder branch to check if tracking branch exists for this version
   # Branch is created when package is submitted to Homebrew and SDKMAN
@@ -560,13 +560,13 @@ jobs:
             echo "Homebrew tracking branch already exists or PR number not available, skipping creation"
           fi
 
-  upload_windows_package:
-    uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
-    secrets: inherit
-    with:
-      version: ${{ inputs.version }}
-      dry_run: ${{ inputs.dry_run }}
-      dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
+  # upload_windows_package:
+  #   uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
+  #   secrets: inherit
+  #   with:
+  #     version: ${{ inputs.version }}
+  #     dry_run: ${{ inputs.dry_run }}
+  #     dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
 
   upload_ansible_role:
     uses: liquibase/liquibase-ansible/.github/workflows/deploy-role.yml@main

--- a/src/liquibase-secure/main/archive/liquibase-secure-env.sh
+++ b/src/liquibase-secure/main/archive/liquibase-secure-env.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
-# Liquibase Secure environment configuration
+#!/bin/sh
+
+# Needed when restarting the terminal
 export LIQUIBASE_HOME=/opt/liquibase
 export PATH=$PATH:$LIQUIBASE_HOME
+exec $SHELL

--- a/src/liquibase-secure/main/archive/liquibase-secure-env.sh
+++ b/src/liquibase-secure/main/archive/liquibase-secure-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Liquibase Secure environment configuration
+export LIQUIBASE_HOME=/opt/liquibase
+export PATH=$PATH:$LIQUIBASE_HOME

--- a/src/liquibase/main/archive/liquibase-env.sh
+++ b/src/liquibase/main/archive/liquibase-env.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
-# Liquibase environment configuration
+#!/bin/sh
+
+# Needed when restarting the terminal
 export LIQUIBASE_HOME=/opt/liquibase
 export PATH=$PATH:$LIQUIBASE_HOME
+exec $SHELL

--- a/src/liquibase/main/archive/liquibase-env.sh
+++ b/src/liquibase/main/archive/liquibase-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Liquibase environment configuration
+export LIQUIBASE_HOME=/opt/liquibase
+export PATH=$PATH:$LIQUIBASE_HOME


### PR DESCRIPTION
This pull request makes several improvements and refactors to the packaging workflow in `.github/workflows/package.yml`, focusing on better handling for the `liquibase-secure` distribution, more robust RPM packaging, and disabling some external publishing steps. It also updates the Ansible role workflow reference and adds a new environment script for `liquibase-secure`.

**Packaging workflow improvements:**

* Added logic to dynamically set the source directory and package name based on the distribution (community or `liquibase-secure`), and consistently use the correct package name throughout all packaging steps. (`.github/workflows/package.yml`) [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L150-R167) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L219-R231) [[3]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L248-R260) [[4]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L277-R289) [[5]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L286-R320)
* Improved RPM packaging by detecting the generated RPM filename, renaming it if necessary for `liquibase-secure`, and passing the correct filename to subsequent steps and uploads. (`.github/workflows/package.yml`) [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L286-R320) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L318-R360) [[3]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L356-R389)

**Distribution-specific handling:**

* Ensured correct asset download and naming for `liquibase-secure` tarballs during packaging. (`.github/workflows/package.yml`)
* Added a new environment setup script for `liquibase-secure` (`src/liquibase-secure/main/archive/liquibase-secure-env.sh`).

**Workflow refactoring and external publishing:**

* Commented out steps for updating Homebrew formulas and SDKMAN releases, as well as the Windows package upload workflow, disabling these external publishing integrations for now. (`.github/workflows/package.yml`) [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L386-R530) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L563-R616)
* Updated the Ansible role workflow reference to use the `DAT-20702` branch and added the `distribution` input. (`.github/workflows/package.yml`)

**Miscellaneous:**

* Added a step to configure Git with the `liquibot` user for automated commits. (`.github/workflows/package.yml`)