### PR TITLE
feat: add version gating for Homebrew package publishing (DAT-20985)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -419,7 +419,7 @@ jobs:
           aws s3 sync $PWD/yum s3://repo.liquibase.com.dry.run/yum
 
       - name: Check for existing Homebrew formula PR for ${{ inputs.distribution }}
-        if: ${{ inputs.distribution != 'liquibase-secure' }}
+        if: ${{ inputs.distribution != 'liquibase-secure' && startsWith(inputs.version, '4.') }}
         continue-on-error: true
         id: check-brew-pr
         run: |
@@ -446,7 +446,7 @@ jobs:
           echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew formula for ${{ inputs.distribution }}
-        if: ${{ inputs.distribution != 'liquibase-secure' && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+        if: ${{ inputs.distribution != 'liquibase-secure' && startsWith(inputs.version, '4.') && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         continue-on-error: true
         uses: mislav/bump-homebrew-formula-action@v3
         with:
@@ -467,7 +467,7 @@ jobs:
       # This is useful for tracking the PR status and creating a tracking issue.
       - name: Capture Homebrew PR Details
         continue-on-error: true
-        if: ${{ inputs.distribution != 'liquibase-secure' && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+        if: ${{ inputs.distribution != 'liquibase-secure' && startsWith(inputs.version, '4.') && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         id: capture-pr
         run: |
           # Wait briefly for PR to be created
@@ -656,14 +656,15 @@ jobs:
           fi
 
           # Create Homebrew tracking branch if it doesn't exist and PR number is available
-          if [[ -n "${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}" ]] && ! git ls-remote --exit-code --heads origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}; then
+          # Only create for 4.x versions due to Homebrew licensing restrictions
+          if [[ "${{ inputs.version }}" == 4.* ]] && [[ -n "${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}" ]] && ! git ls-remote --exit-code --heads origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}; then
             git checkout -b ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}
             echo "This is a placeholder branch for oss homebrew package v.${{ inputs.version }}. If this branch is open, it means the homebrew package is not yet approved" > README.md
             git add README.md
             git commit -m "Create placeholder branch for Homebrew package v.${{ inputs.version }}"
             git push origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}
           else
-            echo "Homebrew tracking branch already exists or PR number not available, skipping creation"
+            echo "Homebrew tracking branch skipped (only 4.x versions supported) or already exists or PR number not available"
           fi
 
   upload_windows_package:


### PR DESCRIPTION
## Summary
Restricts Homebrew package publishing to 4.x versions only due to licensing incompatibility with Liquibase 5.x FSL license.

## Problem
Homebrew only accepts open-source licensed software in their community repository. Liquibase 5.x uses the Functional Source License (FSL), which is incompatible with Homebrew's requirements. Without version gating, 5.x releases will create failed/rejected PRs to Homebrew/homebrew-core.

## Solution
Added `startsWith(inputs.version, '4.')` version checks to prevent Homebrew publishing for 5.x+ versions:

### Changes to `.github/workflows/package.yml`:
1. **Line 422** - "Check for existing Homebrew formula PR" step
2. **Line 449** - "Update Homebrew formula" step  
3. **Line 470** - "Capture Homebrew PR Details" step
4. **Line 660** - Homebrew tracking branch creation logic

## Impact
- ✅ Prevents failed Homebrew PRs for 5.x+ releases
- ✅ 4.x versions continue to publish to Homebrew normally
- ✅ Other package managers (deb, rpm, SDKMAN, Chocolatey, Ansible) are **unaffected**
- ✅ No breaking changes to existing workflows

## Testing
- Verified workflow syntax
- Reviewed all conditional logic for consistency
- Confirmed version check pattern matches expected format

## Related
- Jira: [DAT-20985](https://datical.atlassian.net/browse/DAT-20985)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

[DAT-20985]: https://datical.atlassian.net/browse/DAT-20985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ