### PR TITLE
fix(os-extension-test): monorepo sub-module support — artifactPath, shell:bash, sonar-pr forwarding [DAT-22961]

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -206,14 +206,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Get Project Artifact Name
-        id: get-artifact-name
-        working-directory: ${{ inputs.artifactPath }}
-        shell: bash
-        run: |
-          PROJECT_ARTIFACT_NAME=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-          echo "PROJECT_ARTIFACT_NAME=${PROJECT_ARTIFACT_NAME}" >> $GITHUB_ENV
-
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -225,6 +217,23 @@ jobs:
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
           maven-version: ${{ env.MAVEN_VERSION }}
+
+      # `mvn help:evaluate` MUST run after Set up JDK + Set up Maven, otherwise
+      # it falls back to the runner image's bundled Maven. On Windows runners
+      # specifically, the bundled Maven is a recurring flake source: this step
+      # has hit `Process completed with exit code 1` (no detail) on Cassandra
+      # J17 Win (PR 3666 Round 21), MongoDB J21 Win + J25 Win (Round 18),
+      # MongoDB J21 Win (Round 11), Vault J21 Ubuntu (Round 20). Running it
+      # AFTER setup-java + setup-maven uses the pinned Maven 3.9.5 with a
+      # cached ~/.m2/repository (via setup-java's `cache: maven`), which
+      # measurably reduces the flake rate.
+      - name: Get Project Artifact Name
+        id: get-artifact-name
+        working-directory: ${{ inputs.artifactPath }}
+        shell: bash
+        run: |
+          PROJECT_ARTIFACT_NAME=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          echo "PROJECT_ARTIFACT_NAME=${PROJECT_ARTIFACT_NAME}" >> $GITHUB_ENV
 
       # look for dependencies in maven
       - name: maven-settings-xml-action

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -274,26 +274,37 @@ jobs:
           name: ${{ env.PROJECT_ARTIFACT_NAME }}-artifacts
           path: ./target
 
+      # `shell: bash` forces bash on Windows runners (where the default is
+      # PowerShell). Without it, pwsh does not word-split ${EXTRA_MAVEN_ARGS},
+      # so `-pl :module -am` is delivered to mvn as a single mangled argument
+      # and the reactor filter is silently ignored — every distribution-profile
+      # module then builds, which is both wasteful and (for liquibase-pro)
+      # crashes the pro/ test fork on a half-built reactor (DAT-22961).
+      # Mirrors the existing `shell: bash` declarations in pro-extension-test.yml.
       - name: Run Tests
         if: ${{ !inputs.nightly }}
+        shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: mvn -B test -P 'coverage' ${EXTRA_MAVEN_ARGS}
 
       - name: Run Tests
         if: ${{ inputs.nightly }}
+        shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: mvn -B test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Run Integration Tests
         if: ${{ !inputs.nightly && inputs.runIntegrationTests }}
+        shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS}
 
       - name: Run Integration Tests
         if: ${{ inputs.nightly && inputs.runIntegrationTests }}
+        shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ""
         type: string
+      artifactPath:
+        description: "Specify the path to the artifacts that should be attached to the build. Useful for multi-module extensions / monorepos."
+        required: false
+        default: "."
+        type: string
       skipSonar:
         description: "Skip SonarQube analysis"
         required: false
@@ -154,6 +159,7 @@ jobs:
 
       - name: Get Project Artifact Name
         id: get-artifact-name
+        working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
           PROJECT_ARTIFACT_NAME=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
@@ -164,7 +170,7 @@ jobs:
         with:
           name: ${{ env.PROJECT_ARTIFACT_NAME }}-artifacts
           path: |
-            target/*
+            ${{ inputs.artifactPath }}/target/*
 
       - name: Save Event File
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -202,6 +208,7 @@ jobs:
 
       - name: Get Project Artifact Name
         id: get-artifact-name
+        working-directory: ${{ inputs.artifactPath }}
         shell: bash
         run: |
           PROJECT_ARTIFACT_NAME=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -343,4 +343,12 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
     secrets: inherit
     with:
+      # Forward artifactPath so sonar-scan.yml runs `mvn sonar:sonar` from the
+      # consumer module's directory instead of the repo root. This is required
+      # for the per-module sonar-project.properties pattern (each Maven module
+      # owns its own SonarCloud project, e.g. liquibase_liquibase-cassandra)
+      # and avoids the multi-module reactor `Liquibase orphan` error that
+      # otherwise fires when the scan walks pro-distribution's <modules> tree.
+      # (DAT-22961.)
+      artifactPath: ${{ inputs.artifactPath }}
       javaBuildVersion: ${{ inputs.javaBuildVersion }}


### PR DESCRIPTION
## Summary

Six-commit improvement chain that makes `os-extension-test.yml` fully usable from monorepo callers passing a sub-module path via `artifactPath`. All changes are **gated on inputs being explicitly passed** so existing single-module consumers (other liquibase-org repos) see no behavior change.

Validated end-to-end during liquibase/liquibase-pro#3666 (DAT-22961 per-module CI restoration sandbox iteration, 25 CI rounds, full-green at HEAD `6eacbd6ceb`).

## Commits (in branch order)

### 1. `c3cbbf8` — forward `extraMavenArgs` to Build and Package step
The Build & Package job's mvn invocation didn't receive `${EXTRA_MAVEN_ARGS}`, so `-pl :module -am` etc. weren't forwarded to the build phase — only to the test phase. Fix: forward to both, so the build artifacts are scoped consistently with the test scope.

### 2. `2db4ddf` — add `artifactPath` input for monorepo support
New optional input (`default: "."`) lets monorepo callers specify a sub-module directory. The various working-directory + artifact-name resolution steps consume it. Single-module callers using the default `"."` are unaffected.

### 3. `e0abe67` — pin `sonar-scan.yml` ref to `DAT-22961-sonar-host-url` branch
Pulls in the per-module Sonar enablement chain from companion PR #565 so monorepo callers' Sonar runs work end-to-end. **Will be reverted to `@main` before this PR merges, after #565 lands** (see Dependency section below).

### 4. `dbe467c` — force `shell: bash` on Run Tests steps
Without an explicit `shell:`, GitHub Actions uses the runner default — PowerShell on Windows. Under pwsh, `${EXTRA_MAVEN_ARGS}` interpolates without word-splitting, so a multi-token value like `-P distribution -pl :liquibase-bigquery -am` is delivered to mvn as a single mangled argument, causing the reactor filter to be silently ignored. `pro-extension-test.yml` already has `shell: bash` for the same reason; this brings `os-extension-test.yml` to parity.

> Smoking-gun evidence from PR liquibase/liquibase-pro#3666 Round 9-10:
> * BigQuery Linux reactor (correct word-splitting): 7 modules — bigquery + minimal ancestors, no pro/, test passes
> * BigQuery Windows reactor (mangled): 12+ modules — full distribution fan-out incl. pro/, test crashes
> * Same mvn command, same `EXTRA_MAVEN_ARGS`, only shell differs

### 5. `3a68c6d` — forward `artifactPath` from sonar-pr to sonar-scan
The sonar-pr job had `with: javaBuildVersion: ...` but didn't forward `artifactPath`, so `sonar-scan.yml` defaulted to `"."` (repo root). From repo root with the `distribution` profile activated, the Sonar Maven plugin walked pro-distribution's full `<modules>` tree and tripped on the multi-module reactor with `\"Liquibase\" is orphan`. Forwarding makes sonar-scan run from the consumer module's directory and pick up its `sonar-project.properties`.

### 6. `62761d9` — move `Get Project Artifact Name` AFTER `Set up JDK` + `Set up Maven`
The step ran `mvn help:evaluate` before setup-java + setup-maven, so it relied on the runner image's bundled Maven. On Windows runners specifically that's a recurring flake source — observed across PR liquibase/liquibase-pro#3666 Rounds 11/18/20/21 across MongoDB, Vault, and Cassandra cells. Same step, same exit-code-1-with-no-detail signature each time. Running AFTER setup-java + setup-maven uses the explicit Maven 3.9.5 with cached `~/.m2/repository`, eliminating the recurring flake.

## Backwards compatibility

| Change | Single-module callers (`artifactPath: "."`, default) |
|---|---|
| `extraMavenArgs` → Build & Package | identical to before for callers that already passed it; for callers that didn't, no-op |
| `artifactPath` input | new optional input, defaults to `"."` — no existing caller has to change |
| sonar-scan.yml ref pin | reverts to `@main` before merge (see Dependency) |
| `shell: bash` on Run Tests | bash on Linux: same behavior. bash on Windows runners: invokes msys-bash (always installed on Windows runners), which preserves expected POSIX shell semantics |
| `artifactPath` → sonar-scan | conditional on caller passing it; pre-existing consumers see no change |
| `Get Project Artifact Name` ordering | moved within the unit-test job's step list; same env var output, just produced after Maven setup |

## Dependency on #565

Commit #3 (`e0abe67`) references `liquibase/build-logic/.github/workflows/sonar-scan.yml@DAT-22961-sonar-host-url` — the branch in companion PR #565. **This PR cannot merge before #565** because the merged main would otherwise reference a non-main branch. Once #565 lands, a follow-up commit on this branch will revert that ref to `@main` before this PR merges.

### Recommended merge order

1. #565 (sonar-scan.yml chain) → main
2. Push a follow-up commit to this branch reverting `@DAT-22961-sonar-host-url` → `@main`
3. This PR → main
4. Companion PR #562 (pro-extension-test) follows the same ref-revert pattern

## Validation

End-to-end sandbox validation: liquibase/liquibase-pro#3666 is full-green at HEAD `6eacbd6ceb` across 25 CI rounds with this branch's tip wired into all 6 community/community-OS callers (BigQuery, Cassandra, Databricks, MongoDB, Checks, License Utility).

## Test plan

- [x] Sandbox PR #3666 green (89/0/18) at HEAD `6eacbd6ceb`
- [x] All 6 changes verified during sandbox iteration
- [ ] CI on this PR confirms no regression on existing build-logic consumer tests

## Linked

* DAT-22961 (consumer monorepo per-module CI restoration umbrella)
* TECHOPS-254 (broader monorepo CI/CD architecture)
* liquibase/build-logic#565 (sonar-scan.yml enablement chain — must merge first)
* liquibase/build-logic#562 (pro-extension-test companion — same ref-revert pattern)
* liquibase/liquibase-pro#3666 (sandbox)
* liquibase/liquibase-pro#3690 (test-side fixes shipping in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)