### PR TITLE
fix: DAT-21768 Remove space from mavenArgs default to prevent word splitting

### DIFF
--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -27,7 +27,7 @@ on:
         description: 'The maven arguments to be passed to the mvn command'
         type: string
         required: false
-        default: -Dsonar.coverage.exclusions='**/test/**/*.*, **/pom.xml'
+        default: -Dsonar.coverage.exclusions=**/test/**/*.*,**/pom.xml
       sonarRootPath:
         description: 'The name of the tested classes module'
         type: string


### PR DESCRIPTION
## Summary

Remove the space from the default `mavenArgs` value to prevent bash word splitting.

## Problem

The previous fix used `$MAVEN_ARGS` (unquoted) to pass Maven arguments. However, the default value contained a space after the comma:

```
-Dsonar.coverage.exclusions='**/test/**/*.*, **/pom.xml'
                                          ^ this space
```

Bash word-splits on this space, causing `**/pom.xml'` to be passed as a separate argument to Maven, resulting in:
```
Error: Unknown lifecycle phase "**/pom.xml'"
```

## Solution

Remove the space from the default value. Comma-separated values in Maven properties don't require spaces:

```
-Dsonar.coverage.exclusions=**/test/**/*.*,**/pom.xml
```

Also removed the now-unnecessary single quotes.

## Test plan

- [ ] Merge and re-trigger test PRs for liquibase/liquibase and liquibase-pro
- [ ] Verify sonar analysis runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)