### PR TITLE
feat(jira): disable PR-merge auto-transition to Done [TECHOPS-421]

### DIFF
--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -1,235 +1,56 @@
 name: "Jira: Transition issue on PR merge"
 
-# Reusable workflow. When called from a PR-closed workflow in a downstream
-# repo (with the PR merged), extracts the Jira ticket key from the PR title
-# or branch name and transitions the linked ticket to a target status.
+# DEPRECATED — disabled 2026-05-11 per TECHOPS-421.
 #
-# Idempotent + best-effort: if the ticket is already in the target status,
-# or the workflow doesn't allow a transition from the current status, this
-# logs a warning and exits the job successfully. Real Jira / auth errors
-# fail the job loudly.
+# Field feedback (SECURE team demo): this workflow used to transition
+# tickets to Done when their PR merged, regardless of where the ticket
+# was in the v0.2 workflow. In practice it bypassed Test, UAT, and
+# Code Review — a ticket merged mid-UAT would silently get auto-closed,
+# hiding the fact that user-acceptance testing was incomplete.
 #
-# Caller pattern (in any repo):
+# Team decision: disable the automation entirely. Engineers drive
+# Test → UAT → Ready to Merge → Done by hand. Final transitions are no
+# longer triggered by code-side events.
 #
-#   name: Auto-transition Jira on PR merge
-#   on:
-#     pull_request:
-#       types: [closed]
-#       branches: [main]   # or [master]
-#   jobs:
-#     transition:
-#       if: github.event.pull_request.merged == true
-#       uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
-#       secrets: inherit
+# The file is intentionally kept (rather than deleted) so existing
+# callers — any repo with a line like
+#   uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
+# — don't fail with "workflow not found" on their next PR merge. The
+# workflow now logs a clear deprecation ::warning:: and exits 0.
+# Callers can remove their caller .yml at their own pace.
 #
-# Use `pull_request` (not `pull_request_target`). This workflow only reads
-# the event payload and calls Jira via REST — never checks out PR code —
-# so the extra privilege of `pull_request_target` is unnecessary. Side
-# effect: PRs from forks won't have secrets and the workflow will skip
-# the transition; that's the correct trade-off for a public-fork
-# scenario (we don't want to auto-transition tickets for community PRs
-# anyway).
-#
-# Required org-level setup (one-time):
-#   /vault/liquibase must contain
-#       JIRA_USER        — Jira account email
-#       JIRA_API_TOKEN   — token from id.atlassian.com
-#   The account needs Browse + Transition Issues on every project you
-#   want auto-transitioned. (These are the same vault keys used by
-#   other Liquibase Jira automation; renamed from the original
-#   JIRA_SERVICE_ACCOUNT_* spec to align with what's actually in vault.)
+# If you're considering re-enabling: read TECHOPS-421 first. The
+# UAT-bypass concern needs a redesign (e.g. constrain to firing only
+# when the ticket is in "Ready to Merge"), not a straight resurrection.
 
 on:
   workflow_call:
     inputs:
       project_keys:
-        description: "Comma-separated Jira project keys to recognise. First match wins on PRs that mention multiple."
+        description: "(no-op) Retained for caller-side compatibility — workflow is disabled."
         required: false
         type: string
         default: "TECHOPS,SECURE,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
       target_status:
-        description: "Status name to transition to (case-insensitive)."
+        description: "(no-op) Retained for caller-side compatibility — workflow is disabled."
         required: false
         type: string
         default: "Done"
       jira_base_url:
-        description: "Jira Cloud base URL."
+        description: "(no-op) Retained for caller-side compatibility — workflow is disabled."
         required: false
         type: string
         default: "https://datical.atlassian.net"
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   transition:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Get Jira service-account credentials from vault
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-
-      - name: Transition Jira ticket
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          PROJECT_KEYS: ${{ inputs.project_keys }}
-          TARGET_STATUS: ${{ inputs.target_status }}
-          JIRA_BASE_URL: ${{ inputs.jira_base_url }}
-          # parse-json-secrets exposes vault keys as env vars; pass them
-          # under non-prefixed names for the script.
-          JIRA_EMAIL: ${{ env.JIRA_USER }}
-          JIRA_TOKEN: ${{ env.JIRA_API_TOKEN }}
-        with:
-          script: |
-            // Defense in depth: callers should gate the job on
-            // `github.event.pull_request.merged == true`, but if a future
-            // caller wires this in without that condition we still want a
-            // safe no-op rather than a Jira write on a closed-without-merge
-            // event or a non-PR event.
-            const { pull_request } = context.payload;
-            if (!pull_request) {
-              core.warning('No pull_request payload on this event; skipping');
-              return;
-            }
-            if (!pull_request.merged) {
-              console.log(
-                `PR #${pull_request.number} closed without merge; skipping Jira transition`
-              );
-              return;
-            }
-
-            const projectKeys = process.env.PROJECT_KEYS
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean);
-            const targetStatus = process.env.TARGET_STATUS;
-            const baseUrl = process.env.JIRA_BASE_URL.replace(/\/$/, '');
-            const email = process.env.JIRA_EMAIL;
-            const token = process.env.JIRA_TOKEN;
-
-            if (!email || !token) {
-              core.setFailed(
-                'JIRA_USER or JIRA_API_TOKEN not set in /vault/liquibase'
-              );
-              return;
-            }
-
-            // First match wins; case-insensitive on the key prefix. Word
-            // boundaries prevent matching inside a longer token (e.g.
-            // `DAT-123` inside `NOTDAT-123`). Project keys are regex-
-            // escaped in case any contain special characters in the
-            // future.
-            const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const keyRegex = new RegExp(
-              `\\b(?:${projectKeys.map(escapeRegex).join('|')})-\\d+\\b`,
-              'i'
-            );
-            const haystack = `${pull_request.title || ''} ${pull_request.head?.ref || ''}`;
-            const match = haystack.match(keyRegex);
-
-            if (!match) {
-              core.warning(
-                `PR #${pull_request.number} has no Jira ticket key in title or branch ` +
-                `(allowed: ${projectKeys.join(', ')})`
-              );
-              return;
-            }
-
-            const key = match[0].toUpperCase();
-            console.log(`Found ticket key: ${key}`);
-
-            const auth = `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
-            const headers = {
-              Authorization: auth,
-              Accept: 'application/json',
-              'Content-Type': 'application/json',
-            };
-
-            // 1. Read current status
-            const issueResp = await fetch(
-              `${baseUrl}/rest/api/3/issue/${key}?fields=status,issuetype`,
-              { headers }
-            );
-            if (issueResp.status === 404) {
-              core.warning(`${key} not found in Jira (404) — typo or non-existent issue`);
-              return;
-            }
-            if (!issueResp.ok) {
-              core.setFailed(`GET issue ${key} failed: ${issueResp.status} ${await issueResp.text()}`);
-              return;
-            }
-            const issue = await issueResp.json();
-            const currentStatus = issue.fields?.status?.name;
-            const issueType = issue.fields?.issuetype?.name;
-            if (!currentStatus) {
-              core.warning(`${key} has no readable status; skipping`);
-              return;
-            }
-            // An Epic should never be auto-transitioned by a single PR merge.
-            // Epics complete when *all* their child issues are Done — that
-            // policy lives in Jira automation, not here. PR titles often
-            // reference an Epic key alongside the actual ticket key (e.g.
-            // `[TECHOPS-318][TECHOPS-349]`); the regex returns the first
-            // match, which is sometimes the Epic. Skip Epics defensively
-            // so the convention slip doesn't propagate to a wrong-status
-            // transition.
-            if (issueType && issueType.toLowerCase() === 'epic') {
-              console.log(
-                `${key} is an Epic — auto-transition skipped. Epics complete ` +
-                `when all child issues are Done; PR-merge transitions only ` +
-                `apply to non-Epic tickets.`
-              );
-              return;
-            }
-            if (currentStatus.toLowerCase() === targetStatus.toLowerCase()) {
-              console.log(`${key} already in '${currentStatus}'; no transition needed`);
-              return;
-            }
-
-            // 2. Find a transition that lands in the target status
-            const transResp = await fetch(
-              `${baseUrl}/rest/api/3/issue/${key}/transitions`,
-              { headers }
-            );
-            if (!transResp.ok) {
-              core.setFailed(`GET transitions on ${key} failed: ${transResp.status} ${await transResp.text()}`);
-              return;
-            }
-            const transitions = (await transResp.json()).transitions || [];
-            const t = transitions.find(
-              t => (t.to?.name || '').toLowerCase() === targetStatus.toLowerCase()
-            );
-            if (!t) {
-              core.warning(
-                `No transition from '${currentStatus}' to '${targetStatus}' on ${key}; ` +
-                `the workflow may not allow it from the current status. Skipping.`
-              );
-              return;
-            }
-
-            // 3. POST the transition
-            const postResp = await fetch(
-              `${baseUrl}/rest/api/3/issue/${key}/transitions`,
-              {
-                method: 'POST',
-                headers,
-                body: JSON.stringify({ transition: { id: t.id } }),
-              }
-            );
-            if (!postResp.ok) {
-              core.setFailed(
-                `Transition POST on ${key} failed: ${postResp.status} ${await postResp.text()}`
-              );
-              return;
-            }
-            console.log(`Transitioned ${key}: '${currentStatus}' -> '${targetStatus}'`);
+      - name: Disabled — manual transition required
+        run: |
+          echo "::warning::Jira PR-merge auto-transition is disabled (TECHOPS-421)."
+          echo "::warning::Move the ticket manually through Test → UAT → Ready to Merge → Done."
+          echo "::warning::Context: https://datical.atlassian.net/browse/TECHOPS-421"


### PR DESCRIPTION
## Summary

Field feedback from the SECURE team demo: `jira-transition-on-pr-merge.yml` transitioned tickets to **Done** on PR merge regardless of workflow state — bypassing Test, UAT, and Code Review. A ticket merged mid-UAT got silently auto-closed, hiding the fact that user-acceptance testing was incomplete.

Team decision: **disable the automation entirely**. Engineers drive Test → UAT → Ready to Merge → Done by hand.

Tracks [TECHOPS-421](https://datical.atlassian.net/browse/TECHOPS-421).

## What changed

- Reusable workflow gutted to a no-op: just `echo ::warning::` lines pointing at TECHOPS-421 and `exit 0`
- `workflow_call` signature preserved (all 3 inputs, the `transition` job) so existing callers don't break with "workflow not found"
- 205 deletions, 26 insertions

## Why no-op instead of delete

Several Liquibase repos may already have caller workflows like:

```yaml
uses: liquibase/build-logic/.github/workflows/jira-transition-on-pr-merge.yml@main
```

Deleting the file would fail those workflow runs with `workflow not found` instead of cleanly disabling. The no-op pattern lets each caller remove its `.github/workflows/pr-merge-jira-transition.yml` at its own pace.

## Re-enabling (if ever)

Read TECHOPS-421 first. The UAT-bypass concern needs a redesign (e.g. constrain firing to "Ready to Merge → Done" via the *Merged* transition only), not a straight resurrection.

## Companion PR

liquibase-infrastructure removes its caller workflow + updates `pr-branch-conventions.md` to reflect the new manual flow — separate PR opens shortly.

## Test plan

- [x] `actionlint` clean
- [ ] After merge: any opted-in repo's next PR merge logs the deprecation warning and exits 0 (no Jira touched)
- [ ] After merge: companion liquibase-infrastructure PR can land any time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-421]: https://datical.atlassian.net/browse/TECHOPS-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ