### PR TITLE
Allow all bots in CLAUDE code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,8 +56,8 @@ jobs:
           # Reference: https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md#track_progress
           track_progress: true
           # Allow bot-initiated PRs to be reviewed without failing
-          # This prevents workflow failures for dependabot and liquibase-workflows bot for now
-          allowed_bots: 'dependabot,liquibase-workflows'
+          # This prevents workflow failures for dependabot, renovate, and other automation          
+          allowed_bots: '*'
           prompt: |
             REPO: ${{ github.repository }}
             PR: #${{ github.event.pull_request.number }}


### PR DESCRIPTION
Updated allowed_bots to allow all automation bots.