### PR TITLE
fix: resolve GHSA/CVE aliases in CVE dedup

### DIFF
--- a/scripts/vulnerability-scanning/diff-new-cves.sh
+++ b/scripts/vulnerability-scanning/diff-new-cves.sh
@@ -202,15 +202,49 @@ info "After deduplication: $DEDUP_COUNT unique CVE IDs"
 
 # ---------------------------------------------------------------------------
 # Step 5 — Subtract assessed set (filter out CVEs already in assessments.yaml)
+#
+# Scanners may report CVE or GHSA ids. Assessments file stores one canonical
+# id per entry. To avoid dispatching a scan-reported GHSA whose CVE alias is
+# already assessed (or vice versa), resolve each unmatched id via
+# `gh api /advisories` and re-check. Cached per-run to minimize API calls.
 # ---------------------------------------------------------------------------
 UNASSESSED_TMP="$(mktemp /tmp/unassessed-cves-XXXXXX.jsonl)"
-trap 'rm -f "$ASSESSMENTS_YAML_TMP" "$ASSESSED_TMP" "$RAW_CVE_TMP" "$DEDUP_TMP" "$UNASSESSED_TMP"' EXIT
+ALIAS_CACHE_TMP="$(mktemp /tmp/alias-cache-XXXXXX.txt)"
+trap 'rm -f "$ASSESSMENTS_YAML_TMP" "$ASSESSED_TMP" "$RAW_CVE_TMP" "$DEDUP_TMP" "$UNASSESSED_TMP" "$ALIAS_CACHE_TMP"' EXIT
+
+# resolve_alias <id> — prints alias id (empty if none). Caches results.
+# Cache format: "<input_id> <alias_id_or_empty>" per line.
+resolve_alias() {
+  local id="$1"
+  local cached_line
+  cached_line=$(grep -m1 "^${id} " "$ALIAS_CACHE_TMP" 2>/dev/null || true)
+  if [[ -n "$cached_line" ]]; then
+    # Return everything after the first space (may be empty for negative cache).
+    echo "${cached_line#* }"
+    return 0
+  fi
+  local alias=""
+  if [[ "$id" == GHSA-* ]]; then
+    alias=$(gh api "/advisories/$id" --jq '.cve_id // ""' 2>/dev/null || true)
+  elif [[ "$id" == CVE-* ]]; then
+    alias=$(gh api "/advisories?cve_id=$id" --jq '.[0].ghsa_id // ""' 2>/dev/null || true)
+  fi
+  echo "$id $alias" >> "$ALIAS_CACHE_TMP"
+  echo "$alias"
+}
 
 while IFS= read -r entry; do
   cve_id=$(echo "$entry" | jq -r '.id')
-  if ! grep -qxF "$cve_id" "$ASSESSED_TMP"; then
-    echo "$entry"
+  if grep -qxF "$cve_id" "$ASSESSED_TMP"; then
+    continue
   fi
+  # Primary id not assessed — try alias (GHSA<->CVE) and re-check.
+  alias_id=$(resolve_alias "$cve_id")
+  if [[ -n "$alias_id" ]] && grep -qxF "$alias_id" "$ASSESSED_TMP"; then
+    info "Scan id $cve_id resolves to $alias_id (already assessed) -- skipping"
+    continue
+  fi
+  echo "$entry"
 done < "$DEDUP_TMP" > "$UNASSESSED_TMP"
 
 UNASSESSED_COUNT=$(wc -l < "$UNASSESSED_TMP" | tr -d ' ')


### PR DESCRIPTION
## Problem

Scanners (Grype, Trivy, Scout) report either CVE or GHSA IDs. After [DAT-22809](https://datical.atlassian.net/browse/DAT-22809) removed the `aliases` field from `assessments.yaml`, each entry has a single canonical id. When a scan reports a GHSA whose CVE alias is assessed (or vice versa), the dedup step in `diff-new-cves.sh` misses and the CVE is dispatched for investigation — producing a duplicate VEX PR.

### Real example

- Scan dispatched: `GHSA-rv64-5gf8-9qq8`, `GHSA-x4m4-345f-5h5g`
- Already assessed: `CVE-2026-34483`, `CVE-2026-34487` (lines 661, 674 of assessments.yaml)
- Result: duplicate PR [liquibase-pro#3556](https://github.com/liquibase/liquibase-pro/pull/3556) created

## Fix

Add alias resolution step in `diff-new-cves.sh`. When a scan id doesn't match the assessed set, resolve via `gh api /advisories`:

- GHSA-* → `.cve_id`
- CVE-* → `.[0].ghsa_id`

Re-check the assessed set with the resolved alias. Cached per-run to minimize API calls.

## Companion PR

- liquibase-pro: [fix: check GHSA/CVE alias in assessments.yaml before dispatching agent](https://github.com/liquibase/liquibase-pro/pulls?q=is%3Apr+head%3Afix%2Fcve-dedup-ghsa-resolution) — agent-side safety net

## Test plan
- [ ] Run a scan that reports GHSA-rv64-5gf8-9qq8 with CVE-2026-34483 already assessed — should NOT dispatch
- [ ] Run a scan that reports CVE-2026-34483 with CVE-2026-34483 already assessed — should NOT dispatch (unchanged)
- [ ] Run a scan reporting a truly new GHSA — should dispatch normally

[DAT-22809]: https://datical.atlassian.net/browse/DAT-22809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ