### PR TITLE
DAT-21768: Remove liquibaseBranchName parameter from sonar-test-scan

### DIFF
--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -308,13 +308,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          MAVEN_ARGS_INPUT: ${{ inputs.mavenArgs }}
+          SONAR_BRANCH_NAME: ${{ inputs.thisBranchName }}
+          SONAR_SCM_REVISION: ${{ inputs.thisSha }}
         run: |
+          read -r -a MAVEN_ARGS <<< "$MAVEN_ARGS_INPUT"
           mvn -B sonar:sonar -P 'sonar,!run-proguard' -DskipTests \
-          ${{ inputs.mavenArgs }} \
-          -Dsonar.scm.revision=${{ inputs.thisSha }} \
-          -Dsonar.token=$SONAR_TOKEN \
+          "${MAVEN_ARGS[@]}" \
+          -Dsonar.scm.revision="$SONAR_SCM_REVISION" \
+          -Dsonar.token="$SONAR_TOKEN" \
           -Dsonar.java.coveragePlugin=jacoco \
-          -Dsonar.branch.name=${{ inputs.thisBranchName }} \
+          -Dsonar.branch.name="$SONAR_BRANCH_NAME" \
           -Dsonar.qualitygate.wait=true \
           -Dsonar.organization=${{ github.repository_owner }} \
           -Dsonar.host.url='https://sonarcloud.io' \
@@ -327,15 +331,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
+          MAVEN_ARGS_INPUT: ${{ inputs.mavenArgs }}
+          SONAR_SCM_REVISION: ${{ inputs.thisSha }}
+          PR_KEY: ${{ inputs.pullRequestNumber }}
+          PR_BRANCH: ${{ inputs.pullRequestBranchName }}
+          PR_BASE_BRANCH: ${{ inputs.pullRequestBaseBranchName }}
         run: |
+          read -r -a MAVEN_ARGS <<< "$MAVEN_ARGS_INPUT"
           mvn -B sonar:sonar -P 'sonar,!run-proguard' -DskipTests \
-          ${{ inputs.mavenArgs }} \
-          -Dsonar.scm.revision=${{ inputs.thisSha }} \
-          -Dsonar.token=$SONAR_TOKEN \
+          "${MAVEN_ARGS[@]}" \
+          -Dsonar.scm.revision="$SONAR_SCM_REVISION" \
+          -Dsonar.token="$SONAR_TOKEN" \
           -Dsonar.java.coveragePlugin=jacoco \
-          -Dsonar.pullrequest.key=${{ inputs.pullRequestNumber }} \
-          -Dsonar.pullrequest.branch=${{ inputs.pullRequestBranchName }} \
-          -Dsonar.pullrequest.base=${{ inputs.pullRequestBaseBranchName }} \
+          -Dsonar.pullrequest.key="$PR_KEY" \
+          -Dsonar.pullrequest.branch="$PR_BRANCH" \
+          -Dsonar.pullrequest.base="$PR_BASE_BRANCH" \
           -Dsonar.pullrequest.provider=GitHub \
           -Dsonar.pullrequest.github.repository="${{ github.repository }}" \
           -Dsonar.pullrequest.github.endpoint='https://api.github.com/' \


### PR DESCRIPTION
## Summary

- Remove legacy `liquibaseBranchName` input parameter from sonar-test-scan workflow
- Remove `-Dliquibase.version` Maven flag from all scan steps
- Support independent builds for both liquibase/liquibase and liquibase-pro repositories

## Context

The `liquibaseBranchName` parameter was designed for the old architecture where liquibase-pro depended on external `liquibase-core` artifacts. With the new subtree-based architecture, both repositories build independently and no longer need to specify an external liquibase version.

## Changes

- Remove `liquibaseBranchName` input parameter (was required, now removed)
- Remove `-Dliquibase.version=${{ inputs.liquibaseBranchName }}-SNAPSHOT` from:
  - "Generate classes" step
  - "Sonar Branch Scan" step  
  - "Sonar PR Scan" step

## Breaking Change

Callers of this workflow must remove the `liquibaseBranchName` parameter from their workflow calls. PRs for liquibase/liquibase and liquibase-pro will be created to make this change.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] After merge, verify liquibase/liquibase PR works correctly
- [ ] After merge, verify liquibase-pro PR works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)