### PR TITLE
Fix artifact naming mismatch for Blacksmith Ubuntu runners

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -509,10 +509,12 @@ jobs:
       - name: Parse Ubuntu OS name from inputs
         id: parse-os
         shell: bash
+        env:
+          OS_INPUT: ${{ inputs.os }}
         run: |
           # Extract Ubuntu runner name (could be ubuntu-latest or blacksmith-2vcpu-ubuntu-2404)
           # Blacksmith only supports Ubuntu/Linux, so macOS and Windows are always *-latest
-          UBUNTU_OS=$(echo '${{ inputs.os }}' | jq -r '.[] | select(contains("ubuntu"))' | head -n1)
+          UBUNTU_OS=$(echo "${OS_INPUT}" | jq -r '.[] | select(contains("ubuntu"))' | head -n1)
           echo "ubuntu_os=${UBUNTU_OS}" >> $GITHUB_OUTPUT
           echo "Parsed Ubuntu OS: ${UBUNTU_OS}"
 


### PR DESCRIPTION
## Summary
Fixes artifact naming mismatch that occurred after PR liquibase/liquibase-checks#317 changed runners from `ubuntu-latest` to `blacksmith-2vcpu-ubuntu-2404`.

## Problem
The workflow failed with:
```
Artifact not found for name: liquibase-checks-ubuntu-latest-5.0.2-SNAPSHOT-artifacts
```

**Root Cause:** The `combineJars` job hardcoded `ubuntu-latest` in artifact downloads, but artifacts were being uploaded with the actual runner name (`blacksmith-2vcpu-ubuntu-2404`).

## Changes
1. **Added OS parsing step** - Dynamically extracts the Ubuntu runner name from the `inputs.os` parameter
2. **Updated Ubuntu artifact download** - Uses the parsed OS name instead of hardcoded `ubuntu-latest`
3. **Fixed GPM publishing condition** - Changed from `matrix.os == 'ubuntu-latest'` to `contains(matrix.os, 'ubuntu')` to support both `ubuntu-latest` and `blacksmith-*` runners

## Technical Details
- Only Ubuntu needs dynamic parsing since Blacksmith only supports Linux runners
- macOS and Windows remain hardcoded as `*-latest` (no Blacksmith alternatives)
- Backward compatible with both `ubuntu-latest` and Blacksmith runner names

## Test Plan
- [ ] Verify artifacts are created with correct names
- [ ] Verify `combineJars` job successfully downloads Ubuntu artifacts
- [ ] Verify GPM publishing artifact is created for Blacksmith runners
- [ ] Test with liquibase-checks repository workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)