### PR TITLE
INT-1609: Add snowflake_ext flag for extension test harness

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      snowflake_ext:
+        description: "Deploy or destroy the snowflake Extension infrastructure"
+        required: false
+        type: boolean
+        default: false
       aws_postgresql:
         description: "Deploy or destroy the aws_postgresql infrastructure"
         required: false
@@ -194,7 +199,8 @@ jobs:
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_documentdb ${{ inputs.documentdb }}
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_oss ${{ inputs.snowflake_oss }}
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_pro ${{ inputs.snowflake_pro }}
-          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_th ${{ inputs.snowflake_th }} 
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_th ${{ inputs.snowflake_th }}
+          spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_snowflake_ext ${{ inputs.snowflake_ext }}
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_postgresql ${{ inputs.aws_postgresql }}
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_oracle ${{ inputs.aws_oracle }}
           spacectl stack environment setvar --id $EPHEMERAL_STACK_ID TF_VAR_create_aws_mariadb ${{ inputs.aws_mariadb }}


### PR DESCRIPTION
## Summary
- Add new `snowflake_ext` input parameter to `ephemeral-cloud-infra.yml`
- Enable isolated Snowflake infrastructure for commercial extension test harness

## Context
This PR is part of a multi-repo change to configure CI/CD for test-harness integration tests in the liquibase-commercial-snowflake extension.

**Related PRs:**
- liquibase/liquibase-infrastructure: Terraform resources for LIQUIBASEEXT
- liquibase/liquibase-commercial-snowflake: Workflow and test class

## Changes
- Added `snowflake_ext` boolean input (default: false)
- Added `spacectl stack environment setvar` for `TF_VAR_create_snowflake_ext`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with liquibase-commercial-snowflake after all PRs merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)