### PR TITLE
feat: add codeqlConfigFile input parameter to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: "21"
         type: string
+      codeqlConfigFile:
+        description: "Path to CodeQL configuration file (e.g., .github/codeql/codeql-config.yml) for customizing queries and exclusions"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
@@ -100,6 +105,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ steps.set-build-mode.outputs.buildMode }}
+        config-file: ${{ inputs.codeqlConfigFile || '' }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## Summary
- Adds new `codeqlConfigFile` input parameter to the CodeQL reusable workflow
- Allows extensions to provide a custom CodeQL configuration file for customizing queries and exclusions
- Enables repositories to exclude specific alerts (e.g., `java/missing-clone-method`) without modifying the shared workflow

## Usage

In your extension's workflow that calls this reusable workflow:

```yaml
uses: liquibase/build-logic/.github/workflows/codeql.yml@main
with:
  codeqlConfigFile: .github/codeql/codeql-config.yml
```

Then create `.github/codeql/codeql-config.yml` in your repo:

```yaml
query-filters:
  - exclude:
      id: java/missing-clone-method
```

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test in a calling repository (e.g., liquibase-commercial-snowflake) with a custom config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)