### PR TITLE
fix(workflows): replace master-SNAPSHOT with main-SNAPSHOT [TECHOPS-369]

### DIFF
--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -1,5 +1,5 @@
 name: Build & Deploy extension jar to GPM
-# This action will download an extension from github repo, build it, and deploy it to GPM as version master-SNAPSHOT.
+# This action will download an extension from github repo, build it, and deploy it to GPM as version main-SNAPSHOT.
 
 on:
   workflow_call:
@@ -198,7 +198,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           cd "${EXTENSION}"
-          EXTENSION_VERSION="master-SNAPSHOT"
+          EXTENSION_VERSION="main-SNAPSHOT"
           mvn versions:set -DnewVersion=$EXTENSION_VERSION
           mvn clean install -DskipTests
           # Debug token info (masked in logs)

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -19,7 +19,7 @@ on:
         default: '["ubuntu-latest", "windows-latest"]'
         type: string
       nightly:
-        description: "Specifies nightly builds against liquibase master-SNAPSHOT"
+        description: "Specifies nightly builds against liquibase main-SNAPSHOT"
         required: false
         default: false
         type: boolean
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build and Package latest liquibase version
         if: ${{ inputs.nightly }}
-        run: mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
+        run: mvn -B dependency:go-offline clean package -DskipTests=true "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
@@ -273,7 +273,7 @@ jobs:
         if: ${{ inputs.nightly }}
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
-        run: mvn -B test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=master-SNAPSHOT"
+        run: mvn -B test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Run Integration Tests
         if: ${{ !inputs.nightly && inputs.runIntegrationTests }}
@@ -285,7 +285,7 @@ jobs:
         if: ${{ inputs.nightly && inputs.runIntegrationTests }}
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
-        run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=master-SNAPSHOT"
+        run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -19,7 +19,7 @@ on:
         default: '["ubuntu-latest", "windows-latest"]'
         type: string
       nightly:
-        description: "Specifies nightly builds against liquibase master-SNAPSHOT"
+        description: "Specifies nightly builds against liquibase main-SNAPSHOT"
         required: false
         default: false
         type: boolean
@@ -217,7 +217,7 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ env.AZURE_CLIENT_SECRET }}
           AZURE_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
-        run: mvn -B clean package -DskipTests=true "-Dliquibase.version=master-SNAPSHOT"
+        run: mvn -B clean package -DskipTests=true "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
@@ -463,9 +463,9 @@ jobs:
           MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
         run: |
           if [ -n "$EXTRA_MAVEN_ARGS" ]; then
-            mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS" "-Dliquibase.version=master-SNAPSHOT"
+            mvn -B test -P "$MAVEN_PROFILES" "$EXTRA_MAVEN_ARGS" "-Dliquibase.version=main-SNAPSHOT"
           else
-            mvn -B test -P "$MAVEN_PROFILES" "-Dliquibase.version=master-SNAPSHOT"
+            mvn -B test -P "$MAVEN_PROFILES" "-Dliquibase.version=main-SNAPSHOT"
           fi
 
       - name: Notify Slack on Build Failure


### PR DESCRIPTION
## Summary

- Replaces all `master-SNAPSHOT` references with `main-SNAPSHOT` in the reusable workflows that consume the nightly snapshot artifact published by `liquibase/liquibase`.
- Required because `liquibase/liquibase` renamed its default branch from `master` to `main` (TECHOPS-300), which changed the published nightly artifact name. Nightly builds across OSS and Pro extensions are currently failing.

## Files changed

- `.github/workflows/os-extension-test.yml`: input description and three `-Dliquibase.version=...` invocations (build, test, integration-test).
- `.github/workflows/pro-extension-test.yml`: input description and three `-Dliquibase.version=...` invocations.
- `.github/workflows/build-extension-jar.yml`: file header comment and `EXTENSION_VERSION` value used to deploy the extension snapshot to GPM.

Verified `grep -r master-SNAPSHOT .github/` returns no matches after the change.

## Test plan

- [ ] Confirm the change merges cleanly into `main`.
- [ ] Trigger a nightly run (`nightly: true`) on a downstream OSS extension consumer and confirm it resolves `org.liquibase:liquibase-core:main-SNAPSHOT` successfully.
- [ ] Trigger a nightly run on a downstream Pro extension consumer and confirm the same.
- [ ] Trigger `build-extension-jar.yml` against an extension and confirm the artifact is deployed to GPM as `main-SNAPSHOT`.

## Related

- TECHOPS-369 (this issue)
- TECHOPS-300 (root cause: default branch rename on `liquibase/liquibase`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)