### PR TITLE
DAT-20707   DevOps :: Implement Scarf.sh tracking for all Liquibase package distributions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -469,46 +469,55 @@ jobs:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://repo.liquibase.com/sdkman
+          WEB_URL: https://package.liquibase.com/downloads/sdkman/
           S3_BUCKET: s3://repo.liquibase.com/sdkman/
         run: |
-          wget -q https://github.com/liquibase/liquibase/releases/download/v$VERSION/liquibase-$VERSION.zip
+          # Download the appropriate zip file based on distribution
+          if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
+            wget -q -O liquibase-secure-$VERSION.zip ${{ inputs.download_base_url }}/$VERSION/liquibase-secure-$VERSION.zip
+            ZIP_FILENAME="liquibase-secure-$VERSION.zip"
+            SDKMAN_CANDIDATE="liquibase-secure"
+          else
+            wget -q -O liquibase-$VERSION.zip ${{ inputs.download_base_url }}/v$VERSION/liquibase-$VERSION.zip
+            ZIP_FILENAME="liquibase-$VERSION.zip"
+            SDKMAN_CANDIDATE="liquibase"
+          fi
           mkdir -p liquibase-$VERSION/bin/internal
-          unzip liquibase-$VERSION.zip -d liquibase-$VERSION
-          rm -rf liquibase-$VERSION.zip
+          unzip $ZIP_FILENAME -d liquibase-$VERSION
+          rm -rf $ZIP_FILENAME
           mv ./liquibase-$VERSION/liquibase ./liquibase-$VERSION/bin/
           mv ./liquibase-$VERSION/liquibase.bat ./liquibase-$VERSION/bin/
-          zip -r liquibase-$VERSION.zip ./liquibase-$VERSION
+          zip -r $ZIP_FILENAME ./liquibase-$VERSION
           # Upload the release to S3
-          aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
-          echo "Uploaded liquibase-$VERSION.zip to s3"
+          aws s3 cp $ZIP_FILENAME $S3_BUCKET
+          echo "Uploaded $ZIP_FILENAME to s3"
           # Send the release to SDKMAN
           curl -s -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "'"$S3_WEB_URL"'/liquibase-'"$VERSION"'.zip"}' \
+          -d '{"candidate": "'"$SDKMAN_CANDIDATE"'", "version": "'"$VERSION"'", "url": "'"$WEB_URL"'/'"$ZIP_FILENAME"'"}' \
           https://vendors.sdkman.io/release
-          echo "Sent liquibase-$VERSION.zip to SDKMAN"
+          echo "Sent $ZIP_FILENAME to SDKMAN"
           # Set the default version for SDKMAN
           curl -s -X PUT \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'"}' \
+          -d '{"candidate": "'"$SDKMAN_CANDIDATE"'", "version": "'"$VERSION"'"}' \
           https://vendors.sdkman.io/default
-          echo "Set liquibase-$VERSION.zip as default version for SDKMAN"
+          echo "Set $ZIP_FILENAME as default version for SDKMAN"
           # Announce the release to SDKMAN
           curl -s -X POST \
           -H "Consumer-Key: $SDKMAN_CONSUMER_KEY" \
           -H "Consumer-Token: $SDKMAN_CONSUMER_TOKEN" \
           -H "Content-Type: application/json" \
           -H "Accept: application/json" \
-          -d '{"candidate": "liquibase", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
+          -d '{"candidate": "'"$SDKMAN_CANDIDATE"'", "version": "'"$VERSION"'", "url": "https://github.com/liquibase/liquibase/releases/tag/v'"$VERSION"'"}' \
           https://vendors.sdkman.io/announce/struct
-          echo "Announced liquibase-$VERSION.zip to SDKMAN"
+          echo "Announced $ZIP_FILENAME to SDKMAN"
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
         if: ${{ inputs.dry_run == true }}
@@ -516,7 +525,7 @@ jobs:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          S3_WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
+          WEB_URL: https://s3.amazonaws.com/repo.liquibase.com.dry.run/sdkman
           S3_BUCKET: s3://repo.liquibase.com.dry.run/sdkman/
         run: |
           mkdir -p liquibase-$VERSION/bin/internal
@@ -599,6 +608,7 @@ jobs:
           fi
 
   upload_windows_package:
+    if: ${{ inputs.distribution == 'liquibase' }}
     uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
     secrets: inherit
     with:
@@ -607,6 +617,7 @@ jobs:
       dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
 
   upload_windows_secure_package:
+    if: ${{ inputs.distribution == 'liquibase-secure' }}
     uses: liquibase/liquibase-secure-chocolatey/.github/workflows/deploy-package.yml@master
     secrets: inherit
     with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -469,8 +469,8 @@ jobs:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          WEB_URL: https://package.liquibase.com/downloads/sdkman/
-          S3_BUCKET: s3://repo.liquibase.com/sdkman/
+          WEB_URL: ${{ inputs.distribution == 'liquibase-secure' && 'https://package.liquibase.com/downloads/sdkman/secure/' || 'https://package.liquibase.com/downloads/sdkman/oss/' }}
+          S3_BUCKET: ${{ inputs.distribution == 'liquibase-secure' && 's3://repo.liquibase.com/sdkman/secure/' || 's3://repo.liquibase.com/sdkman/oss/' }}
         run: |
           # Download the appropriate zip file based on distribution
           if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then


### PR DESCRIPTION
This pull request updates the `.github/workflows/package.yml` workflow to support both standard and secure Liquibase distributions, improving flexibility and correctness when packaging and releasing artifacts. The changes ensure that the correct distribution is handled throughout the workflow, including download, packaging, uploading, and SDKMAN release steps.

Distribution-specific packaging and release logic:

* The workflow now conditionally downloads and processes either the standard or secure Liquibase zip file based on the `distribution` input, updating filenames and candidate names dynamically. (`.github/workflows/package.yml`)
* All SDKMAN release steps now use the correct candidate name and artifact filename, ensuring accurate metadata for each distribution. (`.github/workflows/package.yml`)

Windows package deployment improvements:

* The `upload_windows_package` job is now only triggered for the standard distribution (`liquibase`). (`.github/workflows/package.yml`)
* The `upload_windows_secure_package` job is now only triggered for the secure distribution (`liquibase-secure`). (`.github/workflows/package.yml`)