### PR TITLE
fix(jira): never auto-transition Epics on PR merge

### DIFF
--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -157,7 +157,7 @@ jobs:
 
             // 1. Read current status
             const issueResp = await fetch(
-              `${baseUrl}/rest/api/3/issue/${key}?fields=status`,
+              `${baseUrl}/rest/api/3/issue/${key}?fields=status,issuetype`,
               { headers }
             );
             if (issueResp.status === 404) {
@@ -170,8 +170,25 @@ jobs:
             }
             const issue = await issueResp.json();
             const currentStatus = issue.fields?.status?.name;
+            const issueType = issue.fields?.issuetype?.name;
             if (!currentStatus) {
               core.warning(`${key} has no readable status; skipping`);
+              return;
+            }
+            // An Epic should never be auto-transitioned by a single PR merge.
+            // Epics complete when *all* their child issues are Done — that
+            // policy lives in Jira automation, not here. PR titles often
+            // reference an Epic key alongside the actual ticket key (e.g.
+            // `[TECHOPS-318][TECHOPS-349]`); the regex returns the first
+            // match, which is sometimes the Epic. Skip Epics defensively
+            // so the convention slip doesn't propagate to a wrong-status
+            // transition.
+            if (issueType && issueType.toLowerCase() === 'epic') {
+              console.log(
+                `${key} is an Epic — auto-transition skipped. Epics complete ` +
+                `when all child issues are Done; PR-merge transitions only ` +
+                `apply to non-Epic tickets.`
+              );
               return;
             }
             if (currentStatus.toLowerCase() === targetStatus.toLowerCase()) {


### PR DESCRIPTION
## Summary

PR titles like `[TECHOPS-318][TECHOPS-349] …` contain multiple Jira keys. The transition workflow's regex returns the **first match**, which is sometimes the Epic. As a result, when an engineer merges a PR for a child ticket but happens to list the Epic key first in the title, the Epic gets auto-transitioned to Done — even though it has lots of other open children.

Defensive fix: skip transitioning if the issue's `issuetype` is `Epic`. Epics complete when *all* their child issues are Done; that policy lives in Jira automation, not the PR-merge workflow.

## Observed in the wild

Two PRs in `liquibase/liquibase-infrastructure` flipped TECHOPS-318 (Unified Workflow v0.2 epic) to Done while ~10 child tickets were still open:

| PR | Merged | Title |
|---|---|---|
| `liquibase-infrastructure#3653` | 2026-05-02 06:04 UTC | `fix(jira): keep Start + Due date on Default screen [TECHOPS-318][TECHOPS-344]` |
| `liquibase-infrastructure#3672` | 2026-05-08 04:08 UTC | `feat(jira): make Test status mandatory — remove Approved Skip QA bypass [TECHOPS-318][TECHOPS-349]` |

In both cases the Jira audit log shows the human user account as the actor (because the workflow auths via that account's Jira API token), so the issue isn't visible from the audit log alone — only the PR-title pattern reveals it.

## What changed

`.github/workflows/jira-transition-on-pr-merge.yml`:

- GET issue now requests `fields=status,issuetype` (was `fields=status`).
- New early-return after the status read: if `issuetype.name == "Epic"` (case-insensitive), log a clear skip message and exit. Defensive against missing issuetype too.

## Test plan

- [ ] Merge a test PR with `[TECHOPS-318]` (an Epic) in the title → workflow logs `… is an Epic — auto-transition skipped` and exits cleanly. Epic status unchanged.
- [ ] Merge a test PR with `[TECHOPS-360]` (a Task, child of an Epic) in the title → workflow transitions the child to Done as today.
- [ ] Merge a test PR with `[TECHOPS-318][TECHOPS-360]` (Epic + Task, Epic first) → workflow finds TECHOPS-318 first, sees it's an Epic, skips. The Task does NOT get transitioned because the regex is "first match wins" — engineer must put the child key first to get the auto-transition. Documented behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-318]: https://datical.atlassian.net/browse/TECHOPS-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-318]: https://datical.atlassian.net/browse/TECHOPS-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-318]: https://datical.atlassian.net/browse/TECHOPS-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ