### PR TITLE
fix(jira): use existing JIRA_USER/JIRA_API_TOKEN vault keys [TECHOPS-318]

### DIFF
--- a/.github/workflows/jira-set-fixversion-on-release.yml
+++ b/.github/workflows/jira-set-fixversion-on-release.yml
@@ -24,11 +24,12 @@ name: "Jira: Set Fix Version on release tag"
 #
 # Required org-level setup (one-time, shared with jira-transition-on-pr-merge):
 #   /vault/liquibase must contain
-#       JIRA_SERVICE_ACCOUNT_EMAIL
-#       JIRA_SERVICE_ACCOUNT_API_TOKEN
-#   The service account needs Browse + Edit Issues + Resolve Issues on every
+#       JIRA_USER       — Jira account email
+#       JIRA_API_TOKEN  — token from id.atlassian.com
+#   The account needs Browse + Edit Issues + Resolve Issues on every
 #   project (Resolve Issues is the perm that gates Fix Version writes — see
-#   DAT-22616 learnings).
+#   DAT-22616 learnings). Renamed from the original JIRA_SERVICE_ACCOUNT_*
+#   spec to align with what's actually in vault.
 #
 # Behaviour:
 #   - Looks up the previous tag via the GitHub API and compares commits
@@ -101,8 +102,8 @@ jobs:
           PROJECT_KEYS: ${{ inputs.project_keys }}
           TARGET_VERSION_NAME: ${{ inputs.target_version_name }}
           JIRA_BASE_URL: ${{ inputs.jira_base_url }}
-          JIRA_EMAIL: ${{ env.JIRA_SERVICE_ACCOUNT_EMAIL }}
-          JIRA_TOKEN: ${{ env.JIRA_SERVICE_ACCOUNT_API_TOKEN }}
+          JIRA_EMAIL: ${{ env.JIRA_USER }}
+          JIRA_TOKEN: ${{ env.JIRA_API_TOKEN }}
         with:
           script: |
             // ---- Inputs / context ------------------------------------
@@ -124,8 +125,7 @@ jobs:
 
             if (!email || !token) {
               core.setFailed(
-                'JIRA_SERVICE_ACCOUNT_EMAIL or JIRA_SERVICE_ACCOUNT_API_TOKEN ' +
-                'not set in /vault/liquibase'
+                'JIRA_USER or JIRA_API_TOKEN not set in /vault/liquibase'
               );
               return;
             }

--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -32,10 +32,12 @@ name: "Jira: Transition issue on PR merge"
 #
 # Required org-level setup (one-time):
 #   /vault/liquibase must contain
-#       JIRA_SERVICE_ACCOUNT_EMAIL       — service-account email
-#       JIRA_SERVICE_ACCOUNT_API_TOKEN   — token from id.atlassian.com
-#   The service account needs Browse + Transition Issues on every project
-#   you want auto-transitioned.
+#       JIRA_USER        — Jira account email
+#       JIRA_API_TOKEN   — token from id.atlassian.com
+#   The account needs Browse + Transition Issues on every project you
+#   want auto-transitioned. (These are the same vault keys used by
+#   other Liquibase Jira automation; renamed from the original
+#   JIRA_SERVICE_ACCOUNT_* spec to align with what's actually in vault.)
 
 on:
   workflow_call:
@@ -85,8 +87,8 @@ jobs:
           JIRA_BASE_URL: ${{ inputs.jira_base_url }}
           # parse-json-secrets exposes vault keys as env vars; pass them
           # under non-prefixed names for the script.
-          JIRA_EMAIL: ${{ env.JIRA_SERVICE_ACCOUNT_EMAIL }}
-          JIRA_TOKEN: ${{ env.JIRA_SERVICE_ACCOUNT_API_TOKEN }}
+          JIRA_EMAIL: ${{ env.JIRA_USER }}
+          JIRA_TOKEN: ${{ env.JIRA_API_TOKEN }}
         with:
           script: |
             // Defense in depth: callers should gate the job on
@@ -117,8 +119,7 @@ jobs:
 
             if (!email || !token) {
               core.setFailed(
-                'JIRA_SERVICE_ACCOUNT_EMAIL or JIRA_SERVICE_ACCOUNT_API_TOKEN ' +
-                'not set in /vault/liquibase'
+                'JIRA_USER or JIRA_API_TOKEN not set in /vault/liquibase'
               );
               return;
             }


### PR DESCRIPTION
## Summary

Both reusable Jira workflows referenced vault keys that don't exist (`JIRA_SERVICE_ACCOUNT_EMAIL` / `JIRA_SERVICE_ACCOUNT_API_TOKEN`). Renames to the keys that **do** exist and are already in production use elsewhere: `JIRA_USER` / `JIRA_API_TOKEN`.

## Why this matters

The auto-transition workflow has been failing silently on every PR merge in `liquibase-infrastructure` since merge-day with:

```
JIRA_SERVICE_ACCOUNT_EMAIL or JIRA_SERVICE_ACCOUNT_API_TOKEN not set in /vault/liquibase
```

Same root cause for the release-tag Fix Version workflow (would fail on first tag push).

This PR is the unblocker for the [TECHOPS-351](https://datical.atlassian.net/browse/TECHOPS-351) live demos — without it, the demo loop in [unified-workflow-demo](https://github.com/liquibase/unified-workflow-demo) can't fire.

## Changes

| File | Change |
|---|---|
| `jira-transition-on-pr-merge.yml` | `JIRA_SERVICE_ACCOUNT_EMAIL` → `JIRA_USER`, `JIRA_SERVICE_ACCOUNT_API_TOKEN` → `JIRA_API_TOKEN` (env var refs + header comment + error message) |
| `jira-set-fixversion-on-release.yml` | Same rename pattern |

Lint clean (`actionlint` exit 0).

## Follow-up worth considering

`JIRA_USER` is likely a personal account rather than a dedicated service account. For demos this is acceptable — auto-transitions and Fix Version writes will show that user as the actor in audit logs. For long-term production hygiene, provisioning a dedicated `automation-service@liquibase.com` (or similar) account and adding `JIRA_SERVICE_ACCOUNT_*` keys to vault is the cleaner answer. Worth a separate ticket once the demos land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-351]: https://datical.atlassian.net/browse/TECHOPS-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ