### PR TITLE
fix(extension-release): publish-draft PATCH uses GH_TOKEN, not unset GITHUB_TOKEN

### DIFF
--- a/.github/workflows/extension-automated-release.yml
+++ b/.github/workflows/extension-automated-release.yml
@@ -329,7 +329,9 @@ jobs:
           RELEASE_ID=$(echo "$DRAFT_RELEASE" | jq -r '.id')
           echo "INFO: Newest Draft release ID: $RELEASE_ID"
           echo "INFO: Publishing the draft release as the latest release to https://api.github.com/repos/liquibase/$REPOSITORY/releases/$RELEASE_ID"
-          PATCH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer $GITHUB_TOKEN" -d '{"draft": false}' "https://api.github.com/repos/liquibase/$REPOSITORY/releases/$RELEASE_ID")
+          # Use $GH_TOKEN (the GitHub App token set in this step's env), not $GITHUB_TOKEN
+          # which is not exported into the shell and would send an empty Bearer header (HTTP 401).
+          PATCH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer $GH_TOKEN" -d '{"draft": false}' "https://api.github.com/repos/liquibase/$REPOSITORY/releases/$RELEASE_ID")
           if [ "$PATCH_STATUS" != "200" ]; then
             echo "ERROR: Failed to publish draft release $RELEASE_ID (HTTP $PATCH_STATUS)"
             exit 1


### PR DESCRIPTION
## Summary

In `extension-automated-release.yml`'s `release-draft-releases` job, the "Check for Artifact in Draft Releases" step does the following:

```yaml
env:
  REPOSITORY: ${{ matrix.repository }}
  VERSION: ${{ inputs.version }}
  GH_TOKEN: ${{ steps.get-token.outputs.token }}
run: |
  ...
  # earlier in the step: uses $GH_TOKEN successfully via the `gh` CLI
  ...
  PATCH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
    -H "Authorization: Bearer $GITHUB_TOKEN" \
    -d '{"draft": false}' \
    "https://api.github.com/repos/liquibase/$REPOSITORY/releases/$RELEASE_ID")
```

The env block sets **`GH_TOKEN`** only. `GITHUB_TOKEN` is not exported into the shell, so `$GITHUB_TOKEN` expands to an empty string. The curl sends `Authorization: Bearer ` (empty) and GitHub responds with HTTP 401, which the script treats as a publish failure and exits 1.

Replace `$GITHUB_TOKEN` with `$GH_TOKEN` so curl uses the same App token the earlier `gh api` calls in the step are already using.

## How it manifested

Today's 5.0.3 release attempt after build-logic#592 and #593:

- 22 success | Check Security Vulnerabilities
- 22 success | Update pom.xml
- 22 success | Dependabot
- **2 failure | Release Draft (liquibase-cassandra, liquibase-oracle)**
- 19 cancelled | Release Draft (rest of matrix, fail-fast)
- 1 skipped  | Central Portal

Failed run: https://github.com/liquibase/liquibase/actions/runs/26037669560

Cassandra and oracle raced past the upstream "watch in-progress CI runs" sleep first (no in-progress runs to wait on) and surfaced the 401 within seconds of each other:

```
INFO: Found an asset containing '5.0.3'
INFO: Newest Draft release ID: 318228896
INFO: Publishing the draft release as the latest release to https://api.github.com/repos/liquibase/liquibase-cassandra/releases/318228896
ERROR: Failed to publish draft release 318228896 (HTTP 401)
##[error]Process completed with exit code 1.
```

The other 19 matrix entries got cancelled before they reached the PATCH step.

## Why didn't v5.0.2 hit this

This step was added in DAT-22607 ("Draft releases management", commit 7ade4fc6, 2026-03-31), after the v5.0.2 release on 2026-03-06. v5.0.2 had no such PATCH step, so the bug never surfaced until now.

## Test plan

- [ ] After merge, re-run Release Extensions in liquibase/liquibase with `version: 5.0.3`
- [ ] Verify Release Draft jobs publish (no HTTP 401)
- [ ] Verify each extension's `v5.0.3` release is no longer draft (`draft: false`)
- [ ] Verify Central Portal phase runs and uploads to Maven Central