### PR TITLE
feat: add a failed comment when things don't work

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -114,7 +114,7 @@ jobs:
             --model claude-sonnet-4-5-20250929
 
       - name: Comment on failure
-        if: failure()
+        if: ${{ failure() && steps.claude-review.outcome == 'failure' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Summary

  - Add a failure notification step to the Claude Code Review workflow that posts a comment with a ❌ and a link to the failed run when the review step fails

  Test plan

  - Trigger a Claude Code Review that fails (e.g., invalid API key or timeout) and verify the ❌ comment appears on the PR with a working link to the failed run
  - Verify successful reviews are unaffected (the step is skipped via if: failure())

  🤖 Generated with Claude Code