### PR TITLE
fix(sonar-scan): activate `sonar` Maven profile so a modern sonar-maven-plugin is used [DAT-22961]

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -272,8 +272,23 @@ jobs:
             MVN_GOALS="package -DskipTests sonar:sonar"
           fi
 
+          # Activate the consumer's `sonar` Maven profile (when present): in
+          # liquibase-pro's root pom, that profile pins sonar-maven-plugin to
+          # 5.5.0.6356. Without `-P sonar`, Maven falls back to its default
+          # plugin resolution which produces an old version (observed:
+          # 4.0.0.4121) that mishandles the multi-module reactor and fails
+          # with "Unable to determine structure of project. Probably you use
+          # Maven Advanced Reactor Options with a broken tree of modules.
+          # 'Liquibase' is orphan" when running sonar:sonar from a child
+          # module's directory (working-directory: inputs.artifactPath).
+          #
+          # On consumer repos that don't define a `sonar` profile, Maven
+          # warns "[WARNING] The requested profile 'sonar' could not be
+          # activated because it does not exist" and proceeds — no harm.
+          # (DAT-22961.)
           mvn -B -Daws.region="us-east-1" -Dsonar.token=$SONAR_TOKEN \
               -Dsonar.host.url=https://sonarcloud.io \
+              -P sonar \
               $PR_FLAGS $SONAR_PROPS \
               -Dsonar.scm.revision=$SCM_REVISION \
               $MVN_GOALS


### PR DESCRIPTION
## Summary

One-line fix to `sonar-scan.yml`: add `-P sonar` to the `mvn sonar:sonar` invocation so Maven picks up the consumer's pinned plugin version (when defined) instead of the old default.

## Problem

The per-module Sonar invocation runs from `working-directory: inputs.artifactPath` (a child module of a multi-module reactor in liquibase-pro). Without `-P sonar` activation, Maven's default plugin resolution picks up an older `sonar-maven-plugin` (observed: **4.0.0.4121**) that mishandles the multi-module reactor and dies with:

```
[ERROR] Failed to execute goal sonar-maven-plugin:4.0.0.4121:sonar (default-cli)
        on project pro-distribution: 
        Unable to determine structure of project. Probably you use Maven
        Advanced Reactor Options with a broken tree of modules. 
        "Liquibase" is orphan
```

The modern `5.5.0.6356` plugin pin lives inside the `sonar` profile of liquibase-pro's root `pom.xml` (lines 550–...). Activating `-P sonar` causes Maven plugin resolution to pick up the modern version, which scopes analysis correctly to the child module.

## Why this wasn't caught earlier

Sandbox PR [liquibase/liquibase-pro#3666](https://github.com/liquibase/liquibase-pro/pull/3666) ran with `skipSonar: true` on every per-module caller. The `sonar:sonar` invocation never executed end-to-end. The failure surfaces only now that:
1. The Stage 5 `sonar-project.properties` files are on the per-module branches.
2. build-logic [#565](https://github.com/liquibase/build-logic/pull/565) ([sonar-host-url](https://github.com/liquibase/build-logic/commit/a5cf71d)) is on `main`.
3. build-logic [#566](https://github.com/liquibase/build-logic/pull/566) ([os-extension-test artifactPath](https://github.com/liquibase/build-logic/commit/cb09797)) is on `main`.
4. The per-module `sonar-pr` job in `pro-extension-test.yml` and `os-extension-test.yml` actually runs.

## Profile semantics on non-pro consumers

Maven warns:

```
[WARNING] The requested profile 'sonar' could not be activated because it does not exist
```

…and proceeds. No harm — non-pro consumers keep their existing behavior.

## Override compatibility

The system properties already passed on the command line (`-Dsonar.projectKey`, `-Dsonar.organization`, `-Dsonar.host.url`) override anything the profile sets, so per-module bindings (e.g., `liquibase_hashicorp-vault-plugin`, `liquibase_liquibase-aws-extension`) remain correct.

## Verified failing on (will go green after this lands)

Per-module `sonar-pr / Sonar Scan` on:
- [liquibase/liquibase-pro#3610](https://github.com/liquibase/liquibase-pro/pull/3610) (vault)
- [liquibase/liquibase-pro#3621](https://github.com/liquibase/liquibase-pro/pull/3621) (aws)
- [liquibase/liquibase-pro#3638](https://github.com/liquibase/liquibase-pro/pull/3638) (snowflake)

Each shows the same `"Liquibase" is orphan` symptom from the old plugin version.

## Related

- DAT-22961 (parent monorepo CI restoration)
- build-logic #565 (sonar-host-url + multi-module reactor reconciliation, merged)
- build-logic #566 (os-extension-test monorepo support, merged)