### PR TITLE
DAT-21583: Fix CVE diff auth by moving vault steps before diff

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -326,6 +326,43 @@ jobs:
           category: ${{ inputs.sarif_category }}-surface
         continue-on-error: true
 
+      # --- Vault / GitHub App token for cross-repo access ---
+      # Required by diff-new-cves.sh (fetches assessments.yaml from liquibase-pro)
+      # and by the CVE dispatch step (triggers investigate-cve workflow).
+      # Moved before the diff step so the token is available for both.
+      # All steps use continue-on-error: true so failures never block the scan.
+
+      - name: Configure AWS credentials for vault access
+        if: always() && steps.analyze.outputs.total_vulns > 0
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+        continue-on-error: true
+
+      - name: Get secrets from vault
+        id: vault-secrets-cve
+        if: always() && steps.analyze.outputs.total_vulns > 0
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+        continue-on-error: true
+
+      - name: Get GitHub App token for liquibase-pro
+        id: get-token-cve
+        if: always() && steps.analyze.outputs.total_vulns > 0
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: liquibase
+          repositories: liquibase-pro
+          permission-actions: write
+          permission-contents: read
+        continue-on-error: true
+
       # Run diff-new-cves.sh ONCE and persist output for both the check step and
       # the dispatch step. This avoids a double API call to fetch assessments.yaml.
       - name: Run CVE diff
@@ -367,6 +404,7 @@ jobs:
             echo "diff_output_file=$DIFF_OUTPUT_FILE" >> "$GITHUB_OUTPUT"
           fi
         env:
+          GH_TOKEN: ${{ steps.get-token-cve.outputs.token }}
           SCAN_DIR: ${{ github.workspace }}
           SCAN_SOURCE: ${{ inputs.mode == 'docker' && 'docker' || 'build-logic' }}
           IMAGE_NAME: ${{ inputs.image_name || inputs.version || 'unknown' }}
@@ -420,40 +458,7 @@ jobs:
           DIFF_OUTPUT_FILE: ${{ steps.cve-diff.outputs.diff_output_file || '' }}
 
       # --- CVE dispatch to investigate-cve workflow in liquibase-pro ---
-      # Requires a GitHub App token with actions:write on liquibase-pro.
-      # Uses the same OIDC -> AWS Secrets Manager -> GitHub App pattern as other
-      # cross-repo operations in build-logic (e.g. build-extension-jar.yml).
-      # All steps use continue-on-error: true so failures NEVER affect the scan result.
-
-      - name: Configure AWS credentials for vault access (CVE dispatch)
-        if: always() && steps.analyze.outputs.total_vulns > 0
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-        continue-on-error: true
-
-      - name: Get secrets from vault (CVE dispatch)
-        id: vault-secrets-cve
-        if: always() && steps.analyze.outputs.total_vulns > 0
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-        continue-on-error: true
-
-      - name: Get GitHub App token for liquibase-pro (CVE dispatch)
-        id: get-token-cve
-        if: always() && steps.analyze.outputs.total_vulns > 0
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: liquibase
-          repositories: liquibase-pro
-          permission-actions: write
-        continue-on-error: true
+      # Uses the GitHub App token obtained above (same token for diff + dispatch).
 
       - name: Dispatch new CVEs for investigation
         id: dispatch-new-cves


### PR DESCRIPTION
## Summary
- Moves vault/AWS/GitHub App token steps before the CVE diff step in the reusable vulnerability scan workflow
- Passes the GitHub App token to `diff-new-cves.sh` via `GH_TOKEN` so it can fetch `assessments.yaml` from `liquibase-pro`
- Adds `permission-contents: read` to the app token for cross-repo read access
- Fixes conservative scan failures when vulns are found but the diff script can't authenticate

## Test plan
- [ ] Trigger a Docker vulnerability scan that finds HIGH/CRITICAL CVEs and verify the diff step succeeds (no more `DIFF_FAILED=true`)
- [ ] Verify assessed CVEs result in a pass, unassessed CVEs result in a proper fail with dispatch
- [ ] Confirm CVE dispatch still works with the shared token

🤖 Generated with [Claude Code](https://claude.com/claude-code)