### PR TITLE
DAT-21648: Add tag input to package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -746,7 +746,7 @@ jobs:
           formula-name: ${{ inputs.distribution }}
           formula-path: Formula/l/${{ inputs.distribution }}.rb
           homebrew-tap: Homebrew/homebrew-core
-          tag-name: ${{ inputs.tag || inputs.version }}
+          tag-name: ${{ inputs.tag || format('v{0}', inputs.version) }}
           download-url: ${{ inputs.distribution == 'liquibase-secure' && format('{0}/{1}/liquibase-secure-{1}.tar.gz', inputs.download_base_url, inputs.version) || format('{0}/{1}/{2}-{3}.tar.gz', inputs.download_base_url, inputs.tag || format('v{0}', inputs.version), inputs.artifactId, inputs.version) }}
           commit-message: |
             {{formulaName}} {{version}}


### PR DESCRIPTION
## Summary
- Add `tag` input parameter to `package.yml` workflow (both `workflow_call` and `workflow_dispatch`)
- This enables the liquibase release orchestrator to pass the release tag for proper asset downloads

## Related
- Jira: [DAT-21648](https://datical.atlassian.net/browse/DAT-21648)
- Dependent PR: liquibase/liquibase (will be created after this)

## Test plan
- [ ] Merge this PR first
- [ ] Then merge the dependent PR in liquibase/liquibase
- [ ] Run a dry-run release to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-21648]: https://datical.atlassian.net/browse/DAT-21648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ