### PR TITLE
fix(scanner): consolidate vault/token blocks [TECHOPS-410]

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -231,23 +231,25 @@ jobs:
       # Runs alongside Trivy and Grype. Results land in osv-scan-*.json
       # artifacts but are NOT rolled into total_vulns yet — that gate
       # flips after one release cycle of dual-running confirms parity.
-      #
-      # VEX support requires reading liquibase-pro/vex/assessments.yaml
-      # (private repo), so we acquire a GitHub App token here. This is a
-      # second, earlier token fetch than the post-scan dispatch block uses;
-      # consolidating both into one pre-scan fetch is a follow-up refactor.
       # ============================================
-      - name: Configure AWS credentials for VEX token
-        if: inputs.run_osv && inputs.vex_enabled
+      #
+      # Single pre-scan token fetch shared by:
+      #   - OSV's VEX-to-TOML step (needs read access to assessments.yaml).
+      #   - The post-scan CVE-dispatch step (needs actions:write on
+      #     liquibase-pro).
+      # An earlier iteration of this workflow ran two separate vault blocks,
+      # which collided on shared env-var names from parse-json-secrets.
+      - name: Configure AWS credentials for vault access
+        if: (inputs.run_osv && inputs.vex_enabled) || inputs.dispatch_new_cves
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
         continue-on-error: true
 
-      - name: Get vault secrets for VEX token
-        id: vault-secrets-osv
-        if: inputs.run_osv && inputs.vex_enabled
+      - name: Get secrets from vault
+        id: vault-secrets
+        if: (inputs.run_osv && inputs.vex_enabled) || inputs.dispatch_new_cves
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
@@ -255,15 +257,16 @@ jobs:
           parse-json-secrets: true
         continue-on-error: true
 
-      - name: Get GitHub App token for VEX fetch
-        id: get-token-osv
-        if: inputs.run_osv && inputs.vex_enabled
+      - name: Get GitHub App token for liquibase-pro
+        id: get-token
+        if: (inputs.run_osv && inputs.vex_enabled) || inputs.dispatch_new_cves
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: liquibase
           repositories: liquibase-pro
+          permission-actions: write
           permission-contents: read
         continue-on-error: true
 
@@ -287,7 +290,7 @@ jobs:
         id: osv-vex
         if: inputs.run_osv && inputs.vex_enabled
         env:
-          GH_TOKEN: ${{ steps.get-token-osv.outputs.token }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/osv
@@ -510,42 +513,11 @@ jobs:
           done
         continue-on-error: true
 
-      # --- Vault / GitHub App token for cross-repo access ---
-      # Required by diff-new-cves.sh (fetches assessments.yaml from liquibase-pro)
-      # and by the CVE dispatch step (triggers investigate-cve workflow).
-      # Moved before the diff step so the token is available for both.
-      # All steps use continue-on-error: true so failures never block the scan.
-
-      - name: Configure AWS credentials for vault access
-        if: always() && inputs.dispatch_new_cves && steps.analyze.outputs.total_vulns > 0
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-        continue-on-error: true
-
-      - name: Get secrets from vault
-        id: vault-secrets-cve
-        if: always() && inputs.dispatch_new_cves && steps.analyze.outputs.total_vulns > 0
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-        continue-on-error: true
-
-      - name: Get GitHub App token for liquibase-pro
-        id: get-token-cve
-        if: always() && inputs.dispatch_new_cves && steps.analyze.outputs.total_vulns > 0
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: liquibase
-          repositories: liquibase-pro
-          permission-actions: write
-          permission-contents: read
-        continue-on-error: true
+      # Vault / GitHub App token for cross-repo access is acquired in the
+      # consolidated pre-scan block above (steps.get-token). Earlier versions
+      # of this workflow fetched the token a second time here; the resulting
+      # parse-json-secrets env-var collision broke vault access for every
+      # scan that also had run_osv+vex_enabled set.
 
       # Run diff-new-cves.sh ONCE and persist output for both the check step and
       # the dispatch step. This avoids a double API call to fetch assessments.yaml.
@@ -588,7 +560,7 @@ jobs:
             echo "diff_output_file=$DIFF_OUTPUT_FILE" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ steps.get-token-cve.outputs.token }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
           SCAN_DIR: ${{ github.workspace }}
           SCAN_SOURCE: ${{ inputs.mode == 'docker' && 'docker' || 'build-logic' }}
           IMAGE_NAME: ${{ inputs.image_name || inputs.version || 'unknown' }}
@@ -659,7 +631,7 @@ jobs:
         if: always() && inputs.dispatch_new_cves && steps.analyze.outputs.total_vulns > 0
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.get-token-cve.outputs.token }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
           DIFF_OUTPUT_FILE: ${{ steps.cve-diff.outputs.diff_output_file || '' }}
           DIFF_FAILED: ${{ steps.cve-diff.outputs.diff_failed || 'false' }}
         run: |


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by [#578](https://github.com/liquibase/build-logic/pull/578). The OSV-Scanner integration added a second AWS-vault block before scans (for the VEX-to-TOML shim's GitHub App token). Both vault blocks call `aws-secretsmanager-get-secrets` with `parse-json-secrets: true`, which exports each JSON key as a process env var. When **both** conditions held — `run_osv && vex_enabled` (new path) and `dispatch_new_cves && total_vulns > 0` (existing path) — the second action call collided on env-var names and failed.

Caught immediately by a manual verification run of `liquibase-pro/trivy-scan-published-images.yml` on 2026-05-11: every secure-image matrix entry printed

```
Failed to fetch secret: '/vault/liquibase'. Error: The environment name
'AWS_DEV_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC' is already in use.
```

This was already flagged as a follow-up in #578's description ("consolidating both blocks into one pre-scan fetch is a follow-up refactor"). The verification run promoted it from follow-up to blocker.

## Fix

Consolidate to a single pre-scan vault + token block. The token serves both consumers.

| Before | After |
| --- | --- |
| `steps.vault-secrets-osv` (pre-scan, run_osv && vex_enabled) | `steps.vault-secrets` (pre-scan, OR'd condition) |
| `steps.get-token-osv` (pre-scan, run_osv && vex_enabled) | `steps.get-token` (pre-scan, OR'd condition) |
| `steps.vault-secrets-cve` (post-scan, dispatch_new_cves && total_vulns > 0) | *(removed — covered by the consolidated block)* |
| `steps.get-token-cve` (post-scan, dispatch_new_cves && total_vulns > 0) | *(removed — covered by the consolidated block)* |

Condition on the consolidated block: `(inputs.run_osv && inputs.vex_enabled) || inputs.dispatch_new_cves`.

Token now requests `permission-actions: write` + `permission-contents: read` so both downstream consumers (VEX fetch and dispatch) share it.

The three downstream references (OSV-VEX step, diff-new-cves, CVE dispatch) all repoint at `steps.get-token`.

## Trade-off accepted

When `dispatch_new_cves: true` but the scan finds 0 vulns, we now pay an unnecessary token fetch. Small efficiency cost; structurally cleaner.

## Test plan

- [x] `actionlint` clean.
- [x] Shim regression: `bash scripts/vulnerability-scanning/tests/test-vex-to-osv-toml.sh` — **14/14 pass**.
- [ ] Re-run `liquibase-pro/trivy-scan-published-images.yml` against a secure tag once this merges. Expect (a) no vault env-var-collision errors, (b) `osv-scan-image.json` + `osv-scan-deep.json` in the artifact, (c) suppression count ~38 lower than the un-VEX'd baseline.

## Diff stats

`1 file changed, 24 insertions(+), 52 deletions(-)` — net -28 lines.

Related: TECHOPS-410, [build-logic#578](https://github.com/liquibase/build-logic/pull/578), [liquibase-pro#3747](https://github.com/liquibase/liquibase-pro/pull/3747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)