### PR TITLE
feat(ci): remove redundant dependency:go-offline (DAT-22570)

### DIFF
--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -218,7 +218,7 @@ jobs:
           LIQUIBASE_PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS}
+          mvn -B clean package -DskipTests=true ${EXTRA_MAVEN_ARGS}
 
       - name: Get Artifact ID
         working-directory: ${{ inputs.artifactPath }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -252,12 +252,9 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ env.AZURE_CLIENT_SECRET }}
           AZURE_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          if [ -n "${{ inputs.extraMavenArgs }}" ]; then
-            mvn -B clean package -DskipTests=true "${{ inputs.extraMavenArgs }}"
-          else
-            mvn -B clean package -DskipTests=true
-          fi
+          mvn -B clean package -DskipTests=true ${EXTRA_MAVEN_ARGS}
 
       - name: Get Project Artifact Name
         working-directory: ${{ inputs.artifactPath }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -228,7 +228,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ env.AZURE_CLIENT_SECRET }}
           AZURE_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
-        run: mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
+        run: mvn -B clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
@@ -254,9 +254,9 @@ jobs:
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
         run: |
           if [ -n "${{ inputs.extraMavenArgs }}" ]; then
-            mvn -B dependency:go-offline clean package -DskipTests=true "${{ inputs.extraMavenArgs }}"
+            mvn -B clean package -DskipTests=true "${{ inputs.extraMavenArgs }}"
           else
-            mvn -B dependency:go-offline clean package -DskipTests=true
+            mvn -B clean package -DskipTests=true
           fi
 
       - name: Get Project Artifact Name


### PR DESCRIPTION
## Summary

Removes the `dependency:go-offline` Maven goal from build commands in reusable extension workflows. With stickydisk and actions/cache providing warm Maven repository caches, the pre-fetch step is redundant overhead (~1-2 min per build per OS).

### Changes

- **`pro-extension-build-for-liquibase.yml`**: Removed `dependency:go-offline` from the "Build and Package" step (used by RC Release Orchestrator)
- **`pro-extension-test.yml`**: Removed `dependency:go-offline` from 3 build steps (nightly build, regular build with/without extra Maven args)

### Companion PR

- liquibase/liquibase-pro — same branch (`DAT-22570/optimize-rc-release-orchestrator`): main pipeline optimization changes (Maven cache on Win/macOS, Docker parallelization, combined version commands)

### Test plan

- [ ] Verify extension builds still pass without `dependency:go-offline`
- [ ] Verify Maven downloads dependencies on-demand during build phase
- [ ] Run a test RC pipeline using branch reference to validate end-to-end

🔗 [DAT-22570](https://datical.atlassian.net/browse/DAT-22570)

[DAT-22570]: https://datical.atlassian.net/browse/DAT-22570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ