### PR TITLE
INT-1557: fix: properly quote extra Maven arguments in build command

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -239,7 +239,7 @@ jobs:
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
         run: |
           if [ -n "${{ inputs.extraMavenArgs }}" ]; then
-            mvn -B dependency:go-offline clean package -DskipTests=true ${{ inputs.extraMavenArgs }}
+            mvn -B dependency:go-offline clean package -DskipTests=true "${{ inputs.extraMavenArgs }}"
           else
             mvn -B dependency:go-offline clean package -DskipTests=true
           fi


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for Maven builds. The change ensures that any extra Maven arguments provided are correctly passed as a single quoted string, which improves argument handling and prevents potential issues with arguments containing spaces or special characters.