### PR TITLE
fix(extension-release): bump pom to release version before rebuilding artifacts

### DIFF
--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -419,6 +419,11 @@ jobs:
           # Remove only maven-release-plugin leftovers; do NOT git-clean everything because the workflow
           # downloads sign_artifact.sh / get_draft_release.sh / upload_asset.sh into .github/ earlier.
           rm -f pom.xml.releaseBackup pom.xml.next pom.xml.tag pom.xml.branch pom.xml.backup release.properties
+          # Set pom to the release version (no -SNAPSHOT) so the subsequent build and the
+          # "Resolve release version" step below produce/read $RELEASE_VERSION without the suffix.
+          # Without this, the post-reset pom is back at <version>-SNAPSHOT and downstream steps
+          # tag the release and name the artifacts as <version>-SNAPSHOT.
+          mvn versions:set -DnewVersion=$RELEASE_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
           # Use GitHub's default branch from repository settings
           echo "Using default branch: $DEFAULT_BRANCH"
           mvn clean install -DskipTests -P "$MAVEN_PROFILES" -DbuildNumber=$DEFAULT_BRANCH


### PR DESCRIPTION
## Summary

In `extension-attach-artifact-release.yml`, the **production** "Build release artifacts" step (lines 391-433, `if: combineJars == false && dry_run == false`) runs:

1. `mvn release:prepare` with `-DreleaseVersion`/`-DdevelopmentVersion`/`-Dtag` (the TECHOPS-57 fix) — line 415
2. `git reset --hard "$PRE_PREPARE_SHA"` to wipe release-plugin's local commits — line 418
3. `mvn clean install` to rebuild — line 424

After step 2 the pom is back at `<version>-SNAPSHOT`, so step 3 produces `<artifactId>-<version>-SNAPSHOT.jar` etc., and the downstream "Resolve release version" step (line 487, runs `mvn help:evaluate -Dexpression=project.version`) reads the unmodified `-SNAPSHOT` value into `$RELEASE_VERSION` for the rest of the workflow (signing, tag patching, asset upload, release title).

Insert one line right after the reset to bump pom to the proper release version (no `-SNAPSHOT`) before the rebuild:

```yaml
mvn versions:set -DnewVersion=$RELEASE_VERSION -DgenerateBackupPoms=false -DprocessAllModules=true
```

`$RELEASE_VERSION` is already stripped of `-SNAPSHOT` upstream in the same step (line 403), so this just realigns the rebuild and the post-reset version-resolver with the value `release:prepare` was already given.

## Relationship to TECHOPS-57 / TECHOPS-435

**This PR does not change either fix.** It addresses a *separate*, collateral bug that was introduced in the same commit as the TECHOPS-57 fix (a88690e).

| Concern | TECHOPS-57 (a88690e) | TECHOPS-435 (eede8db) | This PR |
|---|---|---|---|
| What it changed | `mvn release:prepare` invocation: strip `-SNAPSHOT` from `RELEASE_VERSION`, derive `DEV_VERSION`, derive `RELEASE_TAG`, pass all three to mvn. Added `PRE_PREPARE_SHA` reset for cleanup. | Same fix applied to the **dry-run** path. | Adds one `mvn versions:set` line between the existing reset and the existing `mvn clean install` in the **production** path only. |
| Lines affected | 391-417 (release:prepare call + args) | 448-466 (dry-run release:prepare call + args) | 420-422 (post-reset, pre-rebuild) |
| Lines this PR touches | None | None | One new line |

Verification matrix:

| TECHOPS-57 guarantee | Where to verify in this PR | Verdict |
|---|---|---|
| `RELEASE_VERSION` is non-empty | Line 401-405 (unchanged) | ✅ preserved |
| `-SNAPSHOT` stripped before `release:prepare` | Line 403 (unchanged) | ✅ preserved |
| `-DdevelopmentVersion=$DEV_VERSION` passed | Line 416 (unchanged) | ✅ preserved |
| `-Dtag=$RELEASE_TAG` passed | Line 416 (unchanged) | ✅ preserved |
| `PRE_PREPARE_SHA` reset for cleanup | Line 418 (unchanged) | ✅ preserved |

| TECHOPS-435 guarantee | Where to verify in this PR | Verdict |
|---|---|---|
| Dry-run path passes same args to `release:prepare` | Lines 448-466 (dry-run "Build release artifacts (dry-run)" step, **unchanged**) | ✅ preserved |
| Wednesday `0 6 * * 3` cron stays green | No change to the dry-run path means no behavior change | ✅ preserved |

## How the bug manifested on the 5.0.3 release attempt

All 21 extension repos ended up with:

- Draft tagged `v5.0.3-SNAPSHOT` (instead of `v5.0.3`)
- 16 assets named `<artifactId>-5.0.3-SNAPSHOT.<ext>` (instead of `<artifactId>-5.0.3.<ext>`)
- Release URL prefix `untagged-XXXXX` (no real `v5.0.3-SNAPSHOT` git tag exists; tag_name set via API PATCH only)

`extension-automated-release.yml` then can't find a `v5.0.3` draft (its `Release Draft` step filters `select(.draft == true and .tag_name == $ver)` where `$ver` is `v5.0.3`) and the whole release stalls. Example failed run:  
https://github.com/liquibase/liquibase/actions/runs/26030234905

Sample affected asset URL:  
`https://github.com/liquibase/liquibase-cdi/releases/download/untagged-a658fdfbcc5c84f2a46a/liquibase-cdi-5.0.3-SNAPSHOT.jar`

The v5.0.2 release (March 2026) cut cleanly because the `PRE_PREPARE_SHA` reset did not exist yet — that line was added in TECHOPS-57's commit on 2026-05-11.

## Test plan

- [ ] After merge, re-trigger `Release Extensions` in `liquibase/liquibase` with `version: 5.0.3`
- [ ] Verify each extension's `attach-artifact-release` run produces:
  - Draft tagged `v5.0.3` (no SNAPSHOT)
  - Assets named `<artifactId>-5.0.3.<ext>` and `<artifactId>-5.0.3-{sources,javadoc}.jar` (+ `.asc`/`.md5`/`.sha1` per asset)
- [ ] Confirm `release-draft-releases` job in the calling workflow finds each draft and publishes it
- [ ] Confirm Central Portal phase bundles and uploads successfully
- [ ] Sanity-check TECHOPS-57 path: `mvn release:prepare` log still shows `-DreleaseVersion=5.0.3 -DdevelopmentVersion=5.0.4-SNAPSHOT -Dtag=<artifactId>-5.0.3`
- [ ] Sanity-check TECHOPS-435 path: next Wednesday cron dry-run completes green across liquibase-sqlfire / -cassandra / -db2i / -teradata / -yugabytedb