### PR TITLE
Remove Java 8/11; update workflows for Java 21

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ on:
       javaBuildVersion:
         description: "Java version to build the project"
         required: false
-        default: "17"
+        default: "21"
         type: string
 
 permissions:

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -62,7 +62,7 @@ on:
       javaBuildVersion:
         description: "Java version to build the project"
         required: false
-        default: "17"
+        default: "21"
         type: string
 
 jobs:

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -16,7 +16,7 @@ on:
       javaBuildVersion:
         description: "Java version to use when building the extension"
         required: false
-        default: "17"
+        default: "21"
         type: string
 
 permissions:

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -21,7 +21,7 @@ on:
       javaBuildVersion:
         description: "Java version to use when building the extension"
         required: false
-        default: "17"
+        default: "21"
         type: string
       deployToMavenCentral:
         description: "Specify it if you want to deploy to maven"

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
           

--- a/.github/workflows/lth-docker.yml
+++ b/.github/workflows/lth-docker.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Start database container # Start the database container using Docker Compose
         run: docker compose -f src/test/resources/docker/docker-compose.yml up -d
 
-      - name: Setup Temurin Java 17 # Set up Java 17 with Temurin distribution and cache the Maven packages
+      - name: Setup Temurin Java 21 # Set up Java 21 with Temurin distribution and cache the Maven packages
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: 'maven'
 

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -6,12 +6,12 @@ on:
       java:
         description: "Java version to test"
         required: false
-        default: "[11, 17, 21]"
+        default: "[17, 21]"
         type: string
       javaBuildVersion:
         description: "Java version to build the project"
         required: false
-        default: "17"
+        default: "21"
         type: string
       os:
         description: "Operating system to test"
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ${{fromJson(inputs.java || '[11, 17, 21]')}}
+        java: ${{fromJson(inputs.java || '[17, 21]')}}
         os: ${{fromJson(inputs.os || '["ubuntu-latest", "windows-latest"]')}}
     name: Test Java ${{ matrix.java }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/owasp-scanner.yml
+++ b/.github/workflows/owasp-scanner.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Java for publishing to GitHub Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/pom-release-published.yml
+++ b/.github/workflows/pom-release-published.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
           cache: "maven"
           server-id: sonatype-nexus-staging

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -6,7 +6,7 @@ on:
       java:
         description: "Java version to test"
         required: false
-        default: "[11, 17, 21]"
+        default: "[17, 21]"
         type: string
       os:
         description: "Operating system to build/test on"
@@ -118,10 +118,10 @@ jobs:
           role-to-assume: ${{ env.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
           aws-region: us-east-1
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
           cache: "maven"
 
@@ -368,4 +368,3 @@ jobs:
               "artifact_id": "${{needs.build.outputs.artifact_id}}",
               "artifact_version": "${{ inputs.version }}"
             }
-            

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -6,7 +6,7 @@ on:
       java:
         description: "Java version to test"
         required: false
-        default: "[11, 17, 21]"
+        default: "[17, 21]"
         type: string
       os:
         description: "Operating system to build/test on"
@@ -121,10 +121,10 @@ jobs:
           role-to-assume: ${{ env.AWS_GITHUB_OIDC_ROLE_ARN_S3_GHA }}
           aws-region: us-east-1
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
           cache: "maven"
 
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ${{fromJson(inputs.java || '[8, 11, 17, 18]')}}
+        java: ${{fromJson(inputs.java || '[17, 21]')}}
         os: ${{fromJson(inputs.os-test || '["ubuntu-latest", "windows-latest"]')}}
     name: Test Java ${{ matrix.java }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -92,10 +92,10 @@ jobs:
         run: |
           ls -l ./artifacts
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
           cache: "maven"
 

--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -16,7 +16,7 @@ on:
       javaBuildVersion:
         description: "Java version to build the project"
         required: false
-        default: "17"
+        default: "21"
         type: string
         
 permissions:

--- a/.github/workflows/sonar-push.yml
+++ b/.github/workflows/sonar-push.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
           cache: "maven"
 
@@ -77,7 +77,7 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: test.yml
-          name: test-reports-jdk-17-ubuntu-latest
+          name: test-reports-jdk-21-ubuntu-latest
           repo: ${{ github.repository }}
           if_no_artifact_found: warn
           workflow_conclusion: ""

--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Set up JDK for Build
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
           overwrite-settings: false
@@ -301,7 +301,7 @@ jobs:
       - name: Set up JDK for Sonar
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
           overwrite-settings: false


### PR DESCRIPTION
This pull request removes support for Java 8 and 11, and updates the GitHub workflows to use Java 21. These changes align the project with newer versions of Java, ensuring compatibility and leveraging modern features.