### PR TITLE
Enable review for bot-initiated pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,8 +56,8 @@ jobs:
           # Reference: https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#track_progress
           track_progress: true
           # Allow bot-initiated PRs to be reviewed without failing
-          # This prevents workflow failures for dependabot for now
-          allowed_bots: 'dependabot'
+          # This prevents workflow failures for dependabot and liquibase-workflows bot for now
+          allowed_bots: 'dependabot,liquibase-workflows'
           prompt: |
             REPO: ${{ github.repository }}
             PR: #${{ github.event.pull_request.number }}


### PR DESCRIPTION
Allow bot-initiated PRs to be reviewed without failing.