### PR TITLE
fix: correct ansible workflow parameter name from dry_run_release_id to dry_run_tar_gz_url

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1038,7 +1038,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}
-      dry_run_release_id: ${{ inputs.dry_run_release_id }}
+      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url }}
 
   upload_secure_ansible_role:
     if: ${{ inputs.distribution == 'liquibase-secure' }}
@@ -1047,4 +1047,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       dry_run: ${{ inputs.dry_run }}
-      dry_run_release_id: ${{ inputs.dry_run_release_id }}
+      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url }}


### PR DESCRIPTION
## Summary
Fixes variable mismatch causing startup failures in liquibase-pro release workflows.

## Problem
The `package.yml` workflow was passing `dry_run_release_id` to both ansible deployment workflows (`liquibase-ansible` and `liquibase-secure-ansible`), but they expect `dry_run_tar_gz_url`. This caused workflow validation failures before any jobs could execute.

## Root Cause
- The `package.yml` workflow correctly defines both input parameters at the top:
  - `dry_run_tar_gz_url` (line 25) - Should be passed to ansible workflows
  - `dry_run_release_id` (line 29) - Used internally for downloading assets
- However, when calling the ansible workflows, it was passing the wrong parameter

## Changes
- Line 1041: Updated `upload_ansible_role` to pass `dry_run_tar_gz_url` instead of `dry_run_release_id`
- Line 1050: Updated `upload_secure_ansible_role` to pass `dry_run_tar_gz_url` instead of `dry_run_release_id`

## Testing
- Resolves startup failure at: https://github.com/liquibase/liquibase-pro/actions/runs/19511620620
- After merge, re-run the failed liquibase-pro workflow to verify the fix

## Impact
- Fixes both regular liquibase releases (liquibase-ansible) and secure releases (liquibase-secure-ansible)
- No breaking changes - only corrects parameter passing to match expected interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)