### PR TITLE
DAT-22065: Remove build release artifacts step from workflow

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -139,14 +139,6 @@ jobs:
         run: |
           ${{ inputs.extraCommand }}
 
-      - name: Build release artifacts
-        working-directory: ${{ inputs.artifactPath }}
-        id: build-release-artifacts
-        continue-on-error: true
-        run: |
-          mvn -B release:clean release:prepare -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=${{ github.event.inputs.liquibaseVersion }} -DpushChanges=false
-          git reset HEAD~ --hard
-
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}
         id: get-artifact-id


### PR DESCRIPTION
This pull request makes a minor change to the `.github/workflows/extension-release-published.yml` workflow. The step responsible for building release artifacts has been removed, simplifying the workflow.

* Workflow simplification:
  * Removed the `Build release artifacts` step, which previously ran Maven release commands and reset the Git history. (`.github/workflows/extension-release-published.yml`)
  * 
The extension-release-prepare.yml workflow already:                                                                                                                                                                                 
  - ✅ Builds the artifacts
  - ✅ Creates the GitHub release with those artifacts                                                                                                                                                                                
                                                                                                                                                                                                                                      
  So the "Build release artifacts" step in extension-release-published.yml is completely redundant. It's trying to rebuild what's already done.

  The release job should only:
  1. Get Artifact ID
  2. Download Release Artifacts (from the existing GitHub release)
  3. Publish to Maven Central