### PR TITLE
DAT-22811: Add vex_enabled input to reusable vulnerability scan

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: true
+      vex_enabled:
+        description: 'Enable VEX suppression (only for liquibase-secure images)'
+        required: false
+        type: boolean
+        default: false
       build_logic_ref:
         description: 'build-logic branch/tag to use'
         required: false
@@ -171,6 +176,7 @@ jobs:
       # VEX — suppress assessed false positives
       # ============================================
       - name: Configure VEX for scanners
+        if: inputs.vex_enabled
         run: |
           # Trivy: configure VEX repository for auto-discovery
           mkdir -p ~/.trivy/vex
@@ -209,7 +215,7 @@ jobs:
           TRIVY_IMAGE_SRC: remote
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ github.token }}
-          TRIVY_VEX: repo
+          TRIVY_VEX: ${{ inputs.vex_enabled && 'repo' || '' }}
 
       - name: Trivy deep scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
@@ -223,7 +229,7 @@ jobs:
           exit-code: "0"
           cache-dir: ${{ github.workspace }}/.cache/trivy-v2
         env:
-          TRIVY_VEX: repo
+          TRIVY_VEX: ${{ inputs.vex_enabled && 'repo' || '' }}
 
       - name: Grype SBOM scan
         if: inputs.mode == 'docker' && inputs.generate_sbom


### PR DESCRIPTION
## Summary
- Add a `vex_enabled` boolean input (default: `false`) to the reusable vulnerability scan workflow
- VEX configuration for Trivy and Grype is now conditional on this input
- Only `liquibase-secure` images should pass `vex_enabled: true`

## Changes
- **New input**: `vex_enabled` (boolean, default `false`)
- **Configure VEX for scanners** step: now has `if: inputs.vex_enabled` condition
- **TRIVY_VEX** env var: set to `repo` only when `vex_enabled` is true, empty string otherwise

### Companion PR
- liquibase/docker — passes `vex_enabled: true` only for liquibase-secure matrix entry

## Test plan
- [ ] Verify scans with `vex_enabled: true` configure Trivy VEX repo and Grype VEX file
- [ ] Verify scans with `vex_enabled: false` (default) skip all VEX configuration
- [ ] Verify existing callers that don't pass `vex_enabled` default to no VEX (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)