### PR TITLE
DAT-21013 Dependabot automerge and Sonar are not working for parent-pom

### DIFF
--- a/.github/workflows/sonar-pull-request.yml
+++ b/.github/workflows/sonar-pull-request.yml
@@ -118,6 +118,7 @@ jobs:
 
       - name: Download unit tests report
         uses: actions/download-artifact@v6
+        continue-on-error: true
         with:
           name: test-reports-jdk-${{ inputs.javaBuildVersion }}-ubuntu-latest
 


### PR DESCRIPTION
This pull request introduces a minor update to the SonarCloud workflow. The change allows the workflow to continue even if downloading the unit test report artifact fails, improving the workflow's resilience.