### PR TITLE
TECHOPS-298: switch ephemeral-cloud-infra checkout to main

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout liquibase-infrastructure
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: master
+          ref: main
           repository: liquibase/liquibase-infrastructure
           token: ${{ steps.get-token.outputs.token }}
 


### PR DESCRIPTION
## Summary

`liquibase/liquibase-infrastructure` renamed its default branch `master` → `main` in [PR #3664](https://github.com/liquibase/liquibase-infrastructure/pull/3664) (TECHOPS-298, merged 2026-05-07 13:52 UTC). The reusable workflow `.github/workflows/ephemeral-cloud-infra.yml` still hardcoded `ref: master` on the `Checkout liquibase-infrastructure` step, so every consumer that calls it has been failing since the rename.

## Repro

[liquibase-pro-tests Snowflake nightly run #25483359779](https://github.com/liquibase/liquibase-pro-tests/actions/runs/25483359779) (fired 2026-05-07 15:26 UTC) failed in `deploy-ephemeral-cloud-infra → Checkout liquibase-infrastructure`:

```
Syncing repository: liquibase/liquibase-infrastructure
[command]/usr/bin/git remote add origin https://github.com/liquibase/liquibase-infrastructure
[command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
[3 retries fail with no output]
##[error]The process '/usr/bin/git' failed with exit code 1
```

Confirmed `liquibase/liquibase-infrastructure` no longer has a `master` branch — only `main`.

## Fix

One-line change in `.github/workflows/ephemeral-cloud-infra.yml:137`:

```diff
        with:
-         ref: master
+         ref: main
          repository: liquibase/liquibase-infrastructure
```

## Blast radius

Every consumer that calls `liquibase/build-logic/.github/workflows/ephemeral-cloud-infra.yml@main` — at minimum: liquibase-pro-tests Snowflake / AWS / Azure / GCP weekly workflows. They will all start succeeding again once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)