### PR TITLE
feat(jira): surface Fix Version overwrites in release automation [TECHOPS-414]

### DIFF
--- a/.github/workflows/jira-set-fixversion-on-release.yml
+++ b/.github/workflows/jira-set-fixversion-on-release.yml
@@ -48,6 +48,11 @@ name: "Jira: Set Fix Version on release tag"
 #         ticket merges early).
 #       * Anything else (released entries, multi-valued) → append, so
 #         legitimate backport / multi-release history stays intact.
+#   - When the REPLACE branch fires, the workflow surfaces the overwrite in
+#     three places so the swap is never silent: a `::warning::` annotation on
+#     the run, a Step Summary table at the end of the run, and a comment on
+#     the affected Jira ticket. Visibility is best-effort — failures to post
+#     comments or write the summary never fail the workflow itself.
 #   - For each Jira project that has at least one updated ticket, marks
 #     the version as Released with today's date.
 #   - Skips silently with a warning when:
@@ -222,6 +227,10 @@ jobs:
             };
 
             const projectsTouched = new Set();
+            // Collect REPLACE-mode overwrites so they can be surfaced in the
+            // run's Step Summary and audited on the affected tickets after
+            // the per-ticket loop completes. Each entry: { key, from, to }.
+            const replaces = [];
             for (const key of keys) {
               projectsTouched.add(key.split('-')[0]);
 
@@ -245,14 +254,18 @@ jobs:
                 continue;
               }
 
-              let body, action;
+              let body, action, replaceInfo = null;
               if (current.length === 0) {
                 body = { update: { fixVersions: [{ add: { name: versionName } }] } };
                 action = `add ${versionName} (was empty)`;
               } else if (current.length === 1 && current[0].released === false) {
                 // Single unreleased planning value → replace with actual release.
+                // Tracked in `replaceInfo` so a successful overwrite gets a
+                // ::warning::, a Step Summary row, and a Jira audit comment —
+                // see the visibility block after this loop.
                 body = { fields: { fixVersions: [{ name: versionName }] } };
                 action = `replace ${current[0].name} (unreleased) → ${versionName}`;
+                replaceInfo = { key, from: current[0].name, to: versionName };
               } else {
                 // Multi-valued or has released entries → append (preserve history).
                 body = { update: { fixVersions: [{ add: { name: versionName } }] } };
@@ -269,11 +282,94 @@ jobs:
               });
               if (resp.ok) {
                 console.log(`${key}: ${action}`);
+                if (replaceInfo) {
+                  replaces.push(replaceInfo);
+                  core.warning(
+                    `${replaceInfo.key}: Fix Version replaced ` +
+                    `${replaceInfo.from} → ${replaceInfo.to}. ` +
+                    `If the PR was merged into the wrong release line, ` +
+                    `investigate before the next release.`
+                  );
+                }
               } else {
                 core.warning(
                   `Failed to update fixVersion on ${key}: ` +
                   `${resp.status} ${await resp.text()}`
                 );
+              }
+            }
+
+            // ---- Visibility: surface every REPLACE overwrite -----------
+            // Three layers: ::warning:: annotations (already emitted inline
+            // above), a Step Summary table for at-a-glance review, and a
+            // Jira audit comment on each affected ticket. Visibility is
+            // best-effort — failures here are logged but do not fail the
+            // workflow because the Fix Version writes have already succeeded
+            // and re-running won't fix audit gaps.
+            if (replaces.length > 0) {
+              try {
+                await core.summary
+                  .addHeading(
+                    `⚠️ ${replaces.length} Fix Version overwrite(s) during ${versionName} release`,
+                    2
+                  )
+                  .addRaw(
+                    'Each ticket below had a single unreleased Fix Version ' +
+                    'that was replaced by the release just shipped. If the ' +
+                    'early merge was intentional (ticket pulled forward into ' +
+                    'this release), no action needed. If unintended, ' +
+                    'investigate the PR merge before the next release.\n\n'
+                  )
+                  .addTable([
+                    [
+                      { data: 'Ticket', header: true },
+                      { data: 'Was', header: true },
+                      { data: 'Now', header: true },
+                    ],
+                    ...replaces.map(r => [
+                      `<a href="${baseUrl}/browse/${r.key}">${r.key}</a>`,
+                      r.from,
+                      r.to,
+                    ]),
+                  ])
+                  .write();
+              } catch (e) {
+                core.warning(`Failed to write Step Summary for overwrites: ${e.message}`);
+              }
+
+              for (const r of replaces) {
+                const commentBody = {
+                  body: {
+                    type: 'doc',
+                    version: 1,
+                    content: [{
+                      type: 'paragraph',
+                      content: [{
+                        type: 'text',
+                        text:
+                          `⚠️ Fix Version automatically changed from ` +
+                          `${r.from} → ${r.to} by release automation ` +
+                          `(jira-set-fixversion-on-release). If unintended, ` +
+                          `the PR may have been merged into a wrong-target ` +
+                          `branch — investigate before the next release.`,
+                      }],
+                    }],
+                  },
+                };
+                const commentResp = await fetch(
+                  `${baseUrl}/rest/api/3/issue/${r.key}/comment`,
+                  {
+                    method: 'POST',
+                    headers,
+                    body: JSON.stringify(commentBody),
+                  }
+                );
+                if (!commentResp.ok) {
+                  core.warning(
+                    `Failed to post audit comment on ${r.key}: ` +
+                    `${commentResp.status} ${await commentResp.text()}`
+                  );
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

The release-tag automation in `jira-set-fixversion-on-release.yml` has a REPLACE branch (line 252) that swaps a ticket's sole unreleased planning value (e.g. `6.0`) for the release just shipped (e.g. `5.2.0`). That's the intended behavior when a planned ticket merges into an earlier release, but it was previously **silent** — only a `console.log` line buried in the workflow run. Field feedback: when a PR was merged early into the wrong release line, the swap left no signal that the ticket's intended target had been overwritten.

This PR adds three-layer visibility so every REPLACE is discoverable after the fact:

1. **`::warning::` annotation** — `core.warning()` emitted inline for each REPLACE so it shows up as a yellow annotation in the Actions run UI, not buried in logs.
2. **Step Summary table** — Ticket / Was / Now rows for every overwrite, rendered at the end of the run for at-a-glance review.
3. **Jira audit comment** — posted on each affected ticket explaining the change and prompting investigation if the merge was unintended.

Visibility is best-effort. Comment-post failures or Step Summary write failures emit their own warning but never fail the workflow itself — the Fix Version writes have already succeeded by that point, and re-running wouldn't repair audit gaps.

## Why now

Surfaced in cross-functional release retro: a `6.0`-scoped ticket got `5.2.0` written on a 5.2 release. No one noticed for days. The fix needs to be in build-logic so it applies to **all caller repos automatically** — anything referencing `@main` inherits the new behavior on next release.

Tracked as TECHOPS-414.

## Scope

- Single file changed: `.github/workflows/jira-set-fixversion-on-release.yml`
- 97 lines added, 1 removed (turning `let body, action;` into `let body, action, replaceInfo = null;`)
- **No behavior change** for ADD / SKIP / APPEND paths
- No new workflow inputs — visibility is default-on
- Header comment block updated to document the new behavior

## Test plan

- [x] `actionlint` clean
- [ ] Dry-run: push a test tag in a caller repo with a planted mismatch ticket; confirm all three visibility layers fire
- [ ] First real release after merge — verify behavior in the wild (will close TECHOPS-414)

## Out of scope (could be future TECHOPS sub-tickets)

- Semver-aware "downgrade detection" — fail the workflow if new version is lower than old per semver
- Pre-merge PR check that compares the PR's target branch's release line to the ticket's fixVersion (preventive, not reactive)
- Auto-revert of unintended replaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)