### PR TITLE
TECHOPS-542: read Secure RCs from correct S3 path + fail loudly when missing

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -181,8 +181,9 @@ jobs:
                 # Secure RC artifacts live under non-releases/secure/ — this is
                 # where publish-to-s3.yml in liquibase-pro writes them and where
                 # every live 5.1.x and 5.2.x RC actually sits today. Community
-                # RCs use releases/rc/; do not conflate the two prefixes. This
-                # path must match the post-trigger download step below.
+                # does not publish RCs to S3 at all (see TECHOPS-367), so this
+                # branch is Secure-only. This path must match the post-trigger
+                # download step below.
                 S3_URL="s3://repo.liquibase.com/non-releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
                 echo "Using RC S3 path: $S3_URL"
               else

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -208,12 +208,14 @@ jobs:
                 exit 1
               else
                 echo "Liquibase-Secure build not found in S3."
-                # If secure_version is provided, don't trigger workflow - the build should exist
+                # If secure_version is provided, the build MUST exist at the expected
+                # path. Do not fall back to the last main artifact — that produced
+                # docker images tagged as an RC but containing a months-old build
+                # (TECHOPS-542). Fail loudly so the release pipeline cannot ship a
+                # stale image with a fresh tag.
                 if [[ -n "$SECURE_VERSION" ]]; then
                   echo "ERROR: secure_version specified but build not found in S3. Build should already exist for version $SECURE_VERSION"
-                  echo "trigger_liquibase_secure_workflow=false" >> "$GITHUB_OUTPUT"
-                  echo "build_ready=false" >> "$GITHUB_OUTPUT"
-                  echo "use_fallback=true" >> "$GITHUB_OUTPUT"
+                  exit 1
                 else
                   echo "Branch-based build not found. Will trigger workflow to create it..."
                   echo "trigger_liquibase_secure_workflow=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -178,10 +178,12 @@ jobs:
                 BASE_VERSION="${BASH_REMATCH[1]}"
                 RC_NUMBER="${BASH_REMATCH[2]}"
                 LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
-                # RC artifacts live under releases/rc/ — this must match the
-                # post-trigger download step below. See the download-after-trigger
-                # step for the symmetric path.
-                S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+                # Secure RC artifacts live under non-releases/secure/ — this is
+                # where publish-to-s3.yml in liquibase-pro writes them and where
+                # every live 5.1.x and 5.2.x RC actually sits today. Community
+                # RCs use releases/rc/; do not conflate the two prefixes. This
+                # path must match the post-trigger download step below.
+                S3_URL="s3://repo.liquibase.com/non-releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
                 echo "Using RC S3 path: $S3_URL"
               else
                 # Regular production version
@@ -345,7 +347,7 @@ jobs:
               BASE_VERSION="${BASH_REMATCH[1]}"
               RC_NUMBER="${BASH_REMATCH[2]}"
               LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
-              S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+              S3_URL="s3://repo.liquibase.com/non-releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
             else
               LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
               S3_URL="s3://repo.liquibase.com/releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"


### PR DESCRIPTION
## The problem
Every `docker.liquibase.net/liquibase-secure-rc:*` image shipped to date contains Liquibase Secure 5.1.1 (built 2026-03-26), not the RC build the tag promises. Verified hands-on against `liquibase-secure-rc:5.2.0-RC8`:

```
Starting Liquibase Secure ... (version 5.1.1 #59 built at 2026-03-26 15:14:01 UTC)
```

Two bugs interacting in this reusable workflow:

1. **Wrong S3 path for Secure RCs.** The workflow read Secure RC artifacts from `s3://repo.liquibase.com/releases/rc/` — but the publisher (`liquibase-pro/.github/workflows/publish-to-s3.yml`) writes them to `s3://repo.liquibase.com/non-releases/secure/` since DAT-20800 (Oct 2025). `releases/rc/` is stale legacy Secure data from before that migration; nothing publishes there today.

2. **Silent fallback hid the miss.** When the artifact wasn't found at the expected path, the step logged ERROR, set `use_fallback=true`, and exited 0. The pipeline then silently grabbed `releases/secure/main/liquibase-secure-main.zip` (currently 5.1.1) and shipped it tagged as the RC.

## What this PR does
Three commits, all in `.github/workflows/reusable-docker-build-qa.yml`:

1. **Fail-fast** — when `secure_version` is set but the artifact is missing in S3, `exit 1` instead of falling back. Branch-based path (no `secure_version`) is untouched.
2. **Path fix** — Secure RCs are now read from `non-releases/secure/` in both the initial download step (line ~186) and the post-trigger retry step (line ~350).
3. **Comment correction** — an earlier comment in this PR claimed Community RCs lived under `releases/rc/`. Verified false: Community does not publish RCs to S3 at all. Comment now points to TECHOPS-367 (open ticket tracking the "should Community have an RC pipeline?" decision).

### Behavior matrix
| `secure_version` | Artifact at correct path? | Before | After |
|---|---|---|---|
| Yes | Yes (at `releases/rc/`) | ✅ Found | n/a — path was wrong |
| **Yes** | **Yes (at `non-releases/secure/`)** | **❌ Path miss → silent fallback to stale main** | **✅ Found** |
| **Yes** | **No** | **⚠️ Silent fallback** | **❌ Fail loudly** |
| No | Yes / No | unchanged | unchanged |

## The result
After this PR + liquibase/liquibase-pro#3884 merge AND RC8 is re-run, the next `liquibase-secure-rc:5.2.0-RC8` will actually contain 5.2.0-RC8 — or the workflow will fail loudly. No more silent success with yesterday's build.

## Companion PR
- liquibase/liquibase-pro#3884 — README doc sync.

Both must land before the next RC re-cut. Order doesn't matter.

## Related
- **TECHOPS-367** — tracks the open decision on whether Community should get an RC pipeline at all. Out of scope for this PR. If it lands "yes", the Community path can be added to this workflow incrementally.

## Test plan
- [ ] Reviewer confirms behavior matrix: `secure_version + non-releases/secure/ has artifact` → use it; `secure_version + miss` → exit 1; branch-based path unchanged.
- [ ] Merge.
- [ ] Re-run RC8 release workflow with both PRs in place.
- [ ] `docker run --rm docker.liquibase.net/liquibase-secure-rc:5.2.0-RC8 --version` → reports `5.2.0-RC8`, NOT `5.1.1`.

Closes part of TECHOPS-542 (with liquibase/liquibase-pro#3884).