### PR TITLE
fix: skip rename when source and destination are the same file

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -243,14 +243,16 @@ jobs:
 
           # Find and rename the main tar.gz (exclude additional files)
           MAIN_TAR=$(ls $PWD/.github/target/liquibase-*.tar.gz 2>/dev/null | grep -v additional | head -1)
-          if [ -n "$MAIN_TAR" ]; then
-            mv "$MAIN_TAR" "$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz"
+          DEST_TAR="$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.tar.gz"
+          if [ -n "$MAIN_TAR" ] && [ "$MAIN_TAR" != "$DEST_TAR" ]; then
+            mv "$MAIN_TAR" "$DEST_TAR"
           fi
 
           # Find and rename the main zip (exclude additional files)
           MAIN_ZIP=$(ls $PWD/.github/target/liquibase-*.zip 2>/dev/null | grep -v additional | head -1)
-          if [ -n "$MAIN_ZIP" ]; then
-            mv "$MAIN_ZIP" "$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.zip"
+          DEST_ZIP="$PWD/.github/target/${{ inputs.artifactId }}-${{ inputs.version }}.zip"
+          if [ -n "$MAIN_ZIP" ] && [ "$MAIN_ZIP" != "$DEST_ZIP" ]; then
+            mv "$MAIN_ZIP" "$DEST_ZIP"
           fi
 
       - name: Build ${{ inputs.artifactId }} deb package


### PR DESCRIPTION
## Summary
- Fix `mv` error when dry-run version equals downloaded filename
- When version is `dry-run-{id}`, the downloaded file `liquibase-dry-run-{id}.tar.gz` already matches the destination filename
- Check if source and destination paths differ before renaming

## Related
- Part of DAT-21648 fix chain
- Follows PR #461 (gh CLI for downloads) and PR #462 (--dir instead of --output)

## Test plan
- [ ] Re-run dry-run release workflow
- [ ] Verify package publishing stage passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)