### PR TITLE
fix(pro-extension-test): unquote $EXTRA_MAVEN_ARGS in Run Tests for proper multi-arg handling [DAT-22961]

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -34,7 +34,13 @@ on:
         default: ""
         type: string
       extraMavenArgs:
-        description: "Specify it if you want to run an extra maven argument"
+        description: >-
+          Extra Maven arg(s) appended to test invocations. The value is
+          word-split on whitespace so multi-token use is supported (e.g.
+          '-pl :liquibase-aws-extension -am'). Values containing internal
+          spaces — e.g. quoted property arguments like '-DargLine="-Xmx512m
+          -XX:+UseG1GC"' — are NOT supported via this input; pass them
+          through alternative channels.
         required: false
         default: ""
         type: string

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -725,5 +725,5 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.skipSonar && !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@DAT-22961-sonar-host-url
+    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
     secrets: inherit

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -63,6 +63,20 @@ on:
         required: false
         default: ""
         type: string
+      # TODO - debate (DAT-22596): per-module Sonar in a monorepo currently
+      # fails with `Unable to determine structure of project... "Liquibase"
+      # is orphan` because each per-module CI runs `mvn ... sonar:sonar`
+      # over a partial reactor (-pl :module -am). Letting callers opt out
+      # via skipSonar is a stopgap; the long-term resolution belongs to
+      # TechOps/DevOps under DAT-22596 (CI/CD selective module testing for
+      # PRs and nightly builds, assigned to Filipe Lautert), where Sonar
+      # would run from the full-reactor nightly path instead of per-module.
+      # Mirrors the existing skipSonar input on os-extension-test.yml.
+      skipSonar:
+        description: "Skip SonarQube analysis"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -709,7 +723,7 @@ jobs:
             }
 
   sonar-pr:
-    if: ${{ !inputs.nightly }}
+    if: ${{ !inputs.skipSonar && !inputs.nightly }}
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@DAT-22961-sonar-host-url
     secrets: inherit

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -445,7 +445,7 @@ jobs:
           MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
         run: |
           if [ -n "$EXTRA_MAVEN_ARGS" ]; then
-            mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS"
+            mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS
           else
             mvn -B test -P "$MAVEN_PROFILES"
           fi
@@ -463,7 +463,7 @@ jobs:
           MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
         run: |
           if [ -n "$EXTRA_MAVEN_ARGS" ]; then
-            mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS" "-Dliquibase.version=master-SNAPSHOT"
+            mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=master-SNAPSHOT"
           else
             mvn -B test -P "$MAVEN_PROFILES" "-Dliquibase.version=master-SNAPSHOT"
           fi

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -711,5 +711,5 @@ jobs:
   sonar-pr:
     if: ${{ !inputs.nightly }}
     needs: [unit-test]
-    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@DAT-22961-sonar-host-url
     secrets: inherit


### PR DESCRIPTION
## Summary

Fix the `Run Tests` step in `pro-extension-test.yml` so multi-token `extraMavenArgs` (e.g. `-pl :module -am`) tokenize via bash word-splitting, aligning with the existing `Build and Package` step pattern.

## Problem

Both `Run Tests` step variants (non-nightly + nightly) currently use:

```bash
mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS"
```

The double-quotes around `"$EXTRA_MAVEN_ARGS"` collapse a multi-token value into a single shell argument with embedded spaces. Maven's CLI parser then:

1. Sees the leading `-P` and treats the rest of the string as the profile name.
2. Profile lookup fails silently (warning, not error).
3. The `-pl` scoping intent is never recognized.

Net effect for a caller like `extraMavenArgs: '-pl :liquibase-hashicorp-vault -am'`: tests run on the entire active reactor (often dozens of modules) instead of the intended single-module + dependencies scope.

The `Build and Package` step in the same file uses unquoted `${EXTRA_MAVEN_ARGS}` and tokenizes correctly — this PR aligns Run Tests with the Build pattern.

## Diff

```diff
@@ Run Tests (non-nightly) @@
-      mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS"
+      mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS

@@ Run Tests (nightly) @@
-      mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS" "-Dliquibase.version=master-SNAPSHOT"
+      mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=master-SNAPSHOT"
```

`"$MAVEN_PROFILES"` (comma-separated profile names, no embedded spaces) and `"-Dliquibase.version=master-SNAPSHOT"` (literal single arg) remain quoted as before.

## Compatibility

| Caller pattern | Before | After |
|---|---|---|
| Single-arg, e.g. `-DskipTests=true` | parses correctly | parses correctly (no change) |
| Multi-arg, e.g. `-pl :module -am` | silently broken — entire string treated as one arg, `-pl` scoping lost | parses correctly via word-splitting |
| Args with internal spaces inside one token | already not handled correctly | needs shell-escape conventions (caller responsibility) |

No caller currently working will break — multi-arg callers were already silently broken; this PR fixes them.

## Context

Encountered while restoring per-module CI for monorepo extensions under [DAT-22961](https://datical.atlassian.net/browse/DAT-22961). Without this fix, the selective-module pattern (`-pl :module -am`) recommended by [TECHOPS-254](https://datical.atlassian.net/browse/TECHOPS-254) doesn't actually scope tests; instead Maven runs the whole active profile reactor, exposing pre-existing test failures in unrelated upstream modules and yielding misleading red CI signals.

## Test plan

- [ ] After merge, re-run liquibase-pro PR #3610 (vault) — confirm the Test step's `Reactor Build Order` shows vault + its dependencies (≈ 8–12 modules), not all 51 distribution-profile modules.
- [ ] Confirm a single-arg caller of `pro-extension-test.yml` (e.g. anything passing `-DskipTests` or empty extraMavenArgs) is unaffected.

[DAT-22961]: https://datical.atlassian.net/browse/DAT-22961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ