### PR TITLE
chore: update master to main references in docs and scripts

### DIFF
--- a/.github/workflows/subtree-sync.yml
+++ b/.github/workflows/subtree-sync.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       source_branch:
-        description: 'Branch to sync from (e.g., "master", "main")'
+        description: 'Branch to sync from (e.g., "main")'
         required: true
         type: string
       pr_branch_name:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ These branches are automatically deleted when packages are verified as available
 ### os-extension-test.yml
 - `java`: Java versions array (default: `"[11, 17, 21]"`)
 - `os`: Operating systems array (default: `'["ubuntu-latest", "windows-latest"]'`)
-- `nightly`: Boolean for master-SNAPSHOT testing
+- `nightly`: Boolean for main-SNAPSHOT testing
 - `skipSonar`: Skip SonarQube analysis
 - `runIntegrationTests`: Enable integration test execution
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The project has to be configured with the following Maven plugins:
 
 For Maven multimodule projects it is recommended to follow this pattern from SonarSource where there is a specific module to leave the aggregated report:
 
-- [Multi-module Apache Maven example](https://github.com/SonarSource/sonar-scanning-examples/blob/main/sonarqube-scanner-maven/maven-multimodule/README.md)
+- [Multi-module Apache Maven example](https://github.com/SonarSource/sonar-scanning-examples/blob/master/sonarqube-scanner-maven/maven-multimodule/README.md)
 
 In the following example we demonstrate how `liquibase-pro` works:
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ jobs:
 | `upload_sarif` | boolean | no | `false` | Upload to GitHub Security tab |
 | `sarif_category` | string | no | `vulnerability-scan` | SARIF category |
 | `generate_sbom` | boolean | no | `true` | Generate SBOM (docker only) |
-| `build_logic_ref` | string | no | `master` | build-logic branch/tag |
+| `build_logic_ref` | string | no | `main` | build-logic branch/tag |
 
 ### Outputs
 
@@ -210,7 +210,7 @@ The `.trivyignore` file at the root of build-logic contains documented false pos
   uses: actions/checkout@v4
   with:
     repository: liquibase/build-logic
-    ref: master
+    ref: main
     path: build-logic
 
 - name: Setup Trivy ignore file
@@ -411,7 +411,7 @@ The project has to be configured with the following Maven plugins:
 
 For Maven multimodule projects it is recommended to follow this pattern from SonarSource where there is a specific module to leave the aggregated report:
 
-- [Multi-module Apache Maven example](https://github.com/SonarSource/sonar-scanning-examples/blob/master/sonarqube-scanner-maven/maven-multimodule/README.md)
+- [Multi-module Apache Maven example](https://github.com/SonarSource/sonar-scanning-examples/blob/main/sonarqube-scanner-maven/maven-multimodule/README.md)
 
 In the following example we demonstrate how `liquibase-pro` works:
 

--- a/scripts/vulnerability-scanning/diff-new-cves.sh
+++ b/scripts/vulnerability-scanning/diff-new-cves.sh
@@ -63,12 +63,12 @@ warn() { echo "WARNING: $*" >&2; }
 info() { echo "INFO: $*" >&2; }
 
 # ---------------------------------------------------------------------------
-# Step 1 — Fetch assessments.yaml from liquibase-pro master via GH Contents API
+# Step 1 — Fetch assessments.yaml from liquibase-pro main via GH Contents API
 # ---------------------------------------------------------------------------
 ASSESSMENTS_YAML_TMP="$(mktemp /tmp/assessments-XXXXXX.yaml)"
 trap 'rm -f "$ASSESSMENTS_YAML_TMP"' EXIT
 
-info "Fetching vex/assessments.yaml from liquibase-pro master..."
+info "Fetching vex/assessments.yaml from liquibase-pro main..."
 
 if ! gh api "repos/liquibase/liquibase-pro/contents/vex/assessments.yaml" 2>/dev/null \
     | jq -r '.content' 2>/dev/null \


### PR DESCRIPTION
## Summary
- Update `master` to `main` in references that point to Liquibase-owned repos (build-logic, liquibase-pro), all of which default to `main`
- Fix CLAUDE.md `nightly` description: actual workflow uses `main-SNAPSHOT`, not `master-SNAPSHOT`
- Fix README.md `build_logic_ref` default and the `ref:` example so they match build-logic's actual default branch
- Update SonarSource sonar-scanning-examples doc link (repo migrated to `main`)
- Drop the stale `"master"` example from `subtree-sync.yml` input description

External fossa-cli URLs were intentionally left on `master` because that repo still uses `master` as its default branch.

## Files changed
- `CLAUDE.md`: `master-SNAPSHOT` to `main-SNAPSHOT`
- `README.md`: `build_logic_ref` default, `ref: master` example, sonar-scanning-examples link
- `.github/workflows/subtree-sync.yml`: input description
- `scripts/vulnerability-scanning/diff-new-cves.sh`: comment + log message referring to liquibase-pro

## Test plan
- [ ] Verify nothing in the consuming workflows depends on the literal string `master` in these locations (all changes are in docs/comments/log messages, not in executable workflow logic)
- [ ] Confirm SonarSource sonar-scanning-examples `main` link resolves
- [ ] Confirm consuming repos that pin `build_logic_ref` are not relying on the documented default (they pass an explicit value)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>