### PR TITLE
Fix JaCoCo duplicate class error by specifying target/classes

### DIFF
--- a/.github/workflows/sonar-test-scan.yml
+++ b/.github/workflows/sonar-test-scan.yml
@@ -290,8 +290,8 @@ jobs:
             java -jar jacococli.jar report merged.exec --classfiles ./classes --sourcefiles src --html site
           else
             echo "Tested classes module name: ${{ env.testedClassesModuleName }}"
-            java -jar jacococli.jar report merged.exec --classfiles ../${{ env.testedClassesModuleName }}/target/ --sourcefiles ../${{ env.testedClassesModuleName }}/src/ --xml jacoco.xml
-            java -jar jacococli.jar report merged.exec --classfiles ../${{ env.testedClassesModuleName }}/target/ --sourcefiles ../${{ env.testedClassesModuleName }}/src/ --html site
+            java -jar jacococli.jar report merged.exec --classfiles ../${{ env.testedClassesModuleName }}/target/classes --sourcefiles ../${{ env.testedClassesModuleName }}/src/ --xml jacoco.xml
+            java -jar jacococli.jar report merged.exec --classfiles ../${{ env.testedClassesModuleName }}/target/classes --sourcefiles ../${{ env.testedClassesModuleName }}/src/ --html site
           fi
 
       - name: Set up JDK for Sonar


### PR DESCRIPTION
## Summary
- Fix JaCoCo duplicate class error in sonar-test-scan workflow
- Changed `--classfiles ../pro/target/` to `--classfiles ../pro/target/classes`
- Prevents scanning JAR files that contain the same classes as target/classes/

## Problem
The JaCoCo report command was analyzing the entire `target/` directory, which contains both:
1. `target/classes/` - compiled class files
2. `target/*.jar` - packaged JAR containing the same classes

This caused the error:
```
Can't add different class with same name: com/datical/liquibase/ext/parser/ProSqlParser
```

## Test plan
- [ ] Verify liquibase-pro sonar scan passes without duplicate class errors

DAT-21768

🤖 Generated with [Claude Code](https://claude.com/claude-code)