### PR TITLE
fix: use gh CLI for dry-run release downloads

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -231,16 +231,19 @@ jobs:
 
       - name: Download ${{ inputs.artifactId }} dry-run Release
         if: ${{ inputs.dry_run == true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p $PWD/.github/target
-          # Download tar.gz from dry-run release URL
-          curl -L -H "Accept: application/octet-stream" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -o $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz \
-            "${{ inputs.dry_run_tar_gz_url }}"
-          # Download zip from dry-run release URL
-          curl -L -H "Accept: application/octet-stream" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -o $PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.zip \
-            "${{ inputs.dry_run_zip_url }}"
+          # Use gh CLI which handles GitHub auth and redirects correctly
+          gh release download "${{ inputs.tag }}" \
+            --repo liquibase/liquibase \
+            --pattern "*.tar.gz" \
+            --output "$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz"
+          gh release download "${{ inputs.tag }}" \
+            --repo liquibase/liquibase \
+            --pattern "*.zip" \
+            --output "$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.zip"
 
       - name: Build ${{ inputs.artifactId }} deb package
         run: |


### PR DESCRIPTION
## Summary
Replace curl with gh CLI for downloading dry-run release assets.

## Problem
curl with `-L` passes the Authorization header through redirects. GitHub redirects release asset downloads to pre-signed S3 URLs. S3 rejects requests that have BOTH query-string auth (pre-signed URL) AND header auth, resulting in an HTML error page being downloaded instead of the binary.

This caused the "Not in GZIP format" error when trying to extract the downloaded file.

## Fix
Use `gh release download` which handles GitHub authentication and redirects correctly.

## Related
- Fixes DAT-21648
- Follow-up to #460

Generated with [Claude Code](https://claude.com/claude-code)