### PR TITLE
feat(docker): add reuse_existing_release input to reusable-docker-publish [DAT-22523]

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -86,6 +86,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_args:
+        description: 'Multi-line Docker `--build-arg` overrides (KEY=VALUE per line). Dockerfile ARG defaults apply for unset keys.'
+        required: false
+        type: string
+        default: ''
       sign_with_cosign:
         description: 'Enable cosign keyless signing (Secure ONLY)'
         required: false
@@ -319,6 +324,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
           sbom: ${{ inputs.generate_sbom }}
           provenance: ${{ inputs.provenance_mode }}
+          build-args: ${{ inputs.build_args }}
           tags: ${{ steps.generate-tags.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ inputs.image_source_url }}

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      extra_tags:
+        description: 'Newline-separated list of additional published tags to list in the Docker Images section (e.g. alpine variants like liquibase/liquibase:5.0.2-alpine). Each non-empty line appended as a bullet.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   publish-release:
@@ -126,6 +131,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           MINOR_VERSION: ${{ inputs.minor_version }}
           LATEST_TAG: ${{ inputs.latest_tag }}
+          EXTRA_TAGS: ${{ inputs.extra_tags }}
         run: |
           TAG="${RELEASE_TAG}"
 
@@ -157,6 +163,16 @@ jobs:
               printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${VERSION}"
               printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${MINOR_VERSION}"
               printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${LATEST_TAG}"
+            fi
+            # Append any extra tags (e.g. alpine variants) passed by caller.
+            # Each non-empty, non-blank line in EXTRA_TAGS becomes an additional bullet.
+            if [[ -n "${EXTRA_TAGS}" ]]; then
+              while IFS= read -r extra_tag; do
+                # Strip surrounding whitespace; skip blank lines
+                trimmed="$(echo "$extra_tag" | awk '{$1=$1}1')"
+                [[ -z "$trimmed" ]] && continue
+                printf "\n- \`%s\`" "$trimmed"
+              done <<< "$EXTRA_TAGS"
             fi
           } >> "${NOTES_FILE}"
 

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -140,8 +140,10 @@ jobs:
             MINOR_VERSION="${VERSION%.*}"
           fi
 
-          # Fetch current Release body
-          EXISTING_BODY="$(gh release view "${TAG}" --repo "${REPOSITORY}" --json body --jq '.body')"
+          # Fetch current Release body. `--jq '.body // ""'` coerces a null body
+          # (empty Release) to an empty string; without this, jq emits the literal
+          # word `null`, which then gets written back into the Release notes.
+          EXISTING_BODY="$(gh release view "${TAG}" --repo "${REPOSITORY}" --json body --jq '.body // ""')"
 
           # Build Docker images section (R6.6) using a temp file to avoid
           # multi-line string assignments that can confuse YAML parsers
@@ -149,10 +151,15 @@ jobs:
 
           # Idempotency guard: strip any pre-existing "## Docker Images" section
           # before re-appending. Handles retries / manual re-dispatch without
-          # duplicating the section. awk prints every line up to (but not
-          # including) the first "## Docker Images" header.
+          # duplicating the section. Skips the Docker block only (until the next
+          # "## " header) so any content added after it by another job or human
+          # is preserved.
           printf '%s' "${EXISTING_BODY}" \
-            | awk '/^## Docker Images[[:space:]]*$/ {exit} {print}' \
+            | awk '
+                /^## Docker Images[[:space:]]*$/ { skip = 1; next }
+                skip && /^## / { skip = 0 }
+                !skip { print }
+              ' \
             | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' \
             > "${NOTES_FILE}"
 
@@ -161,7 +168,11 @@ jobs:
             printf "\n\n## Docker Images\n\nThe following Docker images were published for this release:\n"
             if [[ -n "${IMAGE_NAME}" ]]; then
               printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${VERSION}"
-              printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${MINOR_VERSION}"
+              # Skip the minor_version bullet if it collapses to the same string
+              # as VERSION (e.g. when VERSION is already X.Y or malformed like "5").
+              if [[ "${MINOR_VERSION}" != "${VERSION}" ]]; then
+                printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${MINOR_VERSION}"
+              fi
               printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${LATEST_TAG}"
             fi
             # Append any extra tags (e.g. alpine variants) passed by caller.

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -141,10 +141,16 @@ jobs:
           # multi-line string assignments that can confuse YAML parsers
           NOTES_FILE="$(mktemp)"
 
-          # Write existing body first
-          printf '%s' "${EXISTING_BODY}" > "${NOTES_FILE}"
+          # Idempotency guard: strip any pre-existing "## Docker Images" section
+          # before re-appending. Handles retries / manual re-dispatch without
+          # duplicating the section. awk prints every line up to (but not
+          # including) the first "## Docker Images" header.
+          printf '%s' "${EXISTING_BODY}" \
+            | awk '/^## Docker Images[[:space:]]*$/ {exit} {print}' \
+            | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' \
+            > "${NOTES_FILE}"
 
-          # Append Docker section header and image list (R6.6)
+          # Append fresh Docker section header and image list (R6.6)
           {
             printf "\n\n## Docker Images\n\nThe following Docker images were published for this release:\n"
             if [[ -n "${IMAGE_NAME}" ]]; then

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -26,6 +26,29 @@ on:
         required: false
         type: string
         default: 'main'
+      reuse_existing_release:
+        description: >
+          When true: skip Release creation; locate existing Release by tag and append
+          Docker image notes to its body. Fails fast if no Release exists for the tag.
+          Default false preserves existing draft-create-then-publish behavior.
+        required: false
+        type: boolean
+        default: false
+      image_name:
+        description: 'Docker image name for the appended notes section, e.g. liquibase/liquibase (used when reuse_existing_release: true)'
+        required: false
+        type: string
+        default: ''
+      minor_version:
+        description: 'Major.minor version string, e.g. 5.0 (used when reuse_existing_release: true; derived from version if empty)'
+        required: false
+        type: string
+        default: ''
+      latest_tag:
+        description: 'Floating tag to list in Docker notes section, e.g. latest or alpine (used when reuse_existing_release: true)'
+        required: false
+        type: string
+        default: 'latest'
 
 jobs:
   publish-release:
@@ -73,7 +96,77 @@ jobs:
           echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
           echo "::notice::Publishing GitHub release for ${RELEASE_TYPE} on tag: ${TAG_NAME}"
 
+      # ── reuse_existing_release: true path ────────────────────────────────────
+      # Locate the existing Release (created by Maven), verify it exists, then
+      # append a Docker images section to its body. Does NOT create a new Release
+      # or call softprops/action-gh-release. Fails fast if no Release is found.
+
+      - name: Preflight — verify existing Release exists (reuse path)
+        if: ${{ inputs.reuse_existing_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          TAG="${RELEASE_TAG}"
+          if ! gh release view "${TAG}" --repo "${REPOSITORY}" &>/dev/null; then
+            echo "::error::reuse_existing_release: true but no Release exists for tag ${TAG}."
+            echo "::error::Ensure the Maven deploy-maven job completed successfully and created the Release before Docker publish runs."
+            exit 1
+          fi
+          echo "::notice::Release ${TAG} found — will append Docker notes."
+
+      - name: Append Docker images section to existing Release (reuse path)
+        if: ${{ inputs.reuse_existing_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_NAME: ${{ inputs.image_name }}
+          VERSION: ${{ inputs.version }}
+          MINOR_VERSION: ${{ inputs.minor_version }}
+          LATEST_TAG: ${{ inputs.latest_tag }}
+        run: |
+          TAG="${RELEASE_TAG}"
+
+          # Derive major.minor from version if minor_version input is empty
+          if [[ -z "${MINOR_VERSION}" ]]; then
+            MINOR_VERSION="${VERSION%.*}"
+          fi
+
+          # Fetch current Release body
+          EXISTING_BODY="$(gh release view "${TAG}" --repo "${REPOSITORY}" --json body --jq '.body')"
+
+          # Build Docker images section (R6.6) using a temp file to avoid
+          # multi-line string assignments that can confuse YAML parsers
+          NOTES_FILE="$(mktemp)"
+
+          # Write existing body first
+          printf '%s' "${EXISTING_BODY}" > "${NOTES_FILE}"
+
+          # Append Docker section header and image list (R6.6)
+          {
+            printf "\n\n## Docker Images\n\nThe following Docker images were published for this release:\n"
+            if [[ -n "${IMAGE_NAME}" ]]; then
+              printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${VERSION}"
+              printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${MINOR_VERSION}"
+              printf "\n- \`%s:%s\`" "${IMAGE_NAME}" "${LATEST_TAG}"
+            fi
+          } >> "${NOTES_FILE}"
+
+          gh release edit "${TAG}" \
+            --repo "${REPOSITORY}" \
+            --notes-file "${NOTES_FILE}"
+
+          rm -f "${NOTES_FILE}"
+          echo "::notice::Docker images section appended to Release ${TAG}."
+
+      # ── reuse_existing_release: false path (default / existing behavior) ─────
+      # Regression guard: all steps below run only when reuse_existing_release is
+      # false (the default). Existing Secure callers are fully unaffected.
+
       - name: Get Release Notes from Release Drafter Draft
+        if: ${{ !inputs.reuse_existing_release }}
         id: get-release-notes
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
@@ -118,6 +211,7 @@ jobs:
             }
 
       - name: Create GitHub Release (draft)
+        if: ${{ !inputs.reuse_existing_release }}
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           name: ${{ steps.release-tag.outputs.release_name }}
@@ -131,6 +225,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Release (draft=false, latest=true)
+        if: ${{ !inputs.reuse_existing_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release-tag.outputs.tag_name }}

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -17,10 +17,10 @@ on:
         type: string
         default: ''
       ghcr_tag:
-        description: 'GHCR tag used for the scan target'
+        description: 'GHCR tag used for the scan target; defaults to github.sha when empty'
         required: false
         type: string
-        default: ${{ github.sha }}
+        default: ''
       vex_enabled:
         description: 'Enable VEX passthrough to reusable-vulnerability-scan.yml (Secure ONLY)'
         required: false
@@ -92,7 +92,7 @@ jobs:
         env:
           SUFFIX: ${{ inputs.suffix }}
           IMAGE_NAME: ${{ inputs.image_name }}
-          GHCR_TAG: ${{ inputs.ghcr_tag }}
+          GHCR_TAG: ${{ inputs.ghcr_tag || github.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           # Sanitize suffix for use in image tag (strip leading dash)
@@ -166,7 +166,7 @@ jobs:
           BUILD_CONTEXT: ${{ inputs.build_context }}
           IMAGE_NAME: ${{ inputs.image_name }}
           SUFFIX: ${{ inputs.suffix }}
-          GHCR_TAG: ${{ inputs.ghcr_tag }}
+          GHCR_TAG: ${{ inputs.ghcr_tag || github.sha }}
         run: |
           docker build -f "$DOCKERFILE_PATH" \
             -t "${IMAGE_NAME}${SUFFIX}:${GHCR_TAG}" "$BUILD_CONTEXT"
@@ -211,7 +211,7 @@ jobs:
         uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
         with:
           command: cves
-          image: "${{ inputs.image_name }}${{ inputs.suffix }}:${{ inputs.ghcr_tag }}"
+          image: "${{ inputs.image_name }}${{ inputs.suffix }}:${{ inputs.ghcr_tag || github.sha }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           write-comment: true
           sarif-file: "scout-results.sarif"
@@ -227,7 +227,7 @@ jobs:
         uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
         with:
           command: cves
-          image: "${{ inputs.image_name }}${{ inputs.suffix }}:${{ inputs.ghcr_tag }}"
+          image: "${{ inputs.image_name }}${{ inputs.suffix }}:${{ inputs.ghcr_tag || github.sha }}"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           write-comment: true
           sarif-file: "scout-results.sarif"
@@ -241,7 +241,7 @@ jobs:
           VEX_ENABLED: ${{ inputs.vex_enabled }}
           IMAGE_NAME: ${{ inputs.image_name }}
           SUFFIX: ${{ inputs.suffix }}
-          GHCR_TAG: ${{ inputs.ghcr_tag }}
+          GHCR_TAG: ${{ inputs.ghcr_tag || github.sha }}
         run: |
           SCOUT_ARGS=(
             --format json

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: boolean
         default: true
+      build_context:
+        description: 'Docker build context path'
+        required: false
+        type: string
+        default: '.'
       build_logic_ref:
         description: 'Ref for liquibase/build-logic and nested reusable call'
         required: false
@@ -105,7 +110,7 @@ jobs:
       - name: Build and push to GHCR
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          context: .
+          context: ${{ inputs.build_context }}
           file: ${{ inputs.dockerfile_path }}
           push: true
           tags: ${{ steps.set-ghcr-ref.outputs.ghcr_image }}
@@ -158,12 +163,13 @@ jobs:
       - name: Build ${{ inputs.image_name }}${{ inputs.suffix }} from Dockerfile
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          BUILD_CONTEXT: ${{ inputs.build_context }}
           IMAGE_NAME: ${{ inputs.image_name }}
           SUFFIX: ${{ inputs.suffix }}
           GHCR_TAG: ${{ inputs.ghcr_tag }}
         run: |
           docker build -f "$DOCKERFILE_PATH" \
-            -t "${IMAGE_NAME}${SUFFIX}:${GHCR_TAG}" .
+            -t "${IMAGE_NAME}${SUFFIX}:${GHCR_TAG}" "$BUILD_CONTEXT"
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -152,6 +152,7 @@ jobs:
       packages: read
       security-events: write
       pull-requests: write
+      actions: read
 
     steps:
       - name: Checkout caller repository

--- a/.github/workflows/reusable-docker-test.yml
+++ b/.github/workflows/reusable-docker-test.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: 'docker/test-fixtures'
+      build_context:
+        description: 'Docker build context path'
+        required: false
+        type: string
+        default: '.'
       build_logic_ref:
         description: 'Ref for liquibase/build-logic checkout'
         required: false
@@ -59,9 +64,10 @@ jobs:
       - name: Build image from ${{ inputs.dockerfile_path }}
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          BUILD_CONTEXT: ${{ inputs.build_context }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
-          docker build -f "$DOCKERFILE_PATH" -t "liquibase/liquibase:$IMAGE_TAG" .
+          docker build -f "$DOCKERFILE_PATH" -t "liquibase/liquibase:$IMAGE_TAG" "$BUILD_CONTEXT"
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -235,11 +241,12 @@ jobs:
       - name: Test custom entrypoint
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          BUILD_CONTEXT: ${{ inputs.build_context }}
           TEST_FIXTURES_PATH: ${{ inputs.test_fixtures_path }}
           PRO_LICENSE_KEY: ${{ env.PRO_LICENSE_KEY }}
         run: |
           LOG_STRING="Update has been successful"
-          docker build -f "$DOCKERFILE_PATH" -t liquibase:test-entrypoint .
+          docker build -f "$DOCKERFILE_PATH" -t liquibase:test-entrypoint "$BUILD_CONTEXT"
           docker build -f "$(pwd)/build-logic/$TEST_FIXTURES_PATH/Dockerfile" \
             -t liquibase:test "$(pwd)/build-logic/$TEST_FIXTURES_PATH/"
           docker run --rm --env LIQUIBASE_LICENSE_KEY="$PRO_LICENSE_KEY" --name liquibase-test \


### PR DESCRIPTION
## Summary
Enables `reusable-docker-publish.yml` to append notes to an existing GitHub Release instead of creating a new one. Prerequisite for DAT-22523 (community Dockerfile migration to `liquibase/liquibase`) where Docker release must piggyback on Maven's `v{version}` tag.

## Behavior
- `reuse_existing_release: false` (default) — existing behavior, no regression
- `reuse_existing_release: true` — locate existing Release by tag, append Docker section to body
- If `true` and no Release exists — FAIL FAST (no silent fallback)

## New inputs (all optional, only used when reuse_existing_release: true)
- `image_name` — Docker image name for the notes section (e.g. `liquibase/liquibase`)
- `minor_version` — major.minor string (derived from `version` if empty)
- `latest_tag` — floating tag to list in the section (default `latest`)

## Test plan
- [ ] Existing callers (`liquibase/docker` `create-release.yml`) continue to work with default `false`
- [ ] New caller (`liquibase/liquibase` `docker-release.yml`) uses `reuse_existing_release: true` (validated in DAT-22523 Phase 2)
- [ ] Fail-fast when Release missing: test via `workflow_dispatch` with invalid version
- [ ] `actionlint` + `yq` pass clean (validated locally before commit)

## Jira
DAT-22523 (parent epic DAT-22522)