### PR TITLE
feat(docker): add build_context input to reusable-docker-build-qa

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -600,8 +600,10 @@ jobs:
       - name: Build and push Docker image
         if: ${{ steps.validate-build.outcome == 'success' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        env:
+          BUILD_CONTEXT: ${{ inputs.build_context }}
         with:
-          context: ${{ inputs.build_context }}
+          context: ${{ env.BUILD_CONTEXT }}
           file: ${{ inputs.dockerfile_path }}
           push: true
           platforms: ${{ inputs.platforms }}

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: 'main'
+      build_context:
+        description: 'Docker build context path. Default "." matches the legacy layout where Dockerfiles live at the repo root. Set to e.g. "docker/" when the Dockerfile lives in a subdirectory and uses paths relative to that subdirectory in COPY/ADD instructions.'
+        required: false
+        type: string
+        default: '.'
     outputs:
       image_tag:
         description: 'Tag used for the pushed image (branch name or RC version)'
@@ -596,7 +601,7 @@ jobs:
         if: ${{ steps.validate-build.outcome == 'success' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          context: .
+          context: ${{ inputs.build_context }}
           file: ${{ inputs.dockerfile_path }}
           push: true
           platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
## Summary

Mirrors the change #556 made for the production reusables (\`reusable-docker-build\`, \`-test\`, \`-scan\`, \`-publish\`), now applied to the QA reusable.

\`docker/build-push-action\` defaulted to \`context: .\` (repo root). That worked while the QA Dockerfile lived at the repo root on \`liquibase/docker\`. After DAT-22524 migrated the Secure Dockerfile to \`liquibase/liquibase-pro/docker/Dockerfile\` (with sibling files \`docker/docker-entrypoint.sh\` and \`docker/liquibase.docker.properties\` referenced by relative \`COPY\` paths), the build needs \`context: docker/\` to resolve those copies.

## Failure that prompted this

\`liquibase-pro\` rc-release-orchestrator [#132](https://github.com/liquibase/liquibase-pro/actions/runs/25046052311) → build-qa-docker [run 25052879076](https://github.com/liquibase/liquibase-pro/actions/runs/25052879076):

\`\`\`
#13 ERROR: failed to calculate checksum of ref ...: \"/liquibase.docker.properties\": not found
Dockerfile:63
ERROR: failed to build: failed to solve: failed to compute cache key: ... \"/liquibase.docker.properties\": not found
\`\`\`

## Backwards compatibility

\`build_context\` defaults to \`.\`, so existing callers that haven't moved their Dockerfiles into subdirectories continue to work unchanged.

## Test plan

- [ ] Open the companion PR on \`liquibase-pro\` (\`build-qa-docker.yml\` to pass \`build_context: docker/\`).
- [ ] Once both merged, re-dispatch \`rc-release-orchestrator.yml -f version=5.1.3-RC99\`. The \`Build RC Docker Images\` step should clear the COPY error and build successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)