### PR TITLE
fix: update Homebrew cask handling for version checks and PR capture

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -762,15 +762,23 @@ jobs:
 
       ## HomeBrew CASKS: Versions >= 5.x use Homebrew Casks
       - name: Check for existing Homebrew cask PR for ${{ inputs.distribution }}
-        if: ${{ inputs.distribution != 'liquibase-secure' && !startsWith(inputs.version, '4.') }}
+        if: ${{ !startsWith(inputs.version, '4.') }}
         continue-on-error: true
-        id: check-brew-pr
+        id: check-brew-cask-pr
         run: |
           # Authenticate GitHub CLI
           gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
 
+          # Determine the cask name based on distribution
+          if [ "${{ inputs.distribution }}" = "liquibase" ]; then
+            CASK_NAME="liquibase-community"
+          else
+            CASK_NAME="${{ inputs.distribution }}"
+          fi
+          echo "CASK_NAME=$CASK_NAME" >> $GITHUB_OUTPUT
+
           # Define the PR title
-          pr_title="${{ inputs.distribution }} ${{ inputs.version }}"
+          pr_title="$CASK_NAME ${{ inputs.version }}"
 
           # Search for open pull requests with the specified title in the Homebrew/homebrew-cask repo
           pr_title=$(gh pr list --repo Homebrew/homebrew-cask --state open --search "$pr_title" --json title --jq ".[] | select(.title == \"$pr_title\") | .title" )
@@ -789,13 +797,13 @@ jobs:
           echo "PR_EXISTS is set to $PR_EXISTS"
 
       - name: Update Homebrew cask for ${{ inputs.distribution }}
-        if: ${{ inputs.distribution != 'liquibase-secure' && !startsWith(inputs.version, '4.') && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+        if: ${{ !startsWith(inputs.version, '4.') && steps.check-brew-cask-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
         continue-on-error: true
         uses: macauley/action-homebrew-bump-cask@v1
         with:
           token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
           tap: Homebrew/homebrew-cask
-          cask: ${{ inputs.distribution }}
+          cask: ${{ steps.check-brew-cask-pr.outputs.CASK_NAME }}
           tag: ${{ inputs.version }}
           livecheck: false
           dryrun: false
@@ -803,13 +811,16 @@ jobs:
       # This step captures the PR details after it has been created
       # and stores the PR number and URL in GitHub outputs for later use.
       # This is useful for tracking the PR status and creating a tracking issue.
-      - name: Capture Homebrew PR Details
+      - name: Capture Homebrew Cask PR Details
         continue-on-error: true
-        if: ${{ inputs.distribution != 'liquibase-secure' && !startsWith(inputs.version, '4.') && steps.check-brew-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
-        id: capture-pr
+        if: ${{ !startsWith(inputs.version, '4.') && steps.check-brew-cask-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
+        id: capture-cask-pr
         run: |
           # Wait briefly for PR to be created
           sleep 30
+
+          # Get the cask name
+          CASK_NAME="${{ steps.check-brew-cask-pr.outputs.CASK_NAME }}"
 
           # Search for the PR
           PR_DATA=$(gh api graphql -f query='
@@ -822,7 +833,7 @@ jobs:
                 }
               }
             }
-          }' -f search_query="is:pr is:open repo:Homebrew/homebrew-cask liquibase ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
+          }' -f search_query="is:pr is:open repo:Homebrew/homebrew-cask $CASK_NAME ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
 
           if [ ! -z "$PR_DATA" ]; then
             echo "HOMEBREW_PR_URL=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the Homebrew cask workflow logic in `.github/workflows/package.yml` to improve how cask names are handled and referenced throughout the workflow. The changes ensure that the correct cask name is used for PR checks, updates, and PR detail capturing, making the workflow more robust and adaptable to different distributions.

**Homebrew Cask Workflow Improvements**

* The cask name is now dynamically determined based on the distribution, defaulting to `liquibase-community` for the main distribution and using the distribution name otherwise. This cask name is stored as an output variable for use in subsequent steps.
* All steps that previously used the distribution name directly for PR checks, updates, and capturing PR details now use the dynamically determined cask name, ensuring consistency and correctness.
* The PR search query for capturing PR details now uses the correct cask name in the title search, improving the accuracy of PR tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized cask naming across the Homebrew workflow so cask names are derived consistently by distribution.
  * Generalized PR checks for casks to apply uniformly (with version gating still respected).
  * Updated PR title generation and PR lookup/searches to use the derived cask name.
  * Improved PR capture and downstream detection steps for more reliable cask automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->