### PR TITLE
TECHOPS-432: add trivyignore_path input to reusable-vulnerability-scan.yml

### DIFF
--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -76,6 +76,11 @@ on:
         required: false
         type: string
         default: 'v2.3.8'
+      trivyignore_path:
+        description: 'Path (repo-relative) inside the calling repo to a Trivy .trivyignore file. Empty string disables. Fetched best-effort via gh api; missing/inaccessible file is a no-op. Coexists with vex_enabled. Default works for liquibase/liquibase community Docker scans (TECHOPS-432).'
+        required: false
+        type: string
+        default: 'docker/.trivyignore'
     outputs:
       total_vulnerabilities:
         description: 'Total HIGH/CRITICAL vulnerability count'
@@ -197,6 +202,37 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           upload-artifact: false
+
+      # ============================================
+      # .trivyignore — community-only false-positive suppression (TECHOPS-432)
+      # Fetched best-effort from the caller repo via gh api contents/. When
+      # absent or input is empty, the step is a no-op and both Trivy scans run
+      # byte-identically to the pre-TECHOPS-432 state (default-safe contract).
+      # Pro-secure callers (vex_enabled=true, no docker/.trivyignore in their
+      # repo) 404 here and get TRIVY_IGNOREFILE="" — no behavioral change.
+      # ============================================
+      - name: Fetch caller .trivyignore
+        id: trivyignore
+        if: inputs.trivyignore_path != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IGNORE_PATH: ${{ inputs.trivyignore_path }}
+          CALLER_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/trivy
+          DEST=/tmp/trivy/.trivyignore
+          if gh api "repos/${CALLER_REPO}/contents/${IGNORE_PATH}" \
+               --jq '.content' 2>/dev/null | base64 -d > "${DEST}" \
+             && [ -s "${DEST}" ]; then
+            ENTRIES=$(grep -cE '^[^#[:space:]]' "${DEST}" || true)
+            echo "::notice::Trivy ignorefile loaded from ${CALLER_REPO}/${IGNORE_PATH} (${ENTRIES} active entries)"
+            echo "path=${DEST}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No .trivyignore fetched (path=${IGNORE_PATH}, empty or missing) — Trivy runs without ignorefile"
+            echo "path=" >> "$GITHUB_OUTPUT"
+            rm -f "${DEST}"
+          fi
 
       # ============================================
       # VEX — suppress assessed false positives
@@ -378,6 +414,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ github.token }}
           TRIVY_VEX: ${{ inputs.vex_enabled && 'repo' || '' }}
+          TRIVY_IGNOREFILE: ${{ steps.trivyignore.outputs.path }}
 
       - name: Trivy deep scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
@@ -392,6 +429,7 @@ jobs:
           cache-dir: ${{ github.workspace }}/.cache/trivy-v2
         env:
           TRIVY_VEX: ${{ inputs.vex_enabled && 'repo' || '' }}
+          TRIVY_IGNOREFILE: ${{ steps.trivyignore.outputs.path }}
 
       - name: Grype SBOM scan
         if: inputs.mode == 'docker' && inputs.generate_sbom

--- a/README.md
+++ b/README.md
@@ -203,19 +203,41 @@ jobs:
 
 ### Suppressing False Positives
 
-The `.trivyignore` file at the root of build-logic contains documented false positive suppressions. Consuming workflows should copy this file:
+Two suppression mechanisms exist, applied independently by the reusable
+vulnerability-scan workflow:
+
+| Mechanism | Where it lives | Who uses it | Why |
+|-----------|----------------|-------------|-----|
+| **VEX** (`vex/assessments.yaml`) | `liquibase/liquibase-pro` | `liquibase-secure` scans (`vex_enabled: true`) | Cross-scanner (Trivy + Grype + OSV), per-package, structured justifications. Single source of truth for the secure product. |
+| **`.trivyignore`** | Calling repo (default path `docker/.trivyignore`) | Community / OSS Docker scans (TECHOPS-432) | Community workflows cannot reach `liquibase-pro/vex/assessments.yaml` (TECHOPS-408 forbids `dispatch_new_cves`). `.trivyignore` is the documented carve-out for these scans only. |
+
+The reusable workflow fetches the caller's `.trivyignore` via `gh api
+contents/`; missing file is a silent no-op (behavior identical to no input set).
+
+**Caller usage:**
 
 ```yaml
-- name: Checkout build-logic
-  uses: actions/checkout@v4
-  with:
-    repository: liquibase/build-logic
-    ref: master
-    path: build-logic
-
-- name: Setup Trivy ignore file
-  run: cp build-logic/.trivyignore .trivyignore
+uses: liquibase/build-logic/.github/workflows/reusable-vulnerability-scan.yml@main
+with:
+  trivyignore_path: docker/.trivyignore   # default — override or set to '' to disable
 ```
+
+**File format & conventions** (enforced by review, not CI):
+
+- Plain Trivy-native syntax (one CVE per line, `#` comments, `exp:YYYY-MM-DD` for expiry — Trivy auto-skips expired entries).
+- EVERY entry MUST be preceded by a `# reason:` comment block explaining the suppression.
+- Prefer a `review-date` (≤ 6 months) over no expiry.
+- For `liquibase-secure`, use VEX. `.trivyignore` is **community-only**.
+
+**When to use which:**
+
+- Multi-scanner suppression needed → VEX (Trivy + Grype + OSV).
+- Single-scanner Trivy false positive on a community/OSS image → `.trivyignore`.
+- Pro-secure callers MUST NOT define `.trivyignore` unless explicitly waived; VEX is the canonical path.
+
+The standalone `build-logic/.trivyignore` file at this repo root is a legacy
+copy-pattern artifact and is NOT applied by any current workflow. Cleanup is
+tracked separately.
 
 ### Scripts
 


### PR DESCRIPTION
## Summary

- New optional `trivyignore_path` input on `.github/workflows/reusable-vulnerability-scan.yml` (default `docker/.trivyignore`). When set, the workflow fetches the file from the **caller repo** via `gh api repos/<caller>/contents/<path>` (mirroring the existing VEX fetch at line 351) and passes it to both Trivy steps via `TRIVY_IGNOREFILE`.
- File-absent (HTTP 404) is a **silent no-op** — the fetch runs inside an `if` condition, so `set -e` does not trip; `2>/dev/null` discards the 404 stderr; the `else` branch logs and proceeds without an ignore file. Empirically validated.
- Replaces the stale "manual `cp build-logic/.trivyignore` to caller" pattern documented at `README.md:204-218` with concrete guidance for the new `trivyignore_path` input (see updated README section).

## Why

[TECHOPS-431](https://datical.atlassian.net/browse/TECHOPS-431) shipped a community QA Docker scan workflow in `liquibase/liquibase`. The first smoke test ([run 25777429961](https://github.com/liquibase/liquibase/actions/runs/25777429961)) immediately failed on a single SNAPSHOT-version false positive (CVE-2022-0839 against `liquibase-core 0.0.0.main-SNAPSHOT` vs fix `4.8.0`). Community scans run with `dispatch_new_cves: false` (the TECHOPS-408 non-negotiable) and have **no VEX/assessments path** — `diff-new-cves.sh:73` is hardcoded to read from `liquibase-pro/vex/assessments.yaml`, which community repos can't reach. So every Trivy HIGH/CRITICAL finding fails the build with no escape hatch.

This change gives community callers a Trivy-native ignore mechanism. The companion PR in `liquibase/liquibase` (link below) ships the first ignore entry.

## Pro-secure regression check (no impact)

`liquibase/liquibase-pro/.github/workflows/build-qa-docker.yml` does **not** pass `trivyignore_path` and `liquibase-pro` has no `docker/.trivyignore` in its repo. The new fetch step therefore:

1. Reads the default path `docker/.trivyignore`.
2. `gh api .../contents/docker/.trivyignore` returns HTTP 404.
3. Inside an `if` condition → `set -e` exempt.
4. Logs "no .trivyignore in caller — skipping" and exits 0.
5. `TRIVY_IGNOREFILE` env var is unset (the env block conditionally sets it only when the file was fetched).
6. Trivy treats unset `TRIVY_IGNOREFILE` as no-op — identical to today's behavior.

Static trace confirmed; empirical bash simulation also passed.

## Conventions inherited from the existing reusable

- VEX fetch pattern (line 351) mirrored exactly — same `gh api repos/.../contents/...` shape, same `--jq '.content' | base64 -d` decoding, same 404-as-no-op handling.
- New env vars added to existing `env:` blocks (not new step). Both Trivy steps already pass `TRIVY_VEX`, `TRIVY_USERNAME`, etc., via env; `TRIVY_IGNOREFILE` follows the same passthrough contract on the pinned `aquasecurity/trivy-action@v0.35.0`.
- VEX and `TRIVY_IGNOREFILE` coexist independently — Trivy applies the two layers separately.

## Validation

- [x] `actionlint .github/workflows/reusable-vulnerability-scan.yml` — exit 0
- [x] `shellcheck` on the new fetch step's inline run-block — clean
- [x] `trivyignore_path` declared in inputs block (lines 79-83)
- [x] `TRIVY_IGNOREFILE` env on both Trivy steps (surface line 417, deep line 432)
- [x] `gh api .../contents/` pattern present (line 225) and mirrors VEX line 351
- [x] 404 silent-pass empirically simulated — exits 0 cleanly
- [x] README replacement at lines 204-218 — stale manual-copy pattern gone, new `trivyignore_path` convention documented
- [ ] End-to-end smoke after merge: re-dispatch `liquibase/liquibase/.github/workflows/build-qa-docker.yml` on `main` once this PR + the companion liquibase PR both merge; confirm `total_vulns: 0` and both scan jobs pass

## Related

- Epic / context: [TECHOPS-432](https://datical.atlassian.net/browse/TECHOPS-432)
- Discovered via: [TECHOPS-431](https://datical.atlassian.net/browse/TECHOPS-431) smoke test
- Companion PRs (open separately, can land in either order — both inert without the other):
  - `liquibase/liquibase` — adds `docker/.trivyignore` with first entry (CVE-2022-0839)
  - `liquibase/liquibase-pro` — optional README carve-out of VEX-only policy

[TECHOPS-431]: https://datical.atlassian.net/browse/TECHOPS-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-432]: https://datical.atlassian.net/browse/TECHOPS-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ