### PR TITLE
fix(scan): expand Grype VEX coverage to full vex-repo [TECHOPS-408]

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -212,19 +212,37 @@ jobs:
               enabled: true
           YAML
 
-          # Grype: download OpenVEX file and configure via .grype.yaml
-          mkdir -p /tmp/liquibase-vex
-          curl -sSfL "https://raw.githubusercontent.com/liquibase/vex-repo/main/pkg/maven/org.liquibase/liquibase-core/vex.openvex.json" \
-            -o /tmp/liquibase-vex/vex.openvex.json
-          echo "VEX file downloaded: $(jq '.statements | length' /tmp/liquibase-vex/vex.openvex.json) statements"
+          # Grype: mirror the full liquibase/vex-repo tree so Grype's
+          # suppression coverage matches Trivy's. Trivy auto-discovers every
+          # pkg/**/vex.openvex.json via TRIVY_VEX=repo; Grype takes an explicit
+          # list of documents. Previously only liquibase-core was loaded, so
+          # CVEs assessed as not_affected for other packages (msal4j,
+          # mssql-jdbc, netty-codec-http*, azure-identity, jackson-core,
+          # setuptools, ...) were still reported by Grype and survived the
+          # downstream dedupe in apps/{docker-public,internal} after Trivy
+          # had filtered them. [TECHOPS-408]
+          rm -rf /tmp/liquibase-vex-repo
+          git clone --depth 1 https://github.com/liquibase/vex-repo /tmp/liquibase-vex-repo
 
-          cat > ~/.grype.yaml << 'YAML'
-          vex-documents:
-            - /tmp/liquibase-vex/vex.openvex.json
-          ignore:
-            - vex-status: not_affected
-            - vex-status: fixed
-          YAML
+          vex_files=()
+          while IFS= read -r f; do
+            vex_files+=("$f")
+          done < <(find /tmp/liquibase-vex-repo/pkg -type f -name 'vex.openvex.json')
+
+          total=$(printf '%s\n' "${vex_files[@]}" \
+            | xargs -I{} jq '.statements | length' {} \
+            | awk '{s+=$1} END{print s+0}')
+          echo "Grype VEX: ${#vex_files[@]} document(s), ${total} total statement(s)"
+
+          {
+            echo "vex-documents:"
+            for f in "${vex_files[@]}"; do
+              echo "  - ${f}"
+            done
+            echo "ignore:"
+            echo "  - vex-status: not_affected"
+            echo "  - vex-status: fixed"
+          } > ~/.grype.yaml
 
       # ============================================
       # OSV-Scanner — Phase 1, gated by run_osv flag (TECHOPS-410).


### PR DESCRIPTION
## Summary

Grype was loading only **one** OpenVEX document (`org.liquibase/liquibase-core/vex.openvex.json`) while Trivy's `TRIVY_VEX=repo` auto-discovers **every** `pkg/**/vex.openvex.json` in [liquibase/vex-repo](https://github.com/liquibase/vex-repo). The mismatch leaked VEX-suppressed CVEs onto the internal portal at security-internal.liquibase.net/docker.

[TECHOPS-408](https://datical.atlassian.net/browse/TECHOPS-408) follow-up. None of the four already-archived TECHOPS-408 changes closed this gap.

## The leak

For any non-`liquibase-core` package with a `not_affected` assessment in vex-repo — msal4j, mssql-jdbc, netty-codec-http*, azure-identity, jackson-core, cassandra-driver-kerberos, liquibase-commercial-mongodb, liquibase-license-utility, pypi/setuptools — the flow was:

1. Trivy filters the CVE (VEX honored).
2. Grype reports it (VEX file for that package was never loaded).
3. \`apps/internal/src/lib/sync/docker.ts\` unions all four scanners (Trivy surface + Trivy deep + Grype + Scout) and calls \`deduplicateVulnerabilities\` in \`packages/docker-lib/src/parse.ts:243\`.
4. The dedupe key is just \`\${cveId}::\${pkgName}\` — no VEX awareness — so the Grype entry survives.
5. Dashboard shows the CVE that VEX is supposed to suppress.

OSV-Scanner (TECHOPS-410 Phase-1) gets its assessments translated via \`vex-to-osv-toml.sh\`, so it doesn't have this bug. Scout uses \`--vex-location ./vex\` after a full vex-repo mirror at \`reusable-docker-scan.yml:202-224\`. Only Grype was stuck on the single-file pattern.

## Fix

Mirror the Scout pattern that's already proven in this same file family:

\`\`\`yaml
git clone --depth 1 https://github.com/liquibase/vex-repo /tmp/liquibase-vex-repo
find /tmp/liquibase-vex-repo/pkg -type f -name 'vex.openvex.json'
# build .grype.yaml dynamically with all paths under vex-documents:
\`\`\`

Replaces \`reusable-vulnerability-scan.yml:215-227\` (the single-file \`curl\`) with the full-tree clone + enumeration + dynamic \`.grype.yaml\`. Logs the document and statement counts for runtime visibility. Ignore rules (\`not_affected\`, \`fixed\`) and Trivy's repository config are unchanged.

Diff: 1 file changed, +31/-13.

## Test plan

- [ ] CI passes
- [ ] Test the change end-to-end by pointing a calling repo (e.g. liquibase-pro's \`trivy-scan-published-images.yml\` workflow) at this branch:
  \`uses: liquibase/build-logic/.github/workflows/reusable-vulnerability-scan.yml@feature/TECHOPS-408-grype-vex-coverage\`
- [ ] Confirm the workflow log shows multiple VEX documents loaded (e.g. \"Grype VEX: 11 document(s), N total statement(s)\")
- [ ] Pick a CVE known to be \`not_affected\` on msal4j or netty-codec-http; verify the Grype results no longer list it after this fix while Trivy's results also exclude it

## Behavior matrix

| \`vex_enabled\` | Before this PR | After this PR |
|---|---|---|
| \`false\` | Step skipped | Step skipped (unchanged) |
| \`true\` | Grype suppresses CVEs only for liquibase-core | Grype suppresses CVEs for **all** packages with VEX assessments |

## Related PRs

- [liquibase/liquibase #7707](https://github.com/liquibase/liquibase/pull/7707) — oss-scan workflow add (consumer of this reusable workflow)
- [liquibase/liquibase-pro #3779-#3783](https://github.com/liquibase/liquibase-pro/pulls?q=is:pr+TECHOPS-408) — VEX auto-assess pipeline hardening (5-PR chain; also consumer)
- [liquibase/docker #546](https://github.com/liquibase/docker/pull/546) — decommission docker repo scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-408]: https://datical.atlassian.net/browse/TECHOPS-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ