### PR TITLE
fix(TECHOPS-427): unblock community QA docker builds (unzip overwrite + URL-agnostic Dockerfile patcher)

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -233,7 +233,7 @@ jobs:
                 tar -xzf "$LIQUIBASE_SECURE_ZIP" -C liquibase-build/
                 echo "Liquibase Secure build extracted from tar.gz to liquibase-build/"
               else
-                unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
+                unzip -qo "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
                 echo "Liquibase Secure build extracted from zip to liquibase-build/"
               fi
             fi
@@ -279,7 +279,7 @@ jobs:
                   "$ARTIFACT_URL"
 
                 # Extract the artifact
-                unzip -q liquibase-artifact.zip
+                unzip -qo liquibase-artifact.zip
                 echo "Artifact contents:"
                 ls -la
 
@@ -297,7 +297,7 @@ jobs:
 
                   # Extract the liquibase zip
                   mkdir -p liquibase-build
-                  unzip -q "$LIQUIBASE_ZIP" -d liquibase-build/
+                  unzip -qo "$LIQUIBASE_ZIP" -d liquibase-build/
 
                   echo "Liquibase build extracted to liquibase-build/"
                   echo "build_ready=true" >> "$GITHUB_OUTPUT"
@@ -371,7 +371,7 @@ jobs:
             tar -xzf "$LIQUIBASE_SECURE_ZIP" -C liquibase-build/
             echo "Liquibase Secure build extracted from tar.gz to liquibase-build/"
           else
-            unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
+            unzip -qo "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
             echo "Liquibase Secure build extracted from zip to liquibase-build/"
           fi
           echo "Contents of liquibase-build:"

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -493,8 +493,14 @@ jobs:
             next
           }
 
-          # Handle standard community Dockerfile wget block
-          build_type != "secure" && dockerfile_basename == "Dockerfile" && /^RUN wget.*github\.com.*liquibase.*tar\.gz/ {
+          # Handle standard community Dockerfile wget block.
+          # Anchor on the destination filename rather than the source host —
+          # the URL moved from github.com (releases/download) to
+          # package.liquibase.com (downloads/dockerhub/official) in #7669
+          # when the community Dockerfile was migrated into liquibase/docker,
+          # and may change again. Matching on `-O liquibase-…tar.gz` is
+          # URL-agnostic and matches both layouts.
+          build_type != "secure" && dockerfile_basename == "Dockerfile" && /^RUN wget.*-O liquibase-.*\.tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""


### PR DESCRIPTION
## Summary

Two related fixes in \`reusable-docker-build-qa.yml\`, both surfaced by the liquibase/docker build-qa-docker.yml run failures on the Community path.

### 1. \`unzip -qo\` — non-interactive artifact extraction

The "Download liquibase build artifact (Community) or from S3 (Liquibase-Secure)" step extracts the downloaded GitHub Actions artifact into the workspace root with \`unzip -q liquibase-artifact.zip\`. The artifact contains a \`LICENSE.txt\` that collides with the LICENSE.txt actions/checkout placed in the workspace from the caller repo. With no stdin in CI, the interactive replace prompt receives EOF, unzip treats it as \`[N]one\`, and the step exits non-zero:

\`\`\`
replace LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: NULL
(EOF or read error, treating as "[N]one" ...)
Error: Process completed with exit code 1.
\`\`\`

Added \`-o\` (overwrite without prompting) to all four \`unzip\` calls in the file — the actual failure site (L282, extracts into cwd), plus three defensive companions (L236, L300, L374) that extract into liquibase-build/ but are exposed to the same prompt if the dir has any stale state.

### 2. URL-agnostic anchor for the community Dockerfile patcher

After the unzip fix unblocked the Community build, the next run failed at docker buildx because the awk patcher that rewrites the Dockerfile's wget block to \`COPY liquibase-build/ ./\` was anchored on \`github.com\`:

\`\`\`awk
build_type != "secure" && dockerfile_basename == "Dockerfile" && /^RUN wget.*github\.com.*liquibase.*tar\.gz/ {
\`\`\`

But [liquibase/liquibase#7669 (DAT-22523)](https://github.com/liquibase/liquibase/pull/7669) on 2026-04-28 migrated the community Dockerfile into liquibase/docker and switched the source URL from \`github.com/liquibase/liquibase/releases/download\` to \`package.liquibase.com/downloads/dockerhub/official\`. The awk pattern was never updated, so the wget block silently passed through. Meanwhile the \`sed -i\` on L465 still rewrote \`ARG LIQUIBASE_VERSION=<release>\` to \`ARG LIQUIBASE_VERSION=<branch>\`, so at build time wget hit \`https://package.liquibase.com/.../liquibase-<branch>.tar.gz\`, the CDN 404'd, and the docker buildx step failed with wget exit code 8.

Re-anchored the pattern on the destination filename — \`-O liquibase-…tar.gz\` — mirroring what the alpine handler does with \`^RUN set -x\`. URL-agnostic, robust to future host swaps, matches both the historical github.com layout and the current package.liquibase.com layout.

## Validation

Pre-merge test rig (build-logic feature branch + parallel \`fix/TECHOPS-427-test-unzip\` branch on liquibase/docker pinning the QA build references to this branch):

| Run | Result | Notes |
|---|---|---|
| [docker run 25762986151](https://github.com/liquibase/docker/actions/runs/25762986151) | Community ❌, Alpine ✅ | After unzip-only fix. Alpine passes, Community gets past unzip then fails at wget. |
| [docker run 25763405471](https://github.com/liquibase/docker/actions/runs/25763405471) | Community ✅, Alpine ✅ | After awk-pattern fix lands. End-to-end green on both Community Dockerfiles. |
| [docker run 25763704364](https://github.com/liquibase/docker/actions/runs/25763704364) | Community ✅, Alpine ✅, Secure download step ✅ | All three \`build_type\` paths exercise the unzip code; all pass. |

The remaining failures in those runs are vulnerability-scan findings (CVE-2022-0839 false-positive on Liquibase SNAPSHOT + 5 Go stdlib CVEs in lpm) — separate from this PR.

## Test plan

- [ ] Merge.
- [ ] Revert the docker test branch (\`fix/TECHOPS-427-test-unzip\`) — flip its three \`uses:\` refs and three \`build_logic_ref\` inputs back to \`@main\`, then close that branch.
- [ ] Re-trigger \`build-qa-docker.yml\` on docker \`main\` to confirm the merged \`@main\` reference works without the test pin.

## References

- Jira: [TECHOPS-427](https://datical.atlassian.net/browse/TECHOPS-427)
- Original failing run: [liquibase/docker run 25756949299](https://github.com/liquibase/docker/actions/runs/25756949299)

[TECHOPS-427]: https://datical.atlassian.net/browse/TECHOPS-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ