### PR TITLE
DAT-21254 : add Maven project detection and JDK setup to SonarQube workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -101,6 +101,10 @@ jobs:
           if [ -f "sonar-project.properties" ]; then
             SONAR_PROJECT_KEY=$(grep -E "^sonar.projectKey=" sonar-project.properties | cut -d'=' -f2)
             SONAR_ORGANIZATION=$(grep -E "^sonar.organization=" sonar-project.properties | cut -d'=' -f2)
+            if [ -z "$SONAR_PROJECT_KEY" ] || [ -z "$SONAR_ORGANIZATION" ]; then
+              echo "Error: sonar.projectKey and sonar.organization must be defined in sonar-project.properties"
+              exit 1
+            fi
             mvn clean verify sonar:sonar \
               -Dsonar.host.url=https://sonarcloud.io \
               -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
@@ -115,6 +119,7 @@ jobs:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LIQUIBOT_PAT_GPM_ACCESS: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
 
       - name: SonarQube Scan (non-Maven projects)
         if: steps.check-maven.outputs.is_maven == 'false'
@@ -122,3 +127,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/sonar.yml` GitHub Actions workflow to improve support for Maven-based Java projects when running SonarQube scans. The main changes add conditional logic to detect Maven projects and set up the Java environment only when needed.

**Enhancements for Maven project support:**

* Added an input parameter `java-version` (defaulting to 17) to allow configuration of the Java version used for Maven projects.
* Introduced a step to check for the presence of a `pom.xml` file and set an output flag (`is_maven`) accordingly.
* Conditionally set up the JDK using `actions/setup-java` only if a Maven project is detected, using the specified Java version and enabling Maven caching.
* Added a step to build the Maven project (`mvn clean compile test-compile`) only if a Maven project is present, before running the SonarQube scan.