### PR TITLE
Update Trivy action to v0.34.0 to fix 401 authentication errors

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Trivy surface scan (Docker mode)
         if: inputs.mode == 'docker'
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2  # 0.28.0
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284  # 0.34.0
         with:
           image-ref: ${{ inputs.source }}
           format: json
@@ -184,7 +184,7 @@ jobs:
           exit-code: "0"
 
       - name: Trivy deep scan
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2  # 0.28.0
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284  # 0.34.0
         with:
           scan-type: rootfs
           scan-ref: /tmp/extracted-deps


### PR DESCRIPTION
What This Fixes:

  ✅ Resolves 401 Unauthorized errors when downloading the Trivy action, previously was using old/inaccessible sha
  ✅ Uses the latest stable version (v0.34.0) with improved reliability
  ✅ Uses commit SHA for security (immutable reference)
  ✅ Updates both surface and deep scan steps