### PR TITLE
[DAT-22660] Add composite action wrappers for centralized SHA management

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -13,18 +13,74 @@ inputs:
     description: 'Personal access token for the checkout'
     required: false
     default: ${{ github.token }}
+  ssh-key:
+    description: 'SSH key used to fetch the repository'
+    required: false
+    default: ''
+  ssh-known-hosts:
+    description: 'Known hosts in addition to the user and global host key database'
+    required: false
+    default: ''
+  ssh-strict:
+    description: 'Whether to perform strict host key checking'
+    required: false
+    default: 'true'
+  ssh-user:
+    description: 'The user to use when connecting to the remote SSH host'
+    required: false
+    default: 'git'
+  persist-credentials:
+    description: 'Whether to configure the token or SSH key with the local git config'
+    required: false
+    default: 'true'
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    required: false
+    default: ''
+  clean:
+    description: 'Whether to execute git clean -ffdx and git reset --hard HEAD before fetching'
+    required: false
+    default: 'true'
+  filter:
+    description: 'Partially clone against a given filter (e.g. tree:0, blob:none)'
+    required: false
+    default: ''
+  sparse-checkout:
+    description: 'Do a sparse checkout on given patterns (newline-separated)'
+    required: false
+    default: ''
+  sparse-checkout-cone-mode:
+    description: 'Specifies whether to use cone-mode when doing a sparse checkout'
+    required: false
+    default: 'true'
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags'
     required: false
     default: '1'
-  persist-credentials:
-    description: 'Whether to persist credentials for subsequent steps'
-    required: false
-    default: 'true'
-  submodules:
-    description: 'Whether to checkout submodules'
+  fetch-tags:
+    description: 'Whether to fetch tags, even if fetch-depth > 0'
     required: false
     default: 'false'
+  show-progress:
+    description: 'Whether to show progress status output when fetching'
+    required: false
+    default: 'true'
+  lfs:
+    description: 'Whether to download Git-LFS files'
+    required: false
+    default: 'false'
+  submodules:
+    description: 'Whether to checkout submodules: true to checkout submodules or recursive'
+    required: false
+    default: 'false'
+  set-safe-directory:
+    description: 'Add repository path as safe.directory for the runner user'
+    required: false
+    default: 'true'
+  github-server-url:
+    description: 'The base URL for the GitHub instance to clone from'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -33,6 +89,20 @@ runs:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
         token: ${{ inputs.token }}
-        fetch-depth: ${{ inputs.fetch-depth }}
+        ssh-key: ${{ inputs.ssh-key }}
+        ssh-known-hosts: ${{ inputs.ssh-known-hosts }}
+        ssh-strict: ${{ inputs.ssh-strict }}
+        ssh-user: ${{ inputs.ssh-user }}
         persist-credentials: ${{ inputs.persist-credentials }}
+        path: ${{ inputs.path }}
+        clean: ${{ inputs.clean }}
+        filter: ${{ inputs.filter }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        fetch-tags: ${{ inputs.fetch-tags }}
+        show-progress: ${{ inputs.show-progress }}
+        lfs: ${{ inputs.lfs }}
         submodules: ${{ inputs.submodules }}
+        set-safe-directory: ${{ inputs.set-safe-directory }}
+        github-server-url: ${{ inputs.github-server-url }}

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,38 @@
+name: 'Liquibase Checkout'
+description: 'Org-standard checkout — SHA managed centrally in build-logic'
+inputs:
+  repository:
+    description: 'Repository name with owner'
+    required: false
+    default: ${{ github.repository }}
+  ref:
+    description: 'The branch, tag or SHA to checkout'
+    required: false
+    default: ''
+  token:
+    description: 'Personal access token for the checkout'
+    required: false
+    default: ${{ github.token }}
+  fetch-depth:
+    description: 'Number of commits to fetch. 0 indicates all history for all branches and tags'
+    required: false
+    default: '1'
+  persist-credentials:
+    description: 'Whether to persist credentials for subsequent steps'
+    required: false
+    default: 'true'
+  submodules:
+    description: 'Whether to checkout submodules'
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+        token: ${{ inputs.token }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        persist-credentials: ${{ inputs.persist-credentials }}
+        submodules: ${{ inputs.submodules }}

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -81,10 +81,18 @@ inputs:
     description: 'The base URL for the GitHub instance to clone from'
     required: false
     default: ''
+outputs:
+  ref:
+    description: 'The branch, tag or SHA that was checked out'
+    value: ${{ steps.checkout.outputs.ref }}
+  commit:
+    description: 'The commit SHA that was checked out'
+    value: ${{ steps.checkout.outputs.commit }}
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - id: checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -1,0 +1,22 @@
+name: 'Liquibase Configure AWS Credentials'
+description: 'Org-standard AWS credential setup via OIDC — SHA managed centrally in build-logic'
+inputs:
+  role-to-assume:
+    description: 'The ARN of the role to assume'
+    required: true
+  aws-region:
+    description: 'AWS region'
+    required: false
+    default: 'us-east-1'
+  role-session-name:
+    description: 'Session name for the assumed role'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        role-session-name: ${{ inputs.role-session-name }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -1,15 +1,115 @@
 name: 'Liquibase Configure AWS Credentials'
 description: 'Org-standard AWS credential setup via OIDC — SHA managed centrally in build-logic'
 inputs:
-  role-to-assume:
-    description: 'The ARN of the role to assume'
-    required: true
   aws-region:
-    description: 'AWS region'
+    description: 'AWS Region, e.g. us-east-1'
     required: false
     default: 'us-east-1'
+  role-to-assume:
+    description: 'The Amazon Resource Name (ARN) of the role to assume'
+    required: true
+  aws-access-key-id:
+    description: 'AWS Access Key ID (provide if assuming a role using access keys)'
+    required: false
+    default: ''
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key (required if aws-access-key-id is provided)'
+    required: false
+    default: ''
+  aws-session-token:
+    description: 'AWS Session Token'
+    required: false
+    default: ''
+  web-identity-token-file:
+    description: 'Use the web identity token file from the provided file system path'
+    required: false
+    default: ''
+  role-chaining:
+    description: 'Use existing credentials from the environment to assume a new role'
+    required: false
+    default: ''
+  audience:
+    description: 'The audience to use for the OIDC provider'
+    required: false
+    default: 'sts.amazonaws.com'
+  http-proxy:
+    description: 'Proxy to use for the AWS SDK agent'
+    required: false
+    default: ''
+  no-proxy:
+    description: 'Hosts to skip for the proxy configuration'
+    required: false
+    default: ''
+  mask-aws-account-id:
+    description: 'Whether to mask the AWS account ID for these credentials as a secret value'
+    required: false
+    default: ''
+  role-duration-seconds:
+    description: 'Role duration in seconds (default is one hour)'
+    required: false
+    default: ''
+  role-external-id:
+    description: 'The external ID of the role to assume'
+    required: false
+    default: ''
   role-session-name:
-    description: 'Session name for the assumed role'
+    description: 'Role session name (default: GitHubActions)'
+    required: false
+    default: ''
+  role-skip-session-tagging:
+    description: 'Skip session tagging during role assumption'
+    required: false
+    default: ''
+  transitive-tag-keys:
+    description: 'Define a list of transitive tag keys to pass when assuming a role'
+    required: false
+    default: ''
+  inline-session-policy:
+    description: 'Define an inline session policy to use when assuming a role'
+    required: false
+    default: ''
+  managed-session-policies:
+    description: 'Define a list of managed session policies to use when assuming a role'
+    required: false
+    default: ''
+  output-credentials:
+    description: 'Whether to set credentials as step output'
+    required: false
+    default: ''
+  output-env-credentials:
+    description: 'Whether to export credentials as environment variables'
+    required: false
+    default: 'true'
+  unset-current-credentials:
+    description: 'Whether to unset the existing credentials in your runner'
+    required: false
+    default: ''
+  disable-retry:
+    description: 'Whether to disable the retry and backoff mechanism when assume role fails'
+    required: false
+    default: ''
+  retry-max-attempts:
+    description: 'The maximum number of attempts to retry the assume role call (default 12)'
+    required: false
+    default: ''
+  special-characters-workaround:
+    description: 'Retry fetching credentials until secret access key lacks special characters'
+    required: false
+    default: ''
+  use-existing-credentials:
+    description: 'Check if valid credentials exist in environment before fetching new ones'
+    required: false
+    default: ''
+  allowed-account-ids:
+    description: 'Comma-delimited list of expected AWS account IDs'
+    required: false
+    default: ''
+  force-skip-oidc:
+    description: 'Skip using GitHub OIDC provider even if id-token permission is set'
+    required: false
+    default: ''
+  action-timeout-s:
+    description: 'A global timeout in seconds for the action'
     required: false
     default: ''
 runs:
@@ -17,6 +117,31 @@ runs:
   steps:
     - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
       with:
-        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
+        web-identity-token-file: ${{ inputs.web-identity-token-file }}
+        role-chaining: ${{ inputs.role-chaining }}
+        audience: ${{ inputs.audience }}
+        http-proxy: ${{ inputs.http-proxy }}
+        no-proxy: ${{ inputs.no-proxy }}
+        mask-aws-account-id: ${{ inputs.mask-aws-account-id }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        role-external-id: ${{ inputs.role-external-id }}
         role-session-name: ${{ inputs.role-session-name }}
+        role-skip-session-tagging: ${{ inputs.role-skip-session-tagging }}
+        transitive-tag-keys: ${{ inputs.transitive-tag-keys }}
+        inline-session-policy: ${{ inputs.inline-session-policy }}
+        managed-session-policies: ${{ inputs.managed-session-policies }}
+        output-credentials: ${{ inputs.output-credentials }}
+        output-env-credentials: ${{ inputs.output-env-credentials }}
+        unset-current-credentials: ${{ inputs.unset-current-credentials }}
+        disable-retry: ${{ inputs.disable-retry }}
+        retry-max-attempts: ${{ inputs.retry-max-attempts }}
+        special-characters-workaround: ${{ inputs.special-characters-workaround }}
+        use-existing-credentials: ${{ inputs.use-existing-credentials }}
+        allowed-account-ids: ${{ inputs.allowed-account-ids }}
+        force-skip-oidc: ${{ inputs.force-skip-oidc }}
+        action-timeout-s: ${{ inputs.action-timeout-s }}

--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -112,10 +112,27 @@ inputs:
     description: 'A global timeout in seconds for the action'
     required: false
     default: ''
+outputs:
+  aws-account-id:
+    description: 'The AWS account ID for the provided credentials'
+    value: ${{ steps.configure.outputs.aws-account-id }}
+  aws-access-key-id:
+    description: 'The AWS access key ID for the provided credentials'
+    value: ${{ steps.configure.outputs.aws-access-key-id }}
+  aws-secret-access-key:
+    description: 'The AWS secret access key for the provided credentials'
+    value: ${{ steps.configure.outputs.aws-secret-access-key }}
+  aws-session-token:
+    description: 'The AWS session token for the provided credentials'
+    value: ${{ steps.configure.outputs.aws-session-token }}
+  aws-expiration:
+    description: 'The expiration time for the provided credentials'
+    value: ${{ steps.configure.outputs.aws-expiration }}
 runs:
   using: 'composite'
   steps:
-    - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+    - id: configure
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.role-to-assume }}

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -1,0 +1,38 @@
+name: 'Liquibase Setup Java'
+description: 'Org-standard Java setup — SHA managed centrally in build-logic'
+inputs:
+  java-version:
+    description: 'Java version to set up'
+    required: false
+    default: '17'
+  distribution:
+    description: 'Java distribution'
+    required: false
+    default: 'temurin'
+  cache:
+    description: 'Build tool cache (maven, gradle, sbt)'
+    required: false
+    default: 'maven'
+  server-id:
+    description: 'Maven server ID for settings.xml'
+    required: false
+    default: ''
+  server-username:
+    description: 'Environment variable for Maven server username'
+    required: false
+    default: ''
+  server-password:
+    description: 'Environment variable for Maven server password'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.distribution }}
+        cache: ${{ inputs.cache }}
+        server-id: ${{ inputs.server-id }}
+        server-username: ${{ inputs.server-username }}
+        server-password: ${{ inputs.server-password }}

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -2,27 +2,83 @@ name: 'Liquibase Setup Java'
 description: 'Org-standard Java setup — SHA managed centrally in build-logic'
 inputs:
   java-version:
-    description: 'Java version to set up'
+    description: 'The Java version to set up (whole or semver)'
     required: false
     default: '17'
+  java-version-file:
+    description: 'The path to the .java-version file'
+    required: false
+    default: ''
   distribution:
-    description: 'Java distribution'
+    description: 'Java distribution (e.g. temurin, zulu, adopt, corretto)'
     required: false
     default: 'temurin'
-  cache:
-    description: 'Build tool cache (maven, gradle, sbt)'
+  java-package:
+    description: 'The package type (jdk, jre, jdk+fx, jre+fx)'
     required: false
-    default: 'maven'
+    default: 'jdk'
+  architecture:
+    description: 'The architecture of the package (defaults to runner architecture)'
+    required: false
+    default: ''
+  jdkFile:
+    description: 'Path to where the compressed JDK is located'
+    required: false
+    default: ''
+  check-latest:
+    description: 'Set this option to check for the latest available version'
+    required: false
+    default: 'false'
   server-id:
-    description: 'Maven server ID for settings.xml'
+    description: 'ID of the distributionManagement repository in the pom.xml file'
     required: false
     default: ''
   server-username:
-    description: 'Environment variable for Maven server username'
+    description: 'Environment variable name for the username for Maven repository authentication'
     required: false
     default: ''
   server-password:
-    description: 'Environment variable for Maven server password'
+    description: 'Environment variable name for password/token for Maven repository authentication'
+    required: false
+    default: ''
+  settings-path:
+    description: 'Path to where the settings.xml file will be written (default ~/.m2)'
+    required: false
+    default: ''
+  overwrite-settings:
+    description: 'Overwrite the settings.xml file if it exists'
+    required: false
+    default: 'true'
+  gpg-private-key:
+    description: 'GPG private key to import'
+    required: false
+    default: ''
+  gpg-passphrase:
+    description: 'Environment variable name for the GPG private key passphrase'
+    required: false
+    default: ''
+  cache:
+    description: 'Name of the build platform to cache dependencies (maven, gradle, sbt)'
+    required: false
+    default: 'maven'
+  cache-dependency-path:
+    description: 'The path to a dependency file (pom.xml, build.gradle, build.sbt, etc.)'
+    required: false
+    default: ''
+  job-status:
+    description: 'Workaround to pass job status to post job step (not for manual setting)'
+    required: false
+    default: ${{ job.status }}
+  token:
+    description: 'Token used to authenticate when fetching version manifests from github.com'
+    required: false
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  mvn-toolchain-id:
+    description: 'Name of Maven Toolchain ID if the default name is not wanted'
+    required: false
+    default: ''
+  mvn-toolchain-vendor:
+    description: 'Name of Maven Toolchain Vendor if the default name is not wanted'
     required: false
     default: ''
 runs:
@@ -31,8 +87,22 @@ runs:
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ inputs.java-version }}
+        java-version-file: ${{ inputs.java-version-file }}
         distribution: ${{ inputs.distribution }}
-        cache: ${{ inputs.cache }}
+        java-package: ${{ inputs.java-package }}
+        architecture: ${{ inputs.architecture }}
+        jdkFile: ${{ inputs.jdkFile }}
+        check-latest: ${{ inputs.check-latest }}
         server-id: ${{ inputs.server-id }}
         server-username: ${{ inputs.server-username }}
         server-password: ${{ inputs.server-password }}
+        settings-path: ${{ inputs.settings-path }}
+        overwrite-settings: ${{ inputs.overwrite-settings }}
+        gpg-private-key: ${{ inputs.gpg-private-key }}
+        gpg-passphrase: ${{ inputs.gpg-passphrase }}
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        job-status: ${{ inputs.job-status }}
+        token: ${{ inputs.token }}
+        mvn-toolchain-id: ${{ inputs.mvn-toolchain-id }}
+        mvn-toolchain-vendor: ${{ inputs.mvn-toolchain-vendor }}

--- a/.github/actions/setup-java/action.yml
+++ b/.github/actions/setup-java/action.yml
@@ -81,10 +81,24 @@ inputs:
     description: 'Name of Maven Toolchain Vendor if the default name is not wanted'
     required: false
     default: ''
+outputs:
+  distribution:
+    description: 'Distribution of Java that has been installed'
+    value: ${{ steps.setup-java.outputs.distribution }}
+  version:
+    description: 'Actual version of the java environment that has been installed'
+    value: ${{ steps.setup-java.outputs.version }}
+  path:
+    description: 'Path to where the java environment has been installed (same as $JAVA_HOME)'
+    value: ${{ steps.setup-java.outputs.path }}
+  cache-hit:
+    description: 'A boolean value to indicate an exact match was found for the primary key'
+    value: ${{ steps.setup-java.outputs.cache-hit }}
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+    - id: setup-java
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ inputs.java-version }}
         java-version-file: ${{ inputs.java-version-file }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,28 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Also scan composite action directories for SHA updates
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/checkout"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-java"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/configure-aws-credentials"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-aws-vault"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
     directory: "/.github/actions/setup-aws-vault"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-google-credentials"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To reduce Dependabot noise and centralize SHA management, this repo provides **c
 - Composite actions can only contain **steps**, not jobs
 - Calling repos reference wrappers with `@main` — a bad merge to `build-logic` affects all repos simultaneously
 - Always test composite action changes thoroughly before merging
-- Each wrapper exposes only the most commonly used inputs — check the `action.yml` for available parameters
+- Each wrapper passes through the full set of upstream inputs — see the `action.yml` for all available parameters
 
 ## Example Build/Test/Release Extension Workflow
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,50 @@ If inputs are not provided, `'[8, 11, 17, 18]'` and `'["ubuntu-latest", "windows
 - **artifactId**: Value from the `artifactId` field in the pom file. i.e. `liquibase`
 - **version**: Value from the `version` field in the pom file. i.e `4.23.1`
 
+## 🧩 Composite Action Wrappers
+
+To reduce Dependabot noise and centralize SHA management, this repo provides **composite action wrappers** for high-frequency third-party actions. Instead of every repo pinning SHAs individually, repos reference the wrapper — and SHAs are updated in one place.
+
+### 📦 Available Wrappers
+
+| Wrapper | Wraps | Usage |
+|---------|-------|-------|
+| `checkout` | `actions/checkout` | `uses: liquibase/build-logic/.github/actions/checkout@main` |
+| `setup-java` | `actions/setup-java` | `uses: liquibase/build-logic/.github/actions/setup-java@main` |
+| `configure-aws-credentials` | `aws-actions/configure-aws-credentials` | `uses: liquibase/build-logic/.github/actions/configure-aws-credentials@main` |
+| `setup-aws-vault` | AWS credentials + Secrets Manager | `uses: liquibase/build-logic/.github/actions/setup-aws-vault@main` |
+| `setup-google-credentials` | Google Cloud credentials | `uses: liquibase/build-logic/.github/actions/setup-google-credentials@main` |
+
+### 🚀 Usage Example
+
+**Before** (every repo pins its own SHA):
+```yml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  with:
+    fetch-depth: 0
+```
+
+**After** (SHA managed centrally in build-logic):
+```yml
+- uses: liquibase/build-logic/.github/actions/checkout@main
+  with:
+    fetch-depth: 0
+```
+
+### 🔄 How SHA Updates Work
+
+1. Dependabot monitors each composite action directory in `build-logic`
+2. When a new version is released, Dependabot opens **one PR** in `build-logic`
+3. After merge, all calling repos automatically use the updated SHA on next run
+4. No more N Dependabot PRs across N repos for the same action update! 🎉
+
+### ⚠️ Important Notes
+
+- Composite actions can only contain **steps**, not jobs
+- Calling repos reference wrappers with `@main` — a bad merge to `build-logic` affects all repos simultaneously
+- Always test composite action changes thoroughly before merging
+- Each wrapper exposes only the most commonly used inputs — check the `action.yml` for available parameters
+
 ## Example Build/Test/Release Extension Workflow
 
 ```mermaid


### PR DESCRIPTION
## Summary
- Created 3 composite action wrappers for high-frequency third-party actions:
  - `actions/checkout` (v6.0.2)
  - `actions/setup-java` (v5.2.0)
  - `aws-actions/configure-aws-credentials` (v6.0.0)
- Updated `dependabot.yml` with grouping config and entries for each composite action directory
- Added documentation section to `README.md`

## Usage
Calling repos replace direct SHA pins:
```yaml
# Before
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

# After
- uses: liquibase/build-logic/.github/actions/checkout@main
```

## Test plan
- [x] Validated all 3 wrappers via liquibase-test-harness (run: https://github.com/liquibase/liquibase-test-harness/actions/runs/24413404967)
- [x] All jobs passed, composite actions downloaded and executed correctly

Jira: [DAT-22660](https://datical.atlassian.net/browse/DAT-22660)

[DAT-22660]: https://datical.atlassian.net/browse/DAT-22660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ