### PR TITLE
Fix extension release not updating all liquibase.version values

### DIFF
--- a/.github/workflows/extension-automated-release.yml
+++ b/.github/workflows/extension-automated-release.yml
@@ -259,9 +259,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           REPOSITORY: ${{ matrix.repository }}
         run: |
-          echo "INFO: Updating liquibase.version in pom.xml to ${VERSION}"
-          sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>${VERSION}<\/liquibase.version>/" pom.xml
-          git add pom.xml
+          echo "INFO: Updating liquibase.version in all pom.xml files to ${VERSION}"
+          find . -name "pom.xml" -exec sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>${VERSION}<\/liquibase.version>/" {} \;
+          git add -A '*.xml'
           # Check if there are changes before committing
           if git diff-index --quiet HEAD --; then
             echo "INFO: No changes to commit."


### PR DESCRIPTION
## Summary
- The extension release workflow only ran `sed` on the root `pom.xml`, missing `liquibase.version` definitions in child modules (e.g. `liquibase-cassandra/pom.xml` in liquibase-pro)
- Changed to `find . -name "pom.xml" -exec sed ...` to update all pom.xml files
- Changed `git add pom.xml` to `git add -A '*.xml'` to stage all modified pom files

## Test plan
- [ ] Verify `find . -name "pom.xml" -exec grep -l "liquibase.version" {} \;` finds both root and child pom files in liquibase-pro
- [ ] Run extension release workflow against a test repo with multi-module pom structure
- [ ] Confirm files that only reference `${liquibase.version}` (without defining it) are unaffected

Generated with Claude Code