### PR TITLE
Upgrade anchore/scan-action to v7.3.2 to fix CVE-2025-59250 false positive

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Grype SBOM scan
         if: inputs.mode == 'docker' && inputs.generate_sbom
-        uses: anchore/scan-action@869c549e657a088dc0441b08ce4fc0ecdac2bb65  # v5
+        uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c  # v7.3.2
         with:
           sbom: sbom.spdx.json
           fail-build: false


### PR DESCRIPTION
## Summary

- Upgrades `anchore/scan-action` from v5 (Grype v0.85.0) to v7.3.2 (Grype v0.107.1)
- Fixes the remaining Grype false positive for CVE-2025-59250 on the `liquibase-secure` image

## Context

PR #492 extended the `.trivyignore` expiration which fixed the Trivy scans, but the Grype scan still reports `grype_vulns: 1` because `.trivyignore` only applies to Trivy.

The root cause — Grype's incorrect version comparison of mssql-jdbc `13.2.1` vs `13.2.1.jre11` — was fixed upstream in [anchore/grype#3034](https://github.com/anchore/grype/pull/3034) (merged Nov 2025, shipped in v0.104.1). The workflow was pinned to scan-action v5 which bundles Grype v0.85.0, predating the fix.

Failing run: [#22321625392](https://github.com/liquibase/docker/actions/runs/22321625392)

## Test plan

- [ ] Re-run the [Docker vulnerability scan workflow](https://github.com/liquibase/docker/actions/workflows/vulnerability-scan.yml) after merge
- [ ] Confirm `grype_vulns: 0` in scan output
- [ ] Verify community and alpine scans still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)