### PR TITLE
DAT-21374: Migrate lightweight workflows to ubuntu-slim runners

### DIFF
--- a/.github/workflows/check-for-dependabot-prs.yml
+++ b/.github/workflows/check-for-dependabot-prs.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   check_for_prs:
     name: Check for open Dependabot PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Skip check if PR creator is dependabot
         if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/check-for-subtree-sync-prs.yml
+++ b/.github/workflows/check-for-subtree-sync-prs.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   check_for_prs:
     name: Check for open subtree sync PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Skip check if PR creator is dependabot
         if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,7 +38,7 @@ jobs:
 
   create-release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Create Release Draft
         id: create-release

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,7 +15,7 @@ jobs:
     # The name of the job
     name: Merge dependabot
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # The permissions for the GITHUB_TOKEN
     permissions:
       contents: write

--- a/.github/workflows/jira-ticket-linker.yml
+++ b/.github/workflows/jira-ticket-linker.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   add-jira-ticket-link:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check and add ticket link
         uses: actions/github-script@v8

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     slack-notification:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-slim
         steps:
         - name: Configure AWS credentials for vault access
           uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
## Summary
- Migrate 6 lightweight reusable workflows from `ubuntu-latest` to `ubuntu-slim` runners
- These workflows are shared across 20+ repositories in the Liquibase organization

## Changes
The following workflows have been updated to use `ubuntu-slim`:
- `check-for-dependabot-prs.yml` - Checks for open dependabot PRs
- `check-for-subtree-sync-prs.yml` - Checks for open subtree sync PRs
- `create-release.yml` - Creates release drafts using release-drafter
- `dependabot-automerge.yml` - Auto-merges dependabot PRs
- `jira-ticket-linker.yml` - Adds Jira ticket links to PR descriptions
- `slack-notification.yml` - Sends Slack notifications for test failures

## Why ubuntu-slim?
GitHub's `ubuntu-slim` runners offer significant cost savings for lightweight automation:

| Metric | ubuntu-latest | ubuntu-slim |
|--------|---------------|-------------|
| Cost | $0.008/min | $0.002/min |
| CPU | 4 vCPU | 1 vCPU |
| RAM | 16 GB | 5 GB |
| Storage | 14 GB | 14 GB |
| Job timeout | 6 hours | 15 minutes |

These workflows typically complete in under 1-2 minutes, making them ideal candidates for ubuntu-slim.

## Impact
Since these are reusable workflows, this change will benefit all repositories that consume them:
- liquibase/liquibase
- liquibase/liquibase-pro
- All extension repositories
- 20+ repositories total

## Test plan
- [ ] Verify workflows trigger and complete successfully after merge
- [ ] Monitor workflow execution times to ensure they stay under 15-minute limit
- [ ] Verify cost reduction in GitHub Actions usage reports

## Related
- Jira: [DAT-21374](https://datical.atlassian.net/browse/DAT-21374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-21374]: https://datical.atlassian.net/browse/DAT-21374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ