### PR TITLE
Fix subtree sync auto-merging PRs with unresolved conflicts

### DIFF
--- a/.github/workflows/subtree-sync.yml
+++ b/.github/workflows/subtree-sync.yml
@@ -164,7 +164,7 @@ jobs:
             ${{ steps.pull_subtree.outputs.status == 'conflict' && 'Please resolve the conflicts in the files marked with conflict markers before merging this PR.' || '' }}
 
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number
+        if: steps.create-pr.outputs.pull-request-number && steps.pull_subtree.outputs.status != 'conflict'
         run: |
           gh pr merge --auto --merge "${{ steps.create-pr.outputs.pull-request-number }}"
         env:


### PR DESCRIPTION
## Summary
- Skip auto-merge when subtree sync detects merge conflicts, so PRs with conflict markers require manual resolution before merging
- Root cause: the `Enable auto-merge` step had no condition to check for conflicts, causing `gh pr merge --auto` to run on conflict PRs. Combined with no branch protection, this merged conflict markers directly into `main` (see [liquibase-commercial-mongodb#431](https://github.com/liquibase/liquibase-commercial-mongodb/pull/431))

## Test plan
- [ ] Trigger a subtree sync with a known conflict and verify the resulting PR does **not** have auto-merge enabled
- [ ] Trigger a clean subtree sync and verify auto-merge still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)