### PR TITLE
DAT-21557: fix: Support Blacksmith Windows runners in artifact naming

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -506,17 +506,25 @@ jobs:
           echo "Project Artifact Name: ${PROJECT_ARTIFACT_NAME}"
           echo "Artifact Version: ${ARTIFACT_VERSION}"
 
-      - name: Parse Ubuntu OS name from inputs
+      - name: Parse OS names from inputs
         id: parse-os
         shell: bash
         env:
           OS_INPUT: ${{ inputs.os }}
         run: |
-          # Extract Ubuntu runner name (could be ubuntu-latest or blacksmith-2vcpu-ubuntu-2404)
-          # Blacksmith only supports Ubuntu/Linux, so macOS and Windows are always *-latest
+          # Extract runner names for each platform from the os input array
+          # Handles both traditional runners (*-latest) and Blacksmith runners
           UBUNTU_OS=$(echo "${OS_INPUT}" | jq -r '.[] | select(contains("ubuntu"))' | head -n1)
+          MACOS_OS=$(echo "${OS_INPUT}" | jq -r '.[] | select(contains("macos"))' | head -n1)
+          WINDOWS_OS=$(echo "${OS_INPUT}" | jq -r '.[] | select(contains("windows") or contains("Windows"))' | head -n1)
+
           echo "ubuntu_os=${UBUNTU_OS}" >> $GITHUB_OUTPUT
+          echo "macos_os=${MACOS_OS}" >> $GITHUB_OUTPUT
+          echo "windows_os=${WINDOWS_OS}" >> $GITHUB_OUTPUT
+
           echo "Parsed Ubuntu OS: ${UBUNTU_OS}"
+          echo "Parsed macOS OS: ${MACOS_OS}"
+          echo "Parsed Windows OS: ${WINDOWS_OS}"
 
       - name: Download Ubuntu Artifacts
         uses: actions/download-artifact@v6
@@ -527,13 +535,13 @@ jobs:
       - name: Download macOS Artifacts
         uses: actions/download-artifact@v6
         with:
-          name: ${{ env.PROJECT_ARTIFACT_NAME }}-macos-latest-${{needs.build.outputs.artifact_version}}-artifacts
+          name: ${{ env.PROJECT_ARTIFACT_NAME }}-${{ steps.parse-os.outputs.macos_os }}-${{needs.build.outputs.artifact_version}}-artifacts
           path: /tmp/macos
 
       - name: Download Windows Artifacts
         uses: actions/download-artifact@v6
         with:
-          name: ${{ env.PROJECT_ARTIFACT_NAME }}-windows-latest-${{needs.build.outputs.artifact_version}}-artifacts
+          name: ${{ env.PROJECT_ARTIFACT_NAME }}-${{ steps.parse-os.outputs.windows_os }}-${{needs.build.outputs.artifact_version}}-artifacts
           path: /tmp/windows
 
       - name: Create multiplatform jar


### PR DESCRIPTION
Fixes artifact download failures when using Blacksmith Windows runners (blacksmith-2vcpu-windows-2025) instead of windows-latest.

The combineJars job was hardcoding "windows-latest" and "macos-latest" when downloading artifacts, but artifacts are uploaded using the actual runner name from the matrix.os input.

Changes:
- Parse all OS names (Ubuntu, macOS, Windows) from inputs.os array
- Use parsed OS names in artifact download steps
- Supports both traditional runners (*-latest) and Blacksmith runners

This ensures artifact naming consistency between upload and download, regardless of runner type used.

Resolves: DAT-21557