### PR TITLE
fix(nightly): 2-stage build to avoid pro/ source-rebuild against upstream main-SNAPSHOT (SECURE-127)

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -99,18 +99,18 @@ jobs:
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          # SECURE-127: nightly is a consumer-style build (pre-migration model).
-          # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages
-          # (published on every main push via the branch-named SNAPSHOT convention).
+          # SECURE-127: nightly is a consumer-style build (pre-migration model),
+          # implemented as 2 stages. See pro-extension-test.yml for the full rationale.
           #
-          # We KEEP -am so private siblings still get built locally. We EXCLUDE
-          # :liquibase-commercial from the reactor so pro/ is not source-compiled
-          # against upstream main-SNAPSHOT: its Pro-only deps on liquibase.validate.*
-          # / liquibase.metadata.* (live in the core/ subtree by design) don't exist
-          # in upstream main. pro/ is resolved as a pre-built JAR from GitHub Packages
-          # instead.
-          EXTRA_FIXED=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(-pl :[^ ]+)/\1,!:liquibase-commercial/')
-          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_FIXED} "-Dliquibase.version=main-SNAPSHOT"
+          # Stage 1 — install all in-tree sibling artifacts to ~/.m2 at native version.
+          mvn -B install -DskipTests=true ${EXTRA_MAVEN_ARGS}
+
+          # Stage 2 — re-compile only the target extension against upstream
+          # main-SNAPSHOT. Strip -am so reactor siblings are not rebuilt; they
+          # resolve from ~/.m2 (stage 1) or GitHub Packages (liquibase-core from
+          # upstream, liquibase-commercial from liquibase-pro).
+          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
+          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -99,14 +99,18 @@ jobs:
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          # SECURE-127: nightly is a consumer-style build (pre-migration model):
+          # SECURE-127: nightly is a consumer-style build (pre-migration model).
           # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages
           # (published on every main push via the branch-named SNAPSHOT convention).
-          # Strip -am so reactor siblings are NOT rebuilt from source: notably pro/'s
-          # compile-time deps on liquibase.validate.* / liquibase.metadata.* (Pro-only
-          # classes living in the core/ subtree by design) don't exist in upstream main.
-          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
-          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
+          #
+          # We KEEP -am so private siblings still get built locally. We EXCLUDE
+          # :liquibase-commercial from the reactor so pro/ is not source-compiled
+          # against upstream main-SNAPSHOT: its Pro-only deps on liquibase.validate.*
+          # / liquibase.metadata.* (live in the core/ subtree by design) don't exist
+          # in upstream main. pro/ is resolved as a pre-built JAR from GitHub Packages
+          # instead.
+          EXTRA_FIXED=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(-pl :[^ ]+)/\1,!:liquibase-commercial/')
+          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_FIXED} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -98,7 +98,15 @@ jobs:
         if: ${{ inputs.nightly }}
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
-        run: mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
+        run: |
+          # SECURE-127: nightly is a consumer-style build (pre-migration model):
+          # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages
+          # (published on every main push via the branch-named SNAPSHOT convention).
+          # Strip -am so reactor siblings are NOT rebuilt from source: notably pro/'s
+          # compile-time deps on liquibase.validate.* / liquibase.metadata.* (Pro-only
+          # classes living in the core/ subtree by design) don't exist in upstream main.
+          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
+          mvn -B dependency:go-offline clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -99,6 +99,16 @@ jobs:
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
+          # Guard (coderabbit): the 2-stage flow below assumes the caller scopes
+          # the build to a single extension + its reactor siblings via `-pl :<mod> -am`.
+          # If extraMavenArgs is empty (the input's default), stage 2 would degrade
+          # into a full-reactor build with -Dliquibase.version=main-SNAPSHOT, which
+          # is exactly the SECURE-127 failure mode this PR fixes. Fail fast instead.
+          if [[ " $EXTRA_MAVEN_ARGS " != *" -pl "* || " $EXTRA_MAVEN_ARGS " != *" -am "* ]]; then
+            echo "::error::Nightly builds must pass extraMavenArgs in the form '-pl :<module> -am' (SECURE-127). Got: '${EXTRA_MAVEN_ARGS}'"
+            exit 1
+          fi
+
           # SECURE-127: nightly is a consumer-style build (pre-migration model),
           # implemented as 2 stages. See pro-extension-test.yml for the full rationale.
           #

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -202,20 +202,29 @@ jobs:
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          # SECURE-127: nightly is a consumer-style build (pre-migration model).
-          # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages,
-          # liquibase-commercial:main-SNAPSHOT from liquibase-pro's GitHub Packages
-          # (published on every main push via the branch-named SNAPSHOT convention).
+          # SECURE-127: nightly is a consumer-style build (pre-migration model),
+          # implemented as 2 stages:
           #
-          # We KEEP -am so private siblings still get built locally (e.g.
-          # tools/liquibase-checks/phileas/ → ai.philterd:phileas-core, not published
-          # anywhere outside this monorepo). We EXCLUDE :liquibase-commercial from
-          # the reactor so pro/ is not source-compiled against upstream main-SNAPSHOT:
-          # its Pro-only deps on liquibase.validate.* / liquibase.metadata.* (live in
-          # the core/ subtree by design) don't exist in upstream main. pro/ is
-          # resolved as a pre-built JAR from GitHub Packages instead.
-          EXTRA_FIXED=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(-pl :[^ ]+)/\1,!:liquibase-commercial/')
-          mvn -B clean package -DskipTests=true ${EXTRA_FIXED} "-Dliquibase.version=main-SNAPSHOT"
+          # Stage 1 — install all in-tree sibling artifacts to ~/.m2 at their native
+          # 5.2.0-SNAPSHOT version. No liquibase.version override here, so pro/
+          # compiles cleanly against in-tree liquibase-core (which has the Pro-only
+          # liquibase.validate.* / liquibase.metadata.* classes by design). Ensures
+          # private siblings like tools/liquibase-checks/phileas/ (ai.philterd:phileas-
+          # core, not published anywhere outside this monorepo) are installed.
+          mvn -B install -DskipTests=true ${EXTRA_MAVEN_ARGS}
+
+          # Stage 2 — re-compile only the target extension against upstream
+          # main-SNAPSHOT, the actual forward-compat check. Strip -am so reactor
+          # siblings are NOT rebuilt; their resolution falls back to:
+          #   - liquibase-core:main-SNAPSHOT       → upstream's GitHub Packages
+          #   - liquibase-commercial:main-SNAPSHOT → liquibase-pro's GitHub Packages
+          #                                          (published every main push via
+          #                                          the branch-named SNAPSHOT convention)
+          #   - private siblings (phileas-core etc.) → ~/.m2 from stage 1
+          # pro/ is NOT source-compiled against upstream main, avoiding the Pro-only-
+          # class compile error that was the original SECURE-127 root cause.
+          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
+          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -202,6 +202,16 @@ jobs:
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
+          # Guard (coderabbit): the 2-stage flow below assumes the caller scopes
+          # the build to a single extension + its reactor siblings via `-pl :<mod> -am`.
+          # If extraMavenArgs is empty (the input's default), stage 2 would degrade
+          # into a full-reactor build with -Dliquibase.version=main-SNAPSHOT, which
+          # is exactly the SECURE-127 failure mode this PR fixes. Fail fast instead.
+          if [[ " $EXTRA_MAVEN_ARGS " != *" -pl "* || " $EXTRA_MAVEN_ARGS " != *" -am "* ]]; then
+            echo "::error::Nightly builds must pass extraMavenArgs in the form '-pl :<module> -am' (SECURE-127). Got: '${EXTRA_MAVEN_ARGS}'"
+            exit 1
+          fi
+
           # SECURE-127: nightly is a consumer-style build (pre-migration model),
           # implemented as 2 stages:
           #

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -202,15 +202,20 @@ jobs:
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
         run: |
-          # SECURE-127: nightly is a consumer-style build (pre-migration model):
+          # SECURE-127: nightly is a consumer-style build (pre-migration model).
           # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages,
           # liquibase-commercial:main-SNAPSHOT from liquibase-pro's GitHub Packages
           # (published on every main push via the branch-named SNAPSHOT convention).
-          # Strip -am so pro/ is NOT rebuilt from source: its compile-time deps on
-          # liquibase.validate.* / liquibase.metadata.* (Pro-only classes living in
-          # the core/ subtree by design) don't exist in upstream main-SNAPSHOT.
-          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
-          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
+          #
+          # We KEEP -am so private siblings still get built locally (e.g.
+          # tools/liquibase-checks/phileas/ → ai.philterd:phileas-core, not published
+          # anywhere outside this monorepo). We EXCLUDE :liquibase-commercial from
+          # the reactor so pro/ is not source-compiled against upstream main-SNAPSHOT:
+          # its Pro-only deps on liquibase.validate.* / liquibase.metadata.* (live in
+          # the core/ subtree by design) don't exist in upstream main. pro/ is
+          # resolved as a pre-built JAR from GitHub Packages instead.
+          EXTRA_FIXED=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(-pl :[^ ]+)/\1,!:liquibase-commercial/')
+          mvn -B clean package -DskipTests=true ${EXTRA_FIXED} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -200,7 +200,17 @@ jobs:
           AZURE_CLIENT_SECRET: ${{ env.AZURE_CLIENT_SECRET }}
           AZURE_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}
           LIQUIBASE_AZURE_STORAGE_ACCOUNT: ${{ env.LIQUIBASE_AZURE_STORAGE_ACCOUNT }}
-        run: mvn -B clean package -DskipTests=true "-Dliquibase.version=main-SNAPSHOT"
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+        run: |
+          # SECURE-127: nightly is a consumer-style build (pre-migration model):
+          # liquibase-core:main-SNAPSHOT comes from upstream's GitHub Packages,
+          # liquibase-commercial:main-SNAPSHOT from liquibase-pro's GitHub Packages
+          # (published on every main push via the branch-named SNAPSHOT convention).
+          # Strip -am so pro/ is NOT rebuilt from source: its compile-time deps on
+          # liquibase.validate.* / liquibase.metadata.* (Pro-only classes living in
+          # the core/ subtree by design) don't exist in upstream main-SNAPSHOT.
+          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
+          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}


### PR DESCRIPTION
## SECURE-127

Jira: https://datical.atlassian.net/browse/SECURE-127
Companion validation DRAFT PR: https://github.com/liquibase/liquibase-pro/pull/3836

## Summary

Both `pro-extension-test.yml` and `os-extension-test.yml` had a nightly **Build & Package** step that did a **source rebuild of the entire monorepo reactor** with `-Dliquibase.version=main-SNAPSHOT`. Inside that reactor, `liquibase-pro`'s `pro/` module imports Pro-only classes (`liquibase.validate.RawChangeSet`, `liquibase.metadata.DatabaseMetadataService`) that live in the `core/` subtree by design — they do **not** exist in upstream `liquibase/liquibase:main-SNAPSHOT`. Result: `pro/` failed to compile and 4 nightly workflows on `liquibase-pro@main` were red for days.

## Fix — 2-stage build

```yaml
        run: |
          # Stage 1 — install all in-tree sibling artifacts to ~/.m2 at their native
          # 5.2.0-SNAPSHOT version. No liquibase.version override here, so pro/ compiles
          # cleanly against in-tree liquibase-core (which has the Pro-only liquibase.validate.*
          # / liquibase.metadata.* classes by design). Ensures private siblings like
          # tools/liquibase-checks/phileas/ (ai.philterd:phileas-core, not published outside
          # this monorepo) are installed.
          mvn -B install -DskipTests=true ${EXTRA_MAVEN_ARGS}

          # Stage 2 — re-compile only the target extension against upstream main-SNAPSHOT,
          # the actual forward-compat check. Strip -am so reactor siblings are NOT rebuilt;
          # they resolve from ~/.m2 (stage 1) or GitHub Packages:
          #   - liquibase-core:main-SNAPSHOT       → upstream's GHP (forward-compat target)
          #   - liquibase-commercial:main-SNAPSHOT → liquibase-pro's GHP (published every
          #                                          main push via branch-named SNAPSHOT)
          EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
```

For `pro-extension-test.yml` the env block was also missing `EXTRA_MAVEN_ARGS` entirely (vs the non-nightly Build step right next to it) — added that too.

## Why 2-stage (not a simpler `-pl` exclusion)

Two cleaner-looking approaches were tried first and validated as broken:

1. **Strip `-am`** broke `Checks Nightly` — `phileas-core` is a private sibling (`tools/liquibase-checks/phileas/`, no remote artifact) that needs `-am` to be built.
2. **Inject `,!:liquibase-commercial`** into `-pl` failed because **two modules in `liquibase-pro` declare the same `artifactId=liquibase-commercial`**: `pro/` (`org.liquibase:liquibase-commercial`) and `repackage/` (`com.liquibase:liquibase-commercial`). Maven's `:foo`-style exclusion is ambiguous. Even fully-qualifying with groupId wouldn't help community modules (mongodb/bigquery/databricks) whose `-am` reactor doesn't include `pro/` at all — Maven errors when an exclusion target isn't in the initial reactor.

The 2-stage approach sidesteps both: stage 1 builds everything in-tree as it would for a normal non-nightly build (where pro/ compiles cleanly), stage 2 re-compiles only the named extension against the upstream override.

Trade-off: ~5–10 min extra per nightly. Negligible for once-a-day jobs.

## Validation (on liquibase-pro DRAFT PR #3836)

| Nightly | Result |
|---|---|
| Checks | ✅ pass (37 min) |
| Azure | ✅ pass (13 min) |
| Vault | ✅ pass (13 min) |

(AWS and MongoDB Community surface pre-existing forward-compat regressions in their *own* extension code — `DynamoSnapshotGenerator` and `NoSqlSnapshotGenerator` `@Override` mismatches against upstream main's API — which are out of scope for this ticket and tracked separately. MongoDB's failure was never the `pro/` compile error; its original Reactor Build Order went straight to `liquibase-mongodb`.)

Validation run links:
- Checks: https://github.com/liquibase/liquibase-pro/actions/runs/26061691791
- Azure: https://github.com/liquibase/liquibase-pro/actions/runs/26061693946
- Vault: https://github.com/liquibase/liquibase-pro/actions/runs/26061695604

## Files

- `.github/workflows/pro-extension-test.yml` — nightly Build step
- `.github/workflows/os-extension-test.yml` — nightly Build step

Non-nightly Build steps in both files are untouched.

## Why pre-migration nightly worked

See SECURE-127 description for the full evidence trail. Short version: branch-named SNAPSHOT publishing in `liquibase-pro/build.yml` (lines 119–130 + 911), the dormant pre-migration `build-nightly.yml` line 114 that ran standalone consumer-style mvn, and the already-wired `setup-maven-settings` action.

## Out of scope

- Splitting `\${liquibase.version}` into separate properties (rejected: pom hygiene unrelated to root cause).
- Moving Pro-only classes from `core/` to `pro/` (rejected: breaks semi-OSS subtree merge model).
- Refreshing extension subtrees against upstream API drift (the AWS/MongoDB `@Override` mismatches) — separate forward-compat work for the respective extension teams.

## Test plan

- [x] Companion `liquibase-pro` DRAFT PR pinned at this branch.
- [x] Checks Nightly passes on `liquibase-pro` DRAFT.
- [x] Azure Extension Nightly passes (regression check).
- [x] Vault Extension Nightly passes (regression check).
- [x] Non-nightly path untouched (no regression possible).
- [ ] Mark this PR ready-for-review; TechOps approval.
- [ ] Merge here, then revert `@SECURE-127-fix-nightly` → `@main` on `liquibase-pro` PR, merge there.