### PR TITLE
[DAT-22565] Add CODEOWNERS and harden dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS for liquibase/build-logic
+#
+# This repo contains reusable GitHub Actions workflows consumed by ~1000+
+# org repos via `@main`. Any change to .github/ is high blast-radius and
+# must be reviewed by the DevOps team.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+/.github/ @liquibase/liquibase-devops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       github-actions:
         patterns:
@@ -18,19 +22,39 @@ updates:
     directory: "/.github/actions/checkout"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-java"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/configure-aws-credentials"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-aws-vault"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-google-credentials"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "liquibase/liquibase-devops"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` assigning `@liquibase/liquibase-devops` as owner of `.github/`. Branch protection on `main`/`master` already has `requiresCodeOwnerReviews=true`, so this file immediately activates enforcement.
- Update `.github/dependabot.yml`: add `liquibase/liquibase-devops` as reviewers on every update group and standardize the commit-message prefix to `chore(deps)`.

## Why
build-logic is called via `@main` by ~1000+ org repos. A malicious push to `.github/` would fan out across the org. This PR closes part of [DAT-22565](https://datical.atlassian.net/browse/DAT-22565) (DevOps Security Enhancements 2026). Companion Terraform PR in `liquibase-infrastructure` syncs the source-of-truth with the repo's actual GitHub settings (Issues/Wiki/Projects already disabled in the UI).

Note: `allow_forking=false` was in the original ticket but cannot be enforced on public repos (GitHub only honors it for private/internal). Jake aware; skipping that piece.

## Test plan
- [ ] Verify CI passes
- [ ] After merge, open a trivial test PR touching `.github/` from a non-devops author and confirm the devops team is auto-requested
- [ ] Confirm the next Dependabot PR lists `liquibase/liquibase-devops` as reviewer and uses `chore(deps):` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22565]: https://datical.atlassian.net/browse/DAT-22565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ