### PR TITLE
fix(qa): discriminate secure-vs-community by build_type, not filename [TECHOPS-410]

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -439,24 +439,36 @@ jobs:
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           BRANCH_NAME: ${{ inputs.branch_name }}
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
-          echo "Modifying $DOCKERFILE_PATH to use downloaded artifact instead of GitHub releases..."
+          echo "Modifying $DOCKERFILE_PATH (build_type=$BUILD_TYPE) to use downloaded artifact instead of GitHub releases..."
 
           # Create backup
           cp "$DOCKERFILE_PATH" "${DOCKERFILE_PATH}.backup"
 
-          # Set version ARG based on dockerfile type
-          if [[ "$DOCKERFILE_PATH" == "DockerfileSecure" ]]; then
+          # Discriminate by build_type instead of filename. Callers may pass
+          # a path-prefixed dockerfile_path (e.g. "docker/Dockerfile") that
+          # has secure semantics even though the basename is "Dockerfile";
+          # filename inference would silently mis-classify those builds.
+          if [[ "$BUILD_TYPE" == "secure" ]]; then
             VERSION_ARG="LIQUIBASE_SECURE_VERSION"
           else
             VERSION_ARG="LIQUIBASE_VERSION"
           fi
 
+          # Discriminate alpine community by basename (the only OSS-alpine
+          # build path uses a Dockerfile.alpine wget block that needs a
+          # different anchor than the standard community wget).
+          DOCKERFILE_BASENAME=$(basename "$DOCKERFILE_PATH")
+
           # Replace version ARG with branch name
           sed -i "s|ARG ${VERSION_ARG}=.*|ARG ${VERSION_ARG}=${BRANCH_NAME}|" "$DOCKERFILE_PATH"
 
           # Create modified Dockerfile using awk for cleaner handling
-          cat "$DOCKERFILE_PATH" | awk -v dockerfile="$DOCKERFILE_PATH" -v branch="$BRANCH_NAME" '
+          cat "$DOCKERFILE_PATH" | awk \
+            -v build_type="$BUILD_TYPE" \
+            -v dockerfile_basename="$DOCKERFILE_BASENAME" \
+            -v branch="$BRANCH_NAME" '
           BEGIN {
             in_wget_block = 0
             skip_line = 0
@@ -469,8 +481,8 @@ jobs:
           /^ARG LIQUIBASE_VERSION=/ { print "ARG LIQUIBASE_VERSION=" branch; next }
           /^ARG LIQUIBASE_SECURE_VERSION=/ { print "ARG LIQUIBASE_SECURE_VERSION=" branch; next }
 
-          # Handle standard Dockerfile wget block
-          dockerfile == "Dockerfile" && /^RUN wget.*github\.com.*liquibase.*tar\.gz/ {
+          # Handle Secure Dockerfile wget block (any filename; build_type wins)
+          build_type == "secure" && /^RUN wget.*repo\.liquibase\.com.*tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
@@ -481,8 +493,8 @@ jobs:
             next
           }
 
-          # Handle alpine Dockerfile wget block
-          dockerfile == "Dockerfile.alpine" && /^RUN set -x/ {
+          # Handle standard community Dockerfile wget block
+          build_type != "secure" && dockerfile_basename == "Dockerfile" && /^RUN wget.*github\.com.*liquibase.*tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
@@ -493,8 +505,8 @@ jobs:
             next
           }
 
-          # Handle Secure Dockerfile wget block
-          dockerfile == "DockerfileSecure" && /^RUN wget.*repo\.liquibase\.com.*tar\.gz/ {
+          # Handle alpine community Dockerfile wget block
+          build_type != "secure" && dockerfile_basename == "Dockerfile.alpine" && /^RUN set -x/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""


### PR DESCRIPTION
## Summary

`reusable-docker-build-qa.yml`'s "Modify Dockerfiles for artifact-based build" step inferred secure vs community from the bare filename (`DOCKERFILE_PATH == "DockerfileSecure"`). This broke for any caller that passes a path-prefixed `dockerfile_path` with secure semantics — for example [`liquibase-pro/.github/workflows/build-qa-docker.yml`](https://github.com/liquibase/liquibase-pro/blob/main/.github/workflows/build-qa-docker.yml) passes `docker/Dockerfile`, which **is** a secure Dockerfile (it carries `LIQUIBASE_SECURE_VERSION` and wgets from `repo.liquibase.com/releases/secure/...`) — but the inference fell through to the community branch.

## Failure mode

1. `VERSION_ARG` was set to `LIQUIBASE_VERSION` (wrong — the Dockerfile has `LIQUIBASE_SECURE_VERSION`). The subsequent `sed` silently no-op'd.
2. The awk rewrite predicate `dockerfile == "DockerfileSecure"` never fired, so the `wget` `RUN` block was never replaced with `COPY liquibase-build/`.
3. The build then ran the original `wget` at runtime, with `LIQUIBASE_SECURE_VERSION` still at its Dockerfile default (`main` for a `master`-branch build), and 404'd on `repo.liquibase.com/releases/secure/main/liquibase-secure-main.tar.gz`.

Caught in [run 25652807649](https://github.com/liquibase/liquibase-pro/actions/runs/25652807649) (`Build QA Docker Images`), exit 8 from buildx → wget.

## Fix

Discriminate by the existing `build_type` input. Secure semantics fire on `build_type == "secure"` regardless of filename. The basename-derived community-vs-alpine distinction stays in place via `dockerfile_basename` so OSS callers that pass bare filenames keep working.

## Test plan

- [x] `actionlint` clean (warnings unchanged; same shellcheck SC2001 style hints as `main`).
- [x] **Replayed the awk locally** against `liquibase-pro/docker/Dockerfile` with `build_type=secure` + `branch=main`: the secure `wget … repo.liquibase.com … tar.gz` `RUN` block is correctly replaced with `COPY liquibase-build/ ./` + `liquibase --version`. `LIQUIBASE_SECURE_VERSION` is set to `main`. The `LB_SECURE_SHA256` ARG is dropped.
- [ ] Re-run [`build-qa-docker.yml`](https://github.com/liquibase/liquibase-pro/actions/workflows/build-qa-docker.yml) on `main` with `secure-version=5.1.1`; expect `Scan Secure QA` job to now run (it was previously skipped because the build step failed).
- [ ] Re-verify the existing OSS callers (community Dockerfile + alpine) still strip their wget blocks (they pass bare filenames; `dockerfile_basename` lookups still match).

## Related

- TECHOPS-410.
- Surfaced by [liquibase-pro#3747](https://github.com/liquibase/liquibase-pro/pull/3747) which enabled `run_osv: true` on the QA caller — without that flip the broken Dockerfile rewrite still happened but its consequences (the OSV scan job being unreachable) weren't visible. The discrimination bug pre-existed; this PR also makes the workflow's secure path actually correct independently of OSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)