### PR TITLE
Fix/DAT-22065

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -518,6 +518,14 @@ jobs:
           echo "Latest Draft Release ID: $LATEST_DRAFT_RELEASE"
           echo "RELEASE_ID=$LATEST_DRAFT_RELEASE" >> $GITHUB_ENV
 
+      - name: Verify draft release exists
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          if [ -z "$RELEASE_ID" ]; then
+            echo "::error::No draft release found in the repository. Please create a draft release before running this workflow."
+            exit 1
+          fi
+
       - name: List artifacts in release
         if: ${{ env.RELEASE_ID != '' && env.RELEASE_ID != null && inputs.dry_run == false }}
         id: list-artifacts


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow `.github/workflows/extension-attach-artifact-release.yml` to standardize how the release version and artifact ID are referenced and used during artifact signing and uploading. The main focus is to use the `RELEASE_VERSION` environment variable and `${{ env.artifact_id }}` consistently, instead of invoking Maven or using local shell variables.

Key workflow improvements:

**Consistent Version and Artifact ID Handling:**

* Replaced calls to `mvn help:evaluate` for retrieving the project version with direct use of the `RELEASE_VERSION` environment variable in all artifact signing and uploading steps. [[1]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L577-R582) [[2]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L591-R596) [[3]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L620-R620) [[4]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L661-R661)
* Updated artifact file references to use `${{ env.artifact_id }}` instead of the local `artifact_id` variable, ensuring consistency with the environment variables set earlier in the workflow. [[1]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L577-R582) [[2]](diffhunk://#diff-dfefa73bb010891f1244099cfb9fadddfb8445cde54e8cdd4c9eea9f24e255d9L591-R596)

These changes make the workflow more robust and easier to maintain by relying on explicitly set environment variables rather than dynamic Maven evaluation or local variable assignment.