### PR TITLE
feat(jira): add NTT to project_keys defaults, keep LSI for legacy commits [TECHOPS-447]

### DIFF
--- a/.github/workflows/jira-set-fixversion-on-release.yml
+++ b/.github/workflows/jira-set-fixversion-on-release.yml
@@ -68,7 +68,7 @@ on:
         description: "Comma-separated Jira project keys to recognise."
         required: false
         type: string
-        default: "TECHOPS,SECURE,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
+        default: "TECHOPS,SECURE,NTT,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
       target_version_name:
         description: "Override the Jira version name. Default: tag with leading 'v' stripped (e.g. v5.3.0 → 5.3.0)."
         required: false

--- a/.github/workflows/jira-transition-on-pr-merge.yml
+++ b/.github/workflows/jira-transition-on-pr-merge.yml
@@ -30,7 +30,7 @@ on:
         description: "(no-op) Retained for caller-side compatibility — workflow is disabled."
         required: false
         type: string
-        default: "TECHOPS,SECURE,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
+        default: "TECHOPS,SECURE,NTT,LSI,INT,CSOL,LAI,PD,DAT,DEVX,ITOPS"
       target_status:
         description: "(no-op) Retained for caller-side compatibility — workflow is disabled."
         required: false


### PR DESCRIPTION
## Summary

The Liquibase Secure Insights project was renamed to **New Technologies Team** on 2026-05-13, with both display name and project key changing (LSI → NTT). Companion to [liquibase-infrastructure PR for TECHOPS-447](https://datical.atlassian.net/browse/TECHOPS-447).

This PR updates the reusable workflow `project_keys` defaults so:
- New commits with `NTT-N` keys are recognized at release time
- Old commits with `LSI-N` keys (pre-rename) still resolve via the regex during the transition window

## Files changed

- `.github/workflows/jira-set-fixversion-on-release.yml` — default list adds `NTT` and keeps `LSI`
- `.github/workflows/jira-transition-on-pr-merge.yml` — same (workflow itself is no-op'd per TECHOPS-421, but keep defaults consistent so a future re-enable doesn't need re-touching)

No code change — only the default value of the `project_keys` input. Caller repos that override `project_keys` continue to use their own list unaffected.

## Transition window

LSI stays in the regex for ~3 months. After that, all commits referencing the project will use `NTT-N` keys (because GitHub squash-merge uses current PR title, and PR titles use the live project key). At that point LSI can be removed from the defaults in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)