### PR TITLE
fix(os-extension-test): forward extraMavenArgs to Build and Package step [DAT-22961]

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -128,7 +128,9 @@ jobs:
 
       - name: Build and Package latest liquibase version
         if: ${{ inputs.nightly }}
-        run: mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
+        env:
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+        run: mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=master-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
@@ -146,7 +148,9 @@ jobs:
 
       - name: Build and Package
         if: ${{ !inputs.nightly }}
-        run: mvn -B dependency:go-offline clean package -DskipTests=true
+        env:
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+        run: mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS}
 
       - name: Get Project Artifact Name
         id: get-artifact-name


### PR DESCRIPTION
## Summary

Forward `extraMavenArgs` to both `Build and Package` step variants (non-nightly + nightly) in `os-extension-test.yml`, matching the existing test-step convention in the same file.

## Problem

Both Build and Package step variants currently hardcode the mvn invocation:

```bash
mvn -B dependency:go-offline clean package -DskipTests=true
mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"   # nightly
```

There is no reference to `inputs.extraMavenArgs` at build time. Monorepo callers that pass `extraMavenArgs="-pl :module -am"` to scope the build have the scoping silently dropped — mvn walks the full active reactor.

In `liquibase/liquibase-pro` this pulls in `liquibase-pro-integration-tests`'s `<scope>system</scope>` dependency on `db2-z-licence` (resolved via local `<systemPath>`). `dependency:go-offline` tries to fetch system-scope deps from remote repos and the build fails:

```
[ERROR] Failed to execute goal on project liquibase-pro-integration-tests:
Could not resolve dependencies for project com.liquibase:liquibase-pro-integration-tests:jar:5.2.0-SNAPSHOT
```

## Diff

```diff
@@ Build and Package latest liquibase version (nightly) @@
-        run: mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
+        env:
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+        run: mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=master-SNAPSHOT"

@@ Build and Package (non-nightly) @@
-        run: mvn -B dependency:go-offline clean package -DskipTests=true
+        env:
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+        run: mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS}
```

`\${EXTRA_MAVEN_ARGS}` is left unquoted so bash word-splits multi-token values (e.g. `-pl :module -am` → 3 args). This matches the existing test/integration-test steps in this same file (lines 270, 276, 282, 288), which already use the unquoted form.

## Compatibility

| Caller pattern | Before | After |
|---|---|---|
| Empty `extraMavenArgs` (default) | builds full reactor | builds full reactor (no change) |
| Single-arg, e.g. `-DskipTests=true` | ignored at build time | applied at build time |
| Multi-arg, e.g. `-pl :module -am` | ignored — full reactor walked | scoped via word-splitting |

No caller currently working will break — non-empty `extraMavenArgs` was already silently dropped at build time; this PR honors it.

## Context

Encountered while restoring per-module CI for monorepo extensions under [DAT-22961](https://datical.atlassian.net/browse/DAT-22961). Companion fix to PR #562 (the equivalent unquoting fix on `pro-extension-test.yml`'s `Run Tests` step). Together they unblock the 10 module PRs ([liquibase-pro #3610](https://github.com/liquibase/liquibase-pro/pull/3610), [#3620](https://github.com/liquibase/liquibase-pro/pull/3620), [#3621](https://github.com/liquibase/liquibase-pro/pull/3621), [#3623](https://github.com/liquibase/liquibase-pro/pull/3623), [#3627](https://github.com/liquibase/liquibase-pro/pull/3627), [#3629](https://github.com/liquibase/liquibase-pro/pull/3629), [#3633](https://github.com/liquibase/liquibase-pro/pull/3633), [#3635](https://github.com/liquibase/liquibase-pro/pull/3635), [#3636](https://github.com/liquibase/liquibase-pro/pull/3636), [#3638](https://github.com/liquibase/liquibase-pro/pull/3638)).

## Test plan

- [ ] After merge, re-run liquibase-pro PR #3623 (mongodb) — confirm the `Build and Package` step's `Reactor Build Order` shows mongodb + its dependencies, not the full distribution-profile reactor.
- [ ] Confirm a caller with empty `extraMavenArgs` is unaffected (still builds the default reactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22961]: https://datical.atlassian.net/browse/DAT-22961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ