### PR TITLE
DAT-22809: Remove alias extraction from CVE diff script

### DIFF
--- a/scripts/vulnerability-scanning/diff-new-cves.sh
+++ b/scripts/vulnerability-scanning/diff-new-cves.sh
@@ -83,17 +83,16 @@ if [[ ! -s "$ASSESSMENTS_YAML_TMP" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2 — Extract assessed CVE IDs (vulnerability + aliases fields)
+# Step 2 — Extract assessed CVE IDs (vulnerability field only)
 # ---------------------------------------------------------------------------
 ASSESSED_TMP="$(mktemp /tmp/assessed-cves-XXXXXX.txt)"
 trap 'rm -f "$ASSESSMENTS_YAML_TMP" "$ASSESSED_TMP"' EXIT
 
 info "Extracting assessed CVE IDs from assessments.yaml..."
 
-# yq: emit each vulnerability and each alias on its own line, then deduplicate
 yq e '
   .assessments[]
-  | (.vulnerability, (.aliases // [] | .[]))
+  | .vulnerability
   | select(. != null)
 ' "$ASSESSMENTS_YAML_TMP" 2>/dev/null | sort -u > "$ASSESSED_TMP" || {
   warn "Failed to parse assessments.yaml with yq -- cannot assess CVEs; failing conservatively."
@@ -101,7 +100,7 @@ yq e '
 }
 
 ASSESSED_COUNT=$(wc -l < "$ASSESSED_TMP" | tr -d ' ')
-info "Found $ASSESSED_COUNT assessed CVE/GHSA IDs in assessments.yaml"
+info "Found $ASSESSED_COUNT assessed CVE IDs in assessments.yaml"
 
 # ---------------------------------------------------------------------------
 # Step 3 — Extract HIGH/CRITICAL CVEs from scan result JSON files

--- a/scripts/vulnerability-scanning/tests/test-diff-new-cves.sh
+++ b/scripts/vulnerability-scanning/tests/test-diff-new-cves.sh
@@ -78,9 +78,7 @@ author: "Liquibase Security Team"
 role: "Document Creator"
 
 assessments:
-  - vulnerability: GHSA-jvfv-hrrc-6q72
-    aliases:
-      - CVE-2022-0839
+  - vulnerability: CVE-2022-0839
     subcomponent: "pkg:maven/org.liquibase/liquibase-core"
     status: not_affected
     justification: vulnerable_code_not_present


### PR DESCRIPTION
## Summary
- Stop extracting aliases from `assessments.yaml` when building the assessed CVE set in `diff-new-cves.sh`
- Only the primary `vulnerability` ID is used for deduplication now
- Scanners resolve aliases to canonical CVE IDs, so alias-level matching is unnecessary

## Changes
- `diff-new-cves.sh`: Simplify yq query to extract only `.vulnerability` (no longer `.aliases[]`)
- `tests/test-diff-new-cves.sh`: Update fixture to use `CVE-2022-0839` as primary ID, remove `aliases` field

### Companion PR
- liquibase/liquibase-pro — removes alias logic from VEX generation scripts, agent prompt, and assessments.yaml

## Test plan
- [ ] Run `bash scripts/vulnerability-scanning/tests/test-diff-new-cves.sh` — all 7 suites should pass
- [ ] Verify unassessed CVEs are still correctly identified and dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)