### PR TITLE
DAT-20707  Update ansible calls

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -948,10 +948,19 @@ jobs:
   #    dry_run_zip_url: ${{ inputs.dry_run_zip_url }}
 
   upload_ansible_role:
+    if: ${{ inputs.distribution == 'liquibase' }}
     uses: liquibase/liquibase-ansible/.github/workflows/deploy-role.yml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}
       dry_run_release_id: ${{ inputs.dry_run_release_id }}
-      distribution: ${{ inputs.distribution }}
+
+  upload_secure_ansible_role:
+    if: ${{ inputs.distribution == 'liquibase-secure' }}
+    uses: liquibase/liquibase-secure-ansible/.github/workflows/deploy-role.yml@main
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+      dry_run_release_id: ${{ inputs.dry_run_release_id }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/package.yml` file to improve how Ansible roles are deployed based on the distribution type. The main change is the addition of a new workflow job for the `liquibase-secure` distribution, along with conditional logic to ensure the correct deployment workflow is triggered for each distribution.

Deployment workflow improvements:

* Added a new `upload_secure_ansible_role` job that runs only when the `distribution` input is set to `liquibase-secure`, using the `liquibase-secure-ansible` deployment workflow.
* Updated the existing `upload_ansible_role` job to run only when the `distribution` input is `liquibase`, ensuring the correct workflow is used for each distribution.