### PR TITLE
fix: update SDKMAN version handling for community edition only

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -495,27 +495,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }}
-        if: ${{ inputs.distribution != 'liquibase-secure' && inputs.dry_run == false }}
+        if: ${{ inputs.distribution == 'liquibase' && inputs.dry_run == false }}
         continue-on-error: true
         env:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}
           SDKMAN_CONSUMER_TOKEN: ${{ env.SDKMAN_CONSUMER_TOKEN }}
           VERSION: ${{ inputs.version }}
-          WEB_URL: ${{ inputs.distribution == 'liquibase-secure' && 'https://package.liquibase.com/downloads/secure/sdkman/' || 'https://package.liquibase.com/downloads/oss/sdkman/' }}
-          S3_BUCKET: ${{ inputs.distribution == 'liquibase-secure' && 's3://repo.liquibase.com/sdkman/secure/' || 's3://repo.liquibase.com/sdkman/oss/' }}
+          WEB_URL: https://package.liquibase.com/downloads/oss/sdkman/
+          S3_BUCKET: s3://repo.liquibase.com/sdkman/oss/
         run: |
           set -e  # Exit on any error
 
-          # Download the appropriate zip file based on distribution
-          if [ "${{ inputs.distribution }}" = "liquibase-secure" ]; then
-            wget -q -O liquibase-secure-$VERSION.zip ${{ inputs.download_base_url }}/$VERSION/liquibase-secure-$VERSION.zip
-            ZIP_FILENAME="liquibase-secure-$VERSION.zip"
-            SDKMAN_CANDIDATE="liquibase-secure"
-          else
-            wget -q -O liquibase-$VERSION.zip ${{ inputs.download_base_url }}/v$VERSION/liquibase-$VERSION.zip
-            ZIP_FILENAME="liquibase-$VERSION.zip"
-            SDKMAN_CANDIDATE="liquibase"
-          fi
+          # Download the zip file for liquibase (community edition only)
+          wget -q -O liquibase-$VERSION.zip ${{ inputs.download_base_url }}/v$VERSION/liquibase-$VERSION.zip
+          ZIP_FILENAME="liquibase-$VERSION.zip"
+          SDKMAN_CANDIDATE="liquibase"
           mkdir -p liquibase-$VERSION/bin/internal
           unzip $ZIP_FILENAME -d liquibase-$VERSION
           rm -rf $ZIP_FILENAME
@@ -578,7 +572,7 @@ jobs:
           echo "Announced $ZIP_FILENAME to SDKMAN"
 
       - name: Update SDKMAN version for ${{ inputs.artifactId }} dry-run
-        if: ${{ inputs.distribution != 'liquibase-secure' && inputs.dry_run == true }}
+        if: ${{ inputs.distribution == 'liquibase' && inputs.dry_run == true }}
         continue-on-error: true
         env:
           SDKMAN_CONSUMER_KEY: ${{ env.SDKMAN_CONSUMER_KEY }}


### PR DESCRIPTION
This pull request updates the SDKMAN deployment step in the GitHub Actions workflow to only support the open-source `liquibase` distribution, removing support for the `liquibase-secure` distribution. The changes simplify the workflow logic and ensure that SDKMAN updates and dry-runs are performed exclusively for the community edition.

**SDKMAN Deployment Logic Update:**

* The SDKMAN update step now runs only when `inputs.distribution` is exactly `'liquibase'`, instead of any value except `'liquibase-secure'`. This change is applied to both the main update and dry-run steps. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L498-L518) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L581-R575)
* Environment variables `WEB_URL` and `S3_BUCKET` are now hardcoded to the open-source (oss) endpoints, removing conditional logic for the secure distribution.
* The download and extraction logic is simplified to handle only the `liquibase` (community edition) zip file, removing all references and handling for `liquibase-secure`.