### PR TITLE
fix: correct bash pattern matching syntax for version check

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -657,7 +657,7 @@ jobs:
 
           # Create Homebrew tracking branch if it doesn't exist and PR number is available
           # Only create for 4.x versions due to Homebrew licensing restrictions
-          if [[ "${{ inputs.version }}" == 4.* ]] && [[ -n "${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}" ]] && ! git ls-remote --exit-code --heads origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}; then
+          if [[ "${{ inputs.version }}" =~ ^4\. ]] && [[ -n "${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}" ]] && ! git ls-remote --exit-code --heads origin ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}; then
             git checkout -b ci-oss-homebrew-package-check-${{ needs.upload_packages.outputs.HOMEBREW_PR_NUMBER }}
             echo "This is a placeholder branch for oss homebrew package v.${{ inputs.version }}. If this branch is open, it means the homebrew package is not yet approved" > README.md
             git add README.md


### PR DESCRIPTION
## Summary
Fixes incorrect bash pattern matching syntax in Homebrew version gate introduced in PR #405.

## Problem
Line 660 used incorrect glob pattern syntax:
```bash
if [[ "${{ inputs.version }}" == 4.* ]]
```

This syntax is unreliable because:
- The `==` operator with glob patterns requires specific quoting
- It's inconsistent with the other 3 locations using `startsWith(inputs.version, '4.')`
- May not work reliably across all bash versions

## Solution
Changed to proper regex matching:
```bash
if [[ "${{ inputs.version }}" =~ ^4\. ]]
```

This is better because:
- `=~` is the correct regex matching operator in bash
- `^4\.` explicitly matches "starts with 4." (the `\.` escapes the literal dot)
- More reliable and explicit
- Consistent with standard bash practices

## Credit
This fix addresses a valid concern raised by GitHub Copilot in review comment https://github.com/liquibase/build-logic/pull/405#discussion_r2402892270

## Testing
- Verified workflow syntax
- Confirmed regex pattern matches expected versions (4.0, 4.1, 4.23.0, etc.)
- Confirmed it rejects non-4.x versions (5.0, 3.9, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>