### PR TITLE
DAT-21252: update RPM signing messages and import GPG public key for verification

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -500,7 +500,7 @@ jobs:
           rpm --checksig -v "${{ env.RPM_FILENAME }}" || true
 
           # Check if signature was actually added
-          echo "Checking if RPM has a GPP signature:"
+          echo "Checking if RPM has a GPG signature:"
           if rpm --checksig "${{ env.RPM_FILENAME }}" 2>&1 | grep -q "RSA/SHA"; then
             echo "✓ RPM is successfully signed with GPG signature"
           else
@@ -577,6 +577,13 @@ jobs:
           # Copy the signed RPM to the repository directory
           echo "Copying signed RPM to repository..."
           cp "$SIGNED_RPM_PATH" yum/noarch/
+
+          # Import GPG public key into RPM database for verification
+          echo "Importing GPG public key for signature verification..."
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "sec" | head -1 | sed 's/.*\/\([A-F0-9]\{16\}\).*/\1/')
+          gpg --export -a "$GPG_KEY_ID" > /tmp/gpg-pubkey-verify.asc
+          sudo rpm --import /tmp/gpg-pubkey-verify.asc
+          rm /tmp/gpg-pubkey-verify.asc
 
           # Verify the copied file is still signed
           echo "Verifying copied RPM signature:"
@@ -663,6 +670,13 @@ jobs:
           # Copy the signed RPM to the repository directory
           echo "Copying signed RPM to repository..."
           cp "$SIGNED_RPM_PATH" yum/noarch/
+
+          # Import GPG public key into RPM database for verification
+          echo "Importing GPG public key for signature verification..."
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep "sec" | head -1 | sed 's/.*\/\([A-F0-9]\{16\}\).*/\1/')
+          gpg --export -a "$GPG_KEY_ID" > /tmp/gpg-pubkey-verify.asc
+          sudo rpm --import /tmp/gpg-pubkey-verify.asc
+          rm /tmp/gpg-pubkey-verify.asc
 
           # Verify the copied file is still signed
           echo "Verifying copied RPM signature:"


### PR DESCRIPTION
This pull request makes improvements to the RPM package signing and verification workflow in `.github/workflows/package.yml`. The main changes focus on ensuring that the GPG public key used for signing is imported into the RPM database before signature verification, and correcting a minor typo in the output message.

**Enhancements to RPM signature verification:**

* Added a step to export and import the GPG public key into the RPM database before verifying the RPM signature, ensuring that signature verification works reliably. [[1]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R581-R587) [[2]](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R674-R680)

**Minor corrections:**

* Fixed a typo in the echo statement, changing "GPP signature" to "GPG signature" for clarity.