### PR TITLE
ci: exclude liquibase-parent-pom from release matrix

### DIFF
--- a/.github/workflows/extension-automated-release.yml
+++ b/.github/workflows/extension-automated-release.yml
@@ -239,12 +239,16 @@ jobs:
     # 2. If draft releases are found, check if they contain the specified version to release.
     # 3. If the version is found publish it as the latest release.
     # 4. Print relevant information about the process.
+    # liquibase-parent-pom is excluded because it uses its own 1.x versioning,
+    # so it never has a v<liquibase-version> draft for this matrix to find.
     needs: update-pom
     runs-on: ubuntu-latest
     name: Release Draft
     strategy:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
+        exclude:
+          - repository: liquibase-parent-pom
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -338,12 +342,16 @@ jobs:
     # 2. It downloads artifacts from published GitHub releases and creates Maven bundles.
     # 3. Each bundle is uploaded to Central Portal with USER_MANAGED publishing type.
     # 4. Operators must manually approve deployments at central.sonatype.com before they go live.
+    # liquibase-parent-pom is excluded because it uses its own 1.x versioning,
+    # so it never has a v<liquibase-version> published release to bundle.
     needs: release-draft-releases
     runs-on: ubuntu-latest
     name: Central Portal
     strategy:
       matrix:
         repository: ${{ fromJson(inputs.repositories) }}
+        exclude:
+          - repository: liquibase-parent-pom
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0


### PR DESCRIPTION
## Summary

- Add `strategy.matrix.exclude` to `release-draft-releases` and `publish-to-central-portal` jobs in `extension-automated-release.yml` so `liquibase-parent-pom` is dropped from those matrices.

## Why

`liquibase-parent-pom` uses its own 1.x versioning track (currently has `v1.0.3` drafted while the rest of the org cycles on Liquibase 5.x). The release-draft job looks for a `v<liquibase-version>` draft on every repo:

```
jq --arg ver "v$VERSION" '[.[] | select(.draft == true and .tag_name == $ver)] | sort_by(.created_at) | last'
```

For parent-pom there is no such tag, so the next line `jq -r '.assets[]'` runs over `null` and dies with `Cannot iterate over null`. Fail-fast then cancels the rest of the matrix and the whole release stalls.

This bit the 5.0.3 release this morning:  
https://github.com/liquibase/liquibase/actions/runs/26030234905/job/76514391858

The `update-pom` job already has the same special case (`if: matrix.repository != 'liquibase-parent-pom'`) for the SNAPSHOT version bump, so this isn't a new concept — just extending the existing exclusion pattern to the two downstream jobs that hit the same versioning assumption.

Parent-pom keeps flowing through:
- `check-security-vulnerabilities` — version-agnostic, fine
- `run-extensions-dependabot` — version-agnostic, fine
- `update-pom` — already special-cased

And gets dropped from:
- `release-draft-releases` — would search for v5.x draft (doesn't exist)
- `publish-to-central-portal` — would poll for v5.x published release (doesn't exist)

Parent-pom continues to release on its own cadence outside this workflow.

## Test plan

- [ ] After merge, re-run the Liquibase extension release with version 5.0.3 and confirm:
  - Release Draft jobs run for the 21 non-parent-pom extensions only
  - Central Portal jobs follow (currently blocked by `needs: release-draft-releases`)
  - Parent-pom is silently absent from those job lists
- [ ] Verify the workflow input list can still legally include `liquibase-parent-pom` without breaking (it just gets excluded by the matrix filter)