### PR TITLE
DAT-21250 Liquibase Secure Brew Cask 5.0.2 Release Failed - brew command not found (removed cask logic)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -874,106 +874,12 @@ jobs:
           aws s3 cp liquibase-$VERSION.zip $S3_BUCKET
           echo "Uploaded liquibase-$VERSION.zip to s3"
 
-  update_homebrew_cask:
-    name: Update Homebrew Cask
-    runs-on: macos-latest
-    if: ${{ !startsWith(inputs.version, '4.') }}
-    outputs:
-      HOMEBREW_CASK_PR_NUMBER: ${{ steps.capture-cask-pr.outputs.HOMEBREW_PR_NUMBER }}
-      HOMEBREW_CASK_PR_URL: ${{ steps.capture-cask-pr.outputs.HOMEBREW_PR_URL }}
-    steps:
-      - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-
-      - name: Determine cask name
-        id: cask-name
-        run: |
-          if [ "${{ inputs.distribution }}" = "liquibase" ]; then
-            CASK_NAME="liquibase-community"
-          else
-            CASK_NAME="${{ inputs.distribution }}"
-          fi
-          echo "CASK_NAME=$CASK_NAME" >> $GITHUB_OUTPUT
-          echo "Cask name: $CASK_NAME"
-
-      - name: Check for existing Homebrew cask PR for ${{ inputs.distribution }}
-        if: ${{ !startsWith(inputs.version, '4.') }}
-        id: check-pr
-        continue-on-error: true
-        run: |
-          # Authenticate GitHub CLI
-          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-
-          CASK_NAME="${{ steps.cask-name.outputs.CASK_NAME }}"
-          pr_title="$CASK_NAME ${{ inputs.version }}"
-
-          # Search for open pull requests with the specified title
-          pr_exists=$(gh pr list --repo Homebrew/homebrew-cask --state open --search "$pr_title" --json title --jq ".[] | select(.title == \"$pr_title\") | .title" )
-
-          if [ -z "$pr_exists" ]; then
-            echo "PR_EXISTS=false" >> $GITHUB_OUTPUT
-            echo "No existing PR found"
-          else
-            echo "PR_EXISTS=true" >> $GITHUB_OUTPUT
-            echo "PR already exists: $pr_title"
-          fi
-
-      - name: Update Homebrew cask for ${{ inputs.distribution }}
-        if: ${{ !startsWith(inputs.version, '4.') && steps.check-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
-        continue-on-error: true
-        run: |
-          brew bump-cask-pr --version "${{ inputs.version }}" "${{ steps.cask-name.outputs.CASK_NAME }}"
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
-
-      - name: Capture Homebrew Cask PR Details
-        if: ${{ !startsWith(inputs.version, '4.') && steps.check-pr.outputs.PR_EXISTS == 'false' && inputs.dry_run == false }}
-        id: capture-cask-pr
-        continue-on-error: true
-        run: |
-          # Wait briefly for PR to be created
-          sleep 30
-
-          CASK_NAME="${{ steps.cask-name.outputs.CASK_NAME }}"
-
-          # Search for the PR
-          PR_DATA=$(gh api graphql -f query='
-          query($search_query: String!) {
-            search(query: $search_query, type: ISSUE, first: 1) {
-              nodes {
-                ... on PullRequest {
-                  url,
-                  number
-                }
-              }
-            }
-          }' -f search_query="is:pr is:open repo:Homebrew/homebrew-cask $CASK_NAME ${{ inputs.version }} in:title" --jq '.data.search.nodes[0]')
-
-          if [ ! -z "$PR_DATA" ]; then
-            echo "HOMEBREW_PR_URL=$(echo "$PR_DATA" | jq -r '.url')" >> $GITHUB_OUTPUT
-            echo "HOMEBREW_PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')" >> $GITHUB_OUTPUT
-            echo "Found Homebrew Cask PR: $(echo "$PR_DATA" | jq -r '.url')"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # create a placeholder branch to check if tracking branch exists for this version
   # Branch is created when package is submitted to Homebrew and SDKMAN
   # Branch is deleted when package becomes available on Homebrew and SDKMAN
   create-placeholder-branch:
     runs-on: ubuntu-latest
-    needs: [upload_packages, update_homebrew_cask]
+    needs: [upload_packages]
     if: ${{ inputs.distribution != 'liquibase-secure' && inputs.dry_run == false }}
     steps:
       - name: Configure AWS credentials for vault access


### PR DESCRIPTION
This pull request removes the `update_homebrew_cask` job from the `.github/workflows/package.yml` workflow, simplifying the release automation process by no longer updating the Homebrew cask as part of this workflow.

Workflow simplification:

* Removed the entire `update_homebrew_cask` job, which previously handled updating the Homebrew cask, checking for existing PRs, and capturing PR details for new releases. (`.github/workflows/package.yml`)
* Updated the dependencies for the `create-placeholder-branch` job to no longer depend on the removed `update_homebrew_cask` job. (`.github/workflows/package.yml`)