### PR TITLE
fix(scout): load full vex-repo tree, not just liquibase-core VEX

### DIFF
--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -202,10 +202,25 @@ jobs:
       - name: Download VEX files for Scout
         if: inputs.vex_enabled
         run: |
+          # Mirror the full liquibase/vex-repo tree so Scout sees one VEX
+          # statement set per transitive package. Trivy auto-discovers via
+          # ~/.trivy/vex/repository.yaml in reusable-vulnerability-scan.yml,
+          # but Scout's --vex-location only reads files in the directory it is
+          # pointed at, so we flatten every pkg/**/vex.openvex.json into ./vex/.
           mkdir -p ./vex
-          curl -sSfL "https://raw.githubusercontent.com/liquibase/vex-repo/main/pkg/maven/org.liquibase/liquibase-core/vex.openvex.json" \
-            -o ./vex/liquibase-core.vex.json
-          echo "VEX file downloaded: $(jq '.statements | length' ./vex/liquibase-core.vex.json) statements"
+          git clone --depth 1 https://github.com/liquibase/vex-repo /tmp/vex-repo
+
+          count=0
+          while IFS= read -r f; do
+            rel="${f#/tmp/vex-repo/}"
+            flat="${rel//\//-}"
+            cp "$f" "./vex/$flat"
+            count=$((count + 1))
+          done < <(find /tmp/vex-repo/pkg -type f -name 'vex.openvex.json')
+
+          total=$(find ./vex -type f -name '*.json' -exec jq '.statements | length' {} \; \
+            | awk '{s+=$1} END{print s+0}')
+          echo "VEX files copied to ./vex/: $count file(s), $total total statement(s)"
 
       - name: Docker Scout (with VEX)
         if: inputs.vex_enabled


### PR DESCRIPTION
## Summary

Docker Scout was failing the secure-image scans on CVEs that we believed were assessed (e.g. liquibase-pro [run 25483329975](https://github.com/liquibase/liquibase-pro/actions/runs/25483329975/job/74772692475) reported HIGHs in `io.netty/netty-codec-http`, `io.netty/netty-codec-dns`, `io.netty/netty-transport-native-epoll`, `io.netty/netty-codec`, `io.netty/netty-codec-compression`, `org.postgresql/postgresql`).

Root cause: this workflow only downloads **one** VEX file into `./vex/`:

```
curl ... pkg/maven/org.liquibase/liquibase-core/vex.openvex.json -o ./vex/liquibase-core.vex.json
```

Its statements are scoped to `pkg:maven/org.liquibase/liquibase-core` (and the two docker products). When Scout reports a finding against `pkg:maven/io.netty/netty-codec-http`, the OpenVEX product matchers do not match → no statement applies → finding is shown. Combined with `--only-vex-affected: true` and `exit-code: true`, the job fails.

`vex-repo` already carries per-package VEX statements (e.g. `pkg/maven/io.netty/netty-codec-http/vex.openvex.json`, `pkg/maven/org.postgresql/postgresql/vex.openvex.json`), but they are never made available to Scout. Trivy doesn't have this problem — `reusable-vulnerability-scan.yml` configures `~/.trivy/vex/repository.yaml` to point at the whole repo, and Trivy auto-discovers everything there.

## Fix

Clone `liquibase/vex-repo` and flatten every `pkg/**/vex.openvex.json` into `./vex/` with a unique filename derived from its repo path (e.g. `pkg-maven-io.netty-netty-codec-http-vex.openvex.json`). Scout reads all `.json` files in `--vex-location`, so this gives it the same per-package coverage Trivy already has.

The `liquibase-core` VEX is included automatically (it's just one of the files under `pkg/`), so no separate handling is needed.

## Test plan

- [ ] On the next secure-image scan, the "Download VEX files for Scout" step prints `VEX files copied to ./vex/: N file(s), M total statement(s)` with N matching the number of `pkg/**/vex.openvex.json` files in `vex-repo`
- [ ] Scout step succeeds on a known-assessed transitive-dep CVE (e.g. add a VEX statement for one of the netty advisories in vex-repo, rerun, confirm Scout no longer flags it)
- [ ] Trivy behavior is unchanged (it uses its own VEX configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)