### PR TITLE
fix: remove empty with: blocks left by #535

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,6 @@ jobs:
     if: ${{ inputs.sonar == true }}
     uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
     secrets: inherit
-    with:
 
   create-release:
     name: Create Release

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -713,4 +713,3 @@ jobs:
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
     secrets: inherit
-    with:


### PR DESCRIPTION
## Summary

- Removes two orphaned `with:` blocks in `pro-extension-test.yml` (sonar-pr job, line 716) and `create-release.yml` (sonar job, line 31) that were left behind by #535
- PR #535 deleted the `extraCommand` input from `sonar-scan.yml` and removed the corresponding `extraCommand: ${{ inputs.extraCommand }}` lines from callers, but left the `with:` keyword when it was the **only** entry underneath
- This causes GitHub Actions to fail with `Unexpected value ''` when parsing the workflow, blocking all calling repos (e.g. `liquibase-commercial-bigquery`)

## Root Cause

```yaml
# Before (broken — with: has no children)
    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
    secrets: inherit
    with:

# After (fixed — with: removed since no inputs are passed)
    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
    secrets: inherit
```

## Test plan

- [x] `actionlint` reports no new errors (only pre-existing SC2086 info-level shellcheck findings)
- [ ] Verify `liquibase-commercial-bigquery` test workflow can be queued after merge