### PR TITLE
ci(reusable): flip dispatch_new_cves default from true to false

### DIFF
--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -32,10 +32,10 @@ on:
         type: boolean
         default: true
       dispatch_new_cves:
-        description: 'Pass through to reusable-vulnerability-scan.yml for CVE dispatch'
+        description: 'Pass through to reusable-vulnerability-scan.yml for CVE dispatch. Defaults to false; secure-image callers must opt in explicitly.'
         required: false
         type: boolean
-        default: true
+        default: false
       scout_enabled:
         description: 'Run Docker Scout job'
         required: false

--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -62,10 +62,10 @@ on:
         type: string
         default: 'main'
       dispatch_new_cves:
-        description: 'Dispatch unassessed CVEs to investigate-cve workflow in liquibase-pro. Only relevant for docker/liquibase-pro callers.'
+        description: 'Dispatch unassessed CVEs to investigate-cve workflow in liquibase-pro. Only relevant for liquibase-secure callers; defaults to false so OSS/community scans never trigger it accidentally.'
         required: false
         type: boolean
-        default: true
+        default: false
     outputs:
       total_vulnerabilities:
         description: 'Total HIGH/CRITICAL vulnerability count'


### PR DESCRIPTION
## Summary

The `dispatch_new_cves` input on `reusable-vulnerability-scan.yml` (and the pass-through on `reusable-docker-scan.yml`) triggers `investigate-cve.lock.yml` in `liquibase/liquibase-pro` for every unassessed HIGH/CRITICAL finding. Its docstring already states it is "only relevant for docker/liquibase-pro callers" (the commercial `liquibase-secure` images), but the default of `true` meant OSS callers were dispatching by accident.

This PR flips both defaults from `true` to `false` so secure-image callers must opt in explicitly.

## Sequencing

This PR **must** merge **after** the companion PRs that make secure callers explicit, otherwise legit dispatch goes silently dark:

- liquibase/liquibase-pro#3719 — make `dispatch_new_cves: true` explicit on the 3 secure callers (`build-secure-distribution`, `build-qa-docker`'s `vuln-scan-secure`, `trivy-scan-published-images`)
- liquibase/liquibase#7694 — `dispatch_new_cves: false` on community + alpine
- liquibase/docker#545 — `false` on community/alpine, `true` on secure, gating on `liquibase-secure` for the published-images matrix

After merge, the only callers dispatching CVEs into liquibase-pro will be:
- `liquibase/liquibase-pro/.github/workflows/docker-scan.yml` (the secure image build)
- `liquibase/liquibase-pro/.github/workflows/build-secure-distribution.yml`
- `liquibase/liquibase-pro/.github/workflows/build-qa-docker.yml` (`vuln-scan-secure`)
- `liquibase/liquibase-pro/.github/workflows/trivy-scan-published-images.yml` (matrix entries containing `liquibase-secure`)
- `liquibase/docker/.github/workflows/trivy.yml` (`scan-secure`)
- `liquibase/docker/.github/workflows/build-qa-docker.yml` (`vuln-scan-secure`)
- `liquibase/docker/.github/workflows/trivy-scan-published-images.yml` (matrix entries containing `liquibase-secure`)

## Test plan

- [ ] Confirm the three companion PRs are merged before this one
- [ ] After merge, scheduled OSS Docker scans produce no `gh workflow run investigate-cve.lock.yml` calls in their step summaries
- [ ] Secure scans continue to dispatch as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)