### PR TITLE
fix: add GH_TOKEN to CVE diff step for assessments.yaml fetch

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -367,6 +367,7 @@ jobs:
             echo "diff_output_file=$DIFF_OUTPUT_FILE" >> "$GITHUB_OUTPUT"
           fi
         env:
+          GH_TOKEN: ${{ github.token }} # Required for gh api to fetch vex/assessments.yaml from calling repo
           SCAN_DIR: ${{ github.workspace }}
           SCAN_SOURCE: ${{ inputs.mode == 'docker' && 'docker' || 'build-logic' }}
           IMAGE_NAME: ${{ inputs.image_name || inputs.version || 'unknown' }}


### PR DESCRIPTION
## Summary
Add `GH_TOKEN: ${{ github.token }}` to the `Run CVE diff` step env block so `gh api` can authenticate when fetching `vex/assessments.yaml`.

## Root Cause
PR #531 added the `diff-new-cves.sh` script which uses `gh api` to fetch `vex/assessments.yaml` from `liquibase-pro`. The `gh` CLI requires `GH_TOKEN` env var for authentication, but the step didn't set it. Without auth, the API call fails silently (stderr suppressed by `2>/dev/null`) and the scan fails conservatively: *"cannot determine assessment status; failing conservatively"*.

## Evidence
- `GITHUB_TOKEN` already has `Contents: read` on the calling repo (confirmed in [workflow logs](https://github.com/liquibase/liquibase-pro/actions/runs/24202723594/job/70653333146))
- Failures started after PR #531 merged on April 8
- Last success: `2026-04-09T08:00:38Z`, first failure: `2026-04-09T10:42:24Z`

## Test plan
- [ ] Re-run `build-secure-distribution` in liquibase-pro pointing to this branch
- [ ] Verify `diff-new-cves.sh` successfully fetches `assessments.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)