### PR TITLE
fix(extension-release): apply TECHOPS-57 batch-mode fix to dry-run [TECHOPS-435]

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -447,9 +447,17 @@ jobs:
           MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
           CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
+          # Provide explicit tag + developmentVersion so input-variables phase doesn't need to prompt for defaults
+          # (in batch mode, missing defaults raise "Project tag cannot be selected if version is not yet mapped").
+          # DRY_RUN_VERSION is always shape "0.0.<run_number>", so the IFS-split below is safe.
+          IFS=. read -r MAJOR MINOR PATCH <<< "$DRY_RUN_VERSION"
+          DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+          ARTIFACT_ID=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+          RELEASE_TAG="${ARTIFACT_ID}-${DRY_RUN_VERSION}"
+          echo "Using developmentVersion=$DEV_VERSION tag=$RELEASE_TAG"
           mvn -B release:clean release:prepare -DdryRun=true -Darguments="-Dmaven.javadoc.skip=true -Dmaven.test.skipTests=true -Dmaven.test.skip=true -Dmaven.deploy.skip=true" \
-          -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=$DRY_RUN_VERSION -DpushChanges=false -P "$MAVEN_PROFILES" \
-          -DscmServerId=liquibase
+          -DcheckModificationExcludeList=** -DignoreSnapshots=true -DreleaseVersion=$DRY_RUN_VERSION -DdevelopmentVersion=$DEV_VERSION -Dtag=$RELEASE_TAG \
+          -DpushChanges=false -P "$MAVEN_PROFILES" -DscmServerId=liquibase
           # Use current branch name for dry runs
           echo "Using current branch: $CURRENT_BRANCH"
           mvn clean install -DskipTests -P "$MAVEN_PROFILES" -DbuildNumber=$CURRENT_BRANCH


### PR DESCRIPTION
## Summary

- Backport the maven-release-plugin batch-mode fix from TECHOPS-57 (commit a88690e, prod-release path) to the `Build release artifacts (dry-run)` step in `extension-attach-artifact-release.yml`.
- Derive `DEV_VERSION` and `RELEASE_TAG` from `DRY_RUN_VERSION` (always shape `0.0.<run_number>`) and pass `-DdevelopmentVersion` + `-Dtag` to `mvn release:prepare`. The derivation literally replicates maven-release-plugin 3.1.1's silent defaults (`patch+1-SNAPSHOT` and `${artifactId}-${releaseVersion}`), so behavior matches last week's green runs.

## Why this was failing

Every Wed `0 6 * * 3` cron dry-run failed in liquibase-sqlfire, liquibase-cassandra, liquibase-db2i, liquibase-teradata, and liquibase-yugabytedb on 2026-05-13 — first scheduled run after `liquibase-parent-pom` v1.0.2 bumped `maven-release-plugin` 3.1.1 → 3.3.1 (rolled in via dependabot 2026-05-07/08). Plugin 3.3.1 in batch mode refuses to derive `developmentVersion` / `tag`, so phase `6/17 prepare:input-variables` died with:

\`\`\`
Error: Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.3.1:prepare
(default-cli) on project liquibase-yugabytedb: Project tag cannot be selected if version
is not yet mapped
\`\`\`

Same error class TECHOPS-57 fixed for the prod path; the dry-run twin step was left unpatched.

## Why this exact derivation (not a simpler shape)

Plugin 3.1.1 silently used `developmentVersion = ${MAJOR}.${MINOR}.$((PATCH+1))-SNAPSHOT` and `tag = ${artifactId}-${releaseVersion}` as defaults. Replicating those values keeps the behavior identical to every green run prior to 2026-05-13. A simpler shape like `${DRY_RUN_VERSION}-SNAPSHOT` / `v${DRY_RUN_VERSION}` would technically satisfy the plugin but would diverge from historical behavior.

## Test plan

- [ ] Manually \`workflow_dispatch\` "Dry run release" in liquibase-yugabytedb (or any of the 5 affected repos) against \`main\` after this PR merges and confirm \`dry-run-attach-artifact-to-release / Attach Artifact to Release\` completes green.
- [ ] Next Wed \`0 6 * * 3\` cron run across the 5 extensions is green.
- [ ] The non-dry-run \`Build release artifacts\` step (TECHOPS-57's a88690e path, ~line 391) is unchanged in this diff.

Closes TECHOPS-435. Sibling of TECHOPS-57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)