### PR TITLE
fix: add continue-on-error flag to various upload steps in package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -243,6 +243,7 @@ jobs:
 
       - name: Upload ${{ inputs.artifactId }} deb package
         if: ${{ inputs.dry_run == false }}
+        continue-on-error: true
         run: |
           # Debug: List available GPG keys
           echo "Available GPG keys:"
@@ -272,6 +273,7 @@ jobs:
 
       - name: Upload ${{ inputs.artifactId }} dry-run deb package
         if: ${{ inputs.dry_run == true }}
+        continue-on-error: true
         run: |
           # Debug: List available GPG keys
           echo "Available GPG keys:"
@@ -292,6 +294,7 @@ jobs:
           rm -f "$TEMP_PASSPHRASE_FILE"
 
       - name: Convert deb to rpm
+        continue-on-error: true
         run: |
           sudo apt-get update
           sudo apt-get install -y alien
@@ -315,6 +318,7 @@ jobs:
 
       - name: Upload ${{ inputs.artifactId }} rpm package
         if: ${{ inputs.dry_run == false }}
+        continue-on-error: true
         run: |
           sudo apt-get install -y libcurl4-openssl-dev libbz2-dev libxml2-dev libssl-dev zlib1g-dev pkg-config libglib2.0-dev liblzma-dev libsqlite0-dev libsqlite3-dev librpm-dev libzstd-dev python3 cmake
           ./.github/sign_artifact.sh "${{ env.RPM_FILENAME }}"
@@ -353,6 +357,7 @@ jobs:
 
       - name: Upload ${{ inputs.artifactId }} dry-run rpm package
         if: ${{ inputs.dry_run == true }}
+        continue-on-error: true
         run: |
           # Use the RPM filename from the previous step
           echo "Using RPM file: ${{ env.RPM_FILENAME }}"
@@ -392,6 +397,7 @@ jobs:
           aws s3 sync $PWD/yum s3://repo.liquibase.com.dry.run/yum
 
       - name: Check for existing Homebrew formula PR for ${{ inputs.distribution }}
+        continue-on-error: true  
         id: check-brew-pr
         run: |
           # Authenticate GitHub CLI
@@ -418,6 +424,7 @@ jobs:
 
       - name: Update Homebrew formula for ${{ inputs.distribution }}
         if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+        continue-on-error: true
         uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: ${{ inputs.distribution }}
@@ -436,6 +443,7 @@ jobs:
       # and stores the PR number and URL in GitHub outputs for later use.
       # This is useful for tracking the PR status and creating a tracking issue.
       - name: Capture Homebrew PR Details
+        continue-on-error: true
         if: ${{ steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         id: capture-pr
         run: |
@@ -465,6 +473,7 @@ jobs:
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
         if: ${{ inputs.dry_run == false }}
+        continue-on-error: true
         env:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
@@ -521,6 +530,7 @@ jobs:
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
         if: ${{ inputs.dry_run == true }}
+        continue-on-error: true
         env:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
@@ -609,6 +619,7 @@ jobs:
 
   upload_windows_package:
     if: ${{ inputs.distribution == 'liquibase' }}
+    continue-on-error: true
     uses: liquibase/liquibase-chocolatey/.github/workflows/deploy-package.yml@master
     secrets: inherit
     with:
@@ -618,6 +629,7 @@ jobs:
 
   upload_windows_secure_package:
     if: ${{ inputs.distribution == 'liquibase-secure' }}
+    continue-on-error: true
     uses: liquibase/liquibase-secure-chocolatey/.github/workflows/deploy-package.yml@master
     secrets: inherit
     with:
@@ -626,6 +638,7 @@ jobs:
       dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
 
   upload_ansible_role:
+    continue-on-error: true
     uses: liquibase/liquibase-ansible/.github/workflows/deploy-role.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
This pull request updates the `.github/workflows/package.yml` workflow to make the packaging and deployment steps more resilient to errors. The main change is the addition of `continue-on-error: true` to many workflow steps, ensuring that failures in individual steps do not halt the entire workflow. This is particularly useful for multi-platform packaging and deployment jobs where non-critical failures may occur.

The most important changes are:

**Packaging and Artifact Upload Steps:**
* Added `continue-on-error: true` to all deb and rpm package upload steps, both for standard and dry-run workflows, as well as the conversion from deb to rpm. This ensures the workflow continues even if an upload or conversion fails. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R246) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R276) [[3]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R297) [[4]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R321) [[5]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R360)

**Homebrew Formula Update Steps:**
* Added `continue-on-error: true` to the Homebrew PR check, formula update, and PR details capture steps, making the workflow tolerant to errors in updating or checking Homebrew formulas. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R400) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R427) [[3]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R446)

**SDKMAN Version Update Steps:**
* Added `continue-on-error: true` to both standard and dry-run SDKMAN update steps, allowing the workflow to proceed even if SDKMAN updates fail. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R476) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R533)

**Windows Package Deployment Jobs:**
* Added `continue-on-error: true` to the Windows package and secure package upload jobs, improving robustness for Chocolatey deployments. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R622) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R632)

**Ansible Role Deployment Job:**
* Added `continue-on-error: true` to the Ansible role upload job, allowing the workflow to continue if the role deployment fails.