### PR TITLE
feat(jira): reusable workflow to auto-transition Jira issue on PR merge [DAT-22622]

### DIFF
--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -13,7 +13,7 @@ name: "Jira: Transition issue on PR merge"
 #
 #   name: Auto-transition Jira on PR merge
 #   on:
-#     pull_request_target:
+#     pull_request:
 #       types: [closed]
 #       branches: [main]   # or [master]
 #   jobs:
@@ -21,6 +21,14 @@ name: "Jira: Transition issue on PR merge"
 #       if: github.event.pull_request.merged == true
 #       uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
 #       secrets: inherit
+#
+# Use `pull_request` (not `pull_request_target`). This workflow only reads
+# the event payload and calls Jira via REST — never checks out PR code —
+# so the extra privilege of `pull_request_target` is unnecessary. Side
+# effect: PRs from forks won't have secrets and the workflow will skip
+# the transition; that's the correct trade-off for a public-fork
+# scenario (we don't want to auto-transition tickets for community PRs
+# anyway).
 #
 # Required org-level setup (one-time):
 #   /vault/liquibase must contain

--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -1,0 +1,185 @@
+name: "Jira: Transition issue on PR merge"
+
+# Reusable workflow. When called from a PR-closed workflow in a downstream
+# repo (with the PR merged), extracts the Jira ticket key from the PR title
+# or branch name and transitions the linked ticket to a target status.
+#
+# Idempotent + best-effort: if the ticket is already in the target status,
+# or the workflow doesn't allow a transition from the current status, this
+# logs a warning and exits the job successfully. Real Jira / auth errors
+# fail the job loudly.
+#
+# Caller pattern (in any repo):
+#
+#   name: Auto-transition Jira on PR merge
+#   on:
+#     pull_request_target:
+#       types: [closed]
+#       branches: [main]   # or [master]
+#   jobs:
+#     transition:
+#       if: github.event.pull_request.merged == true
+#       uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
+#       secrets: inherit
+#
+# Required org-level setup (one-time):
+#   /vault/liquibase must contain
+#       JIRA_SERVICE_ACCOUNT_EMAIL       — service-account email
+#       JIRA_SERVICE_ACCOUNT_API_TOKEN   — token from id.atlassian.com
+#   The service account needs Browse + Transition Issues on every project
+#   you want auto-transitioned.
+
+on:
+  workflow_call:
+    inputs:
+      project_keys:
+        description: "Comma-separated Jira project keys to recognise. First match wins on PRs that mention multiple."
+        required: false
+        type: string
+        default: "TECHOPS,SECURE,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
+      target_status:
+        description: "Status name to transition to (case-insensitive)."
+        required: false
+        type: string
+        default: "Done"
+      jira_base_url:
+        description: "Jira Cloud base URL."
+        required: false
+        type: string
+        default: "https://datical.atlassian.net"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  transition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get Jira service-account credentials from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Transition Jira ticket
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PROJECT_KEYS: ${{ inputs.project_keys }}
+          TARGET_STATUS: ${{ inputs.target_status }}
+          JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+          # parse-json-secrets exposes vault keys as env vars; pass them
+          # under non-prefixed names for the script.
+          JIRA_EMAIL: ${{ env.JIRA_SERVICE_ACCOUNT_EMAIL }}
+          JIRA_TOKEN: ${{ env.JIRA_SERVICE_ACCOUNT_API_TOKEN }}
+        with:
+          script: |
+            const { pull_request } = context.payload;
+            const projectKeys = process.env.PROJECT_KEYS
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const targetStatus = process.env.TARGET_STATUS;
+            const baseUrl = process.env.JIRA_BASE_URL.replace(/\/$/, '');
+            const email = process.env.JIRA_EMAIL;
+            const token = process.env.JIRA_TOKEN;
+
+            if (!email || !token) {
+              core.setFailed(
+                'JIRA_SERVICE_ACCOUNT_EMAIL or JIRA_SERVICE_ACCOUNT_API_TOKEN ' +
+                'not set in /vault/liquibase'
+              );
+              return;
+            }
+
+            // First match wins; case-insensitive on the key prefix.
+            const keyRegex = new RegExp(`(${projectKeys.join('|')})-\\d+`, 'i');
+            const haystack = `${pull_request.title || ''} ${pull_request.head?.ref || ''}`;
+            const match = haystack.match(keyRegex);
+
+            if (!match) {
+              core.warning(
+                `PR #${pull_request.number} has no Jira ticket key in title or branch ` +
+                `(allowed: ${projectKeys.join(', ')})`
+              );
+              return;
+            }
+
+            const key = match[0].toUpperCase();
+            console.log(`Found ticket key: ${key}`);
+
+            const auth = `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
+            const headers = {
+              Authorization: auth,
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            };
+
+            // 1. Read current status
+            const issueResp = await fetch(
+              `${baseUrl}/rest/api/3/issue/${key}?fields=status`,
+              { headers }
+            );
+            if (issueResp.status === 404) {
+              core.warning(`${key} not found in Jira (404) — typo or non-existent issue`);
+              return;
+            }
+            if (!issueResp.ok) {
+              core.setFailed(`GET issue ${key} failed: ${issueResp.status} ${await issueResp.text()}`);
+              return;
+            }
+            const issue = await issueResp.json();
+            const currentStatus = issue.fields?.status?.name;
+            if (!currentStatus) {
+              core.warning(`${key} has no readable status; skipping`);
+              return;
+            }
+            if (currentStatus.toLowerCase() === targetStatus.toLowerCase()) {
+              console.log(`${key} already in '${currentStatus}'; no transition needed`);
+              return;
+            }
+
+            // 2. Find a transition that lands in the target status
+            const transResp = await fetch(
+              `${baseUrl}/rest/api/3/issue/${key}/transitions`,
+              { headers }
+            );
+            if (!transResp.ok) {
+              core.setFailed(`GET transitions on ${key} failed: ${transResp.status} ${await transResp.text()}`);
+              return;
+            }
+            const transitions = (await transResp.json()).transitions || [];
+            const t = transitions.find(
+              t => (t.to?.name || '').toLowerCase() === targetStatus.toLowerCase()
+            );
+            if (!t) {
+              core.warning(
+                `No transition from '${currentStatus}' to '${targetStatus}' on ${key}; ` +
+                `the workflow may not allow it from the current status. Skipping.`
+              );
+              return;
+            }
+
+            // 3. POST the transition
+            const postResp = await fetch(
+              `${baseUrl}/rest/api/3/issue/${key}/transitions`,
+              {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ transition: { id: t.id } }),
+              }
+            );
+            if (!postResp.ok) {
+              core.setFailed(
+                `Transition POST on ${key} failed: ${postResp.status} ${await postResp.text()}`
+              );
+              return;
+            }
+            console.log(`Transitioned ${key}: '${currentStatus}' -> '${targetStatus}'`);

--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -89,7 +89,23 @@ jobs:
           JIRA_TOKEN: ${{ env.JIRA_SERVICE_ACCOUNT_API_TOKEN }}
         with:
           script: |
+            // Defense in depth: callers should gate the job on
+            // `github.event.pull_request.merged == true`, but if a future
+            // caller wires this in without that condition we still want a
+            // safe no-op rather than a Jira write on a closed-without-merge
+            // event or a non-PR event.
             const { pull_request } = context.payload;
+            if (!pull_request) {
+              core.warning('No pull_request payload on this event; skipping');
+              return;
+            }
+            if (!pull_request.merged) {
+              console.log(
+                `PR #${pull_request.number} closed without merge; skipping Jira transition`
+              );
+              return;
+            }
+
             const projectKeys = process.env.PROJECT_KEYS
               .split(',')
               .map(s => s.trim())
@@ -107,8 +123,16 @@ jobs:
               return;
             }
 
-            // First match wins; case-insensitive on the key prefix.
-            const keyRegex = new RegExp(`(${projectKeys.join('|')})-\\d+`, 'i');
+            // First match wins; case-insensitive on the key prefix. Word
+            // boundaries prevent matching inside a longer token (e.g.
+            // `DAT-123` inside `NOTDAT-123`). Project keys are regex-
+            // escaped in case any contain special characters in the
+            // future.
+            const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const keyRegex = new RegExp(
+              `\\b(?:${projectKeys.map(escapeRegex).join('|')})-\\d+\\b`,
+              'i'
+            );
             const haystack = `${pull_request.title || ''} ${pull_request.head?.ref || ''}`;
             const match = haystack.match(keyRegex);
 

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -600,8 +600,10 @@ jobs:
       - name: Build and push Docker image
         if: ${{ steps.validate-build.outcome == 'success' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        env:
+          BUILD_CONTEXT: ${{ inputs.build_context }}
         with:
-          context: ${{ inputs.build_context }}
+          context: ${{ env.BUILD_CONTEXT }}
           file: ${{ inputs.dockerfile_path }}
           push: true
           platforms: ${{ inputs.platforms }}

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: 'main'
+      build_context:
+        description: 'Docker build context path. Default "." matches the legacy layout where Dockerfiles live at the repo root. Set to e.g. "docker/" when the Dockerfile lives in a subdirectory and uses paths relative to that subdirectory in COPY/ADD instructions.'
+        required: false
+        type: string
+        default: '.'
     outputs:
       image_tag:
         description: 'Tag used for the pushed image (branch name or RC version)'
@@ -596,7 +601,7 @@ jobs:
         if: ${{ steps.validate-build.outcome == 'success' }}
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          context: .
+          context: ${{ inputs.build_context }}
           file: ${{ inputs.dockerfile_path }}
           push: true
           platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
## Summary

Adds a reusable workflow (`workflow_call`) that downstream Liquibase repos can opt into to auto-transition a linked Jira ticket to **Done** when a PR merges.

Sibling to the existing [`jira-ticket-linker.yml`](https://github.com/liquibase/build-logic/blob/main/.github/workflows/jira-ticket-linker.yml) — that one annotates PR descriptions on open; this one transitions the ticket on merge. Together they cover the full PR ↔ Jira lifecycle.

Step 1 of Unified Workflow v0.2 release automation (deck slide 13) — see [DAT-22622](https://datical.atlassian.net/browse/DAT-22622).

## Caller pattern

```yaml
name: Auto-transition Jira on PR merge

on:
  pull_request_target:
    types: [closed]
    branches: [main]   # or master

jobs:
  transition:
    if: github.event.pull_request.merged == true
    uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
    secrets: inherit
```

That's it — 13 lines. The reusable workflow handles credential lookup, regex extraction, transition discovery, and idempotency.

## Inputs (all optional)

| Input | Default | Notes |
|---|---|---|
| `project_keys` | `TECHOPS,SECURE,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS` | Comma-separated project keys to recognise. First match wins on PRs that mention multiple. |
| `target_status` | `Done` | Status name (case-insensitive). Pass `In Review` etc. for non-merge use cases. |
| `jira_base_url` | `https://datical.atlassian.net` | Override only if testing against a different Jira tenant. |

## Behaviour

Idempotent + best-effort:
- Already in target status → log + exit 0
- No transition path from current status → `core.warning` + exit 0
- No ticket key in PR title or branch → `core.warning` + exit 0
- Real Jira / auth errors → `core.setFailed` (red ❌)

This makes the merge-PR check non-blocking. By the time the workflow runs, the PR is already merged; failing the run loudly on non-actionable cases would just create noise.

## Required org-admin setup (one-time)

Add to `/vault/liquibase`:

- `JIRA_SERVICE_ACCOUNT_EMAIL` — service-account email at liquibase.com
- `JIRA_SERVICE_ACCOUNT_API_TOKEN` — token from <https://id.atlassian.com/manage-profile/security/api-tokens> (logged in as the service account)

Service-account permissions on every project you want auto-transitioned: `Browse Projects` + `Transition Issues`. Easiest grant: a dedicated `jira-bots` group, or `jira-administrators` as a stopgap.

## Implementation notes

- Uses `actions/github-script` with native Node 20 `fetch` — same pattern as `jira-ticket-linker.yml`. No external Python or curl required.
- All actions SHA-pinned (matches the rest of build-logic).
- `runs-on: ubuntu-latest` — broad compatibility; callers can wrap if they need a specific runner.
- Built-in protection: the regex requires `<KEY>-<digits>`, so loose mentions of project names elsewhere won't match.

## First adopter

[liquibase/liquibase-infrastructure#3627](https://github.com/liquibase/liquibase-infrastructure/pull/3627) — once that PR is updated to call this reusable workflow, every PR merge into `liquibase-infrastructure/master` will exercise this code path. Other repos can opt in by dropping the 13-line caller above into their `.github/workflows/`.

## Test plan

- [ ] After merge, update [liquibase-infrastructure PR #3627](https://github.com/liquibase/liquibase-infrastructure/pull/3627) to use `@main`
- [ ] Merge that PR with title `[DAT-22622] ...` — workflow fires on its own merge, transitions DAT-22622 to Done (perfect end-to-end)
- [ ] Open a follow-up PR on liquibase-infrastructure with no ticket key in title or branch — workflow logs warning, doesn't fail
- [ ] Open a PR with a typo'd key (`TECHOPS-99999999`) — workflow logs `404` warning, doesn't fail
- [ ] Try `actionlint .github/workflows/jira-transition-on-pr-merge.yml` locally before merging

## Tickets

- [DAT-22622](https://datical.atlassian.net/browse/DAT-22622) — primary
- [DAT-22874](https://datical.atlassian.net/browse/DAT-22874) — convention reference (lives in liquibase-infrastructure/jira/docs/pr-branch-conventions.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22622]: https://datical.atlassian.net/browse/DAT-22622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DAT-22622]: https://datical.atlassian.net/browse/DAT-22622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ