### PR TITLE
fix(sonar-scan): forward artifactPath in pro-extension-test sonar-pr; revert #571 [DAT-22961]

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -659,3 +659,13 @@ jobs:
     needs: [unit-test]
     uses: liquibase/build-logic/.github/workflows/sonar-scan.yml@main
     secrets: inherit
+    with:
+      # Forward artifactPath so sonar-scan.yml runs `mvn sonar:sonar` from the
+      # consumer module's directory instead of the repo root. Required for the
+      # per-module sonar-project.properties pattern (each Maven module owns
+      # its own SonarCloud project, e.g. liquibase_hashicorp-vault-plugin)
+      # and avoids the multi-module reactor "Liquibase orphan" error that
+      # otherwise fires when the scan walks pro-distribution's <modules> from
+      # repo root. Mirrors the same forwarding already in place on
+      # os-extension-test.yml's sonar-pr job (DAT-22961).
+      artifactPath: ${{ inputs.artifactPath }}

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -235,23 +235,8 @@ jobs:
             MVN_GOALS="package -DskipTests sonar:sonar"
           fi
 
-          # Activate the consumer's `sonar` Maven profile (when present): in
-          # liquibase-pro's root pom, that profile pins sonar-maven-plugin to
-          # 5.5.0.6356. Without `-P sonar`, Maven falls back to its default
-          # plugin resolution which produces an old version (observed:
-          # 4.0.0.4121) that mishandles the multi-module reactor and fails
-          # with "Unable to determine structure of project. Probably you use
-          # Maven Advanced Reactor Options with a broken tree of modules.
-          # 'Liquibase' is orphan" when running sonar:sonar from a child
-          # module's directory (working-directory: inputs.artifactPath).
-          #
-          # On consumer repos that don't define a `sonar` profile, Maven
-          # warns "[WARNING] The requested profile 'sonar' could not be
-          # activated because it does not exist" and proceeds — no harm.
-          # (DAT-22961.)
           mvn -B -Daws.region="us-east-1" -Dsonar.token=$SONAR_TOKEN \
               -Dsonar.host.url=https://sonarcloud.io \
-              -P sonar \
               $PR_FLAGS $SONAR_PROPS \
               -Dsonar.scm.revision=$SCM_REVISION \
               $MVN_GOALS


### PR DESCRIPTION
## Summary

Two-part fix for the per-module Sonar \"Liquibase orphan\" error on liquibase-pro extension CI:

1. **Forward \`artifactPath\` from \`pro-extension-test.yml\` to \`sonar-scan.yml\`** (+10 lines). Mirrors the same forwarding that's already in place on \`os-extension-test.yml\`. Without it, sonar-scan defaults \`artifactPath\` to \`.\` and runs \`mvn sonar:sonar\` from the repo root, which walks pro-distribution's multi-module reactor into \`core/liquibase-core\` whose parent chain (\`org.liquibase:liquibase\`) is a separate Maven root — triggering \`\"Liquibase\" is orphan\`.

2. **Revert #571** (-15 lines, removes the \`-P sonar\` activation and its rationale comment). #571 was opened on the theory that the orphan was caused by Maven's default plugin resolution picking up an old sonar-maven-plugin (4.0.0.4121). After #571 merged the orphan persisted unchanged on the same PRs, proving plugin version was not the cause. \`-P sonar\` is therefore unnecessary and removed to keep build-logic main clean.

Why per-module sonar scans avoid the orphan with \`artifactPath\` set: when sonar-scan cds into the consumer module's directory and invokes \`mvn sonar:sonar\` there, Maven loads only that module's pom and the per-module \`sonar-project.properties\` drives a single-project scan (e.g. \`liquibase_hashicorp-vault-plugin\`) — no reactor walk, no parent-chain divergence.

## Sandbox validation

End-to-end validated on 4 liquibase-pro sandbox PRs covering every \`pro-extension-test.yml\` caller:

| Sandbox PR | Module | sonar-pr |
|---|---|---|
| liquibase/liquibase-pro#3745 | hashicorp-vault-plugin | ✅ 10m0s (combined commit) |
| liquibase/liquibase-pro#3759 | snowflake | ✅ 10m14s (forwarding alone) |
| liquibase/liquibase-pro#3758 | aws | ✅ 8m48s (forwarding alone) |
| liquibase/liquibase-pro#3760 | checks | ✅ 18m0s (forwarding alone) |

Each sandbox pinned \`pro-extension-test.yml\` to this branch (or its forwarding-only predecessor) via the consumer workflow's \`uses:\` line. The vault sandbox was re-pinned to validate the *combined commit* (forwarding fix + #571 revert) end-to-end after the initial 3 sandboxes confirmed the forwarding fix alone resolves the orphan.

## Diff

\`\`\`
.github/workflows/pro-extension-test.yml | 10 ++++++++++
.github/workflows/sonar-scan.yml         | 15 ---------------
2 files changed, 10 insertions(+), 15 deletions(-)
\`\`\`

## Test plan

- [x] All 4 \`pro-extension-test.yml\` callers' sonar-pr jobs verified green on sandbox PRs
- [x] Combined commit (forwarding + #571 revert) validated on vault sandbox
- [ ] After merge: refresh liquibase-pro per-module PR branches, verify sonar-pr passes on each
- [ ] After merge: close sandbox branches (\`DAT-22961-sonar-cli-scanner\`, the four \`DAT-22961-*-sonar-test\` branches)