### PR TITLE
[SECURE-139][SECURE-140] pro-extension-test: race-tolerant main-SNAPSHOT pre-resolve on nightly

### DIFF
--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -428,6 +428,33 @@ jobs:
             mvn -B test -P "$MAVEN_PROFILES"
           fi
 
+      - name: Pre-resolve main-SNAPSHOT dependencies (SECURE-139/140 race-tolerant)
+        if: ${{ inputs.nightly }}
+        shell: bash
+        env:
+          EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
+          MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
+        run: |
+          # SECURE-139/140: the nightly test job re-resolves liquibase-commercial and
+          # liquibase-extension-testing :main-SNAPSHOT from GitHub Packages independently
+          # of the build job, and can land in a publish/cleanup race window where the
+          # SNAPSHOT metadata points at a timestamp whose .jar is briefly absent (a
+          # concurrent liquibase-pro main build is re-publishing/cleaning SNAPSHOTs).
+          # Maven does not retry a 404-absent artifact, so resolve the dependency closure
+          # up front with bounded retries to let a transient miss settle; the test step
+          # then runs with --no-snapshot-updates to consume what we just fetched without
+          # re-racing. Gated to nightly so the common per-PR test path is unaffected.
+          for attempt in 1 2 3 4 5; do
+            if mvn -B -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=main-SNAPSHOT" dependency:resolve; then
+              echo "main-SNAPSHOT dependencies resolved on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Resolve attempt ${attempt} failed (likely SNAPSHOT publish/cleanup race); retrying in 20s..."
+            sleep 20
+          done
+          echo "main-SNAPSHOT dependency resolution still failing after 5 attempts."
+          exit 1
+
       - name: Run Tests
         if: ${{ inputs.nightly }}
         shell: bash
@@ -440,10 +467,13 @@ jobs:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
           MAVEN_PROFILES: ${{ inputs.mavenProfiles }}
         run: |
+          # -nsu (--no-snapshot-updates): consume the main-SNAPSHOT artifacts the
+          # pre-resolve step just fetched into ~/.m2 instead of re-checking GitHub
+          # Packages for a newer timestamp (which is what hit the SECURE-139/140 race).
           if [ -n "$EXTRA_MAVEN_ARGS" ]; then
-            mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=main-SNAPSHOT"
+            mvn -B test -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=main-SNAPSHOT" -nsu
           else
-            mvn -B test -P "$MAVEN_PROFILES" "-Dliquibase.version=main-SNAPSHOT"
+            mvn -B test -P "$MAVEN_PROFILES" "-Dliquibase.version=main-SNAPSHOT" -nsu
           fi
 
       - name: Notify Slack on Build Failure

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -232,7 +232,27 @@ jobs:
           # pro/ is NOT source-compiled against upstream main, avoiding the Pro-only-
           # class compile error that was the original SECURE-127 root cause.
           EXTRA_NO_AM=$(echo "$EXTRA_MAVEN_ARGS" | sed -E 's/(^| )-am( |$)/\1\2/g')
-          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT"
+
+          # SECURE-139/140 (Build-step mitigation, per #601 review feedback): Stage 2 below
+          # resolves liquibase-core / liquibase-commercial :main-SNAPSHOT from GitHub Packages
+          # -- the exact same race surface the unit-test job hit. Pre-resolve with bounded
+          # retries so a transient miss can settle, then -nsu on the package step below so
+          # it consumes what we just fetched. -U on each retry forces a fresh registry check
+          # so Maven's negative-resolution cache doesn't make the retry loop a no-op.
+          for attempt in 1 2 3 4 5; do
+            if mvn -B -U ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT" dependency:resolve; then
+              echo "Build-step main-SNAPSHOT dependencies resolved on attempt ${attempt}."
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "Build-step main-SNAPSHOT dependency resolution still failing after 5 attempts."
+              exit 1
+            fi
+            echo "Build-step resolve attempt ${attempt} failed (likely SNAPSHOT publish/cleanup race); retrying in 20s..."
+            sleep 20
+          done
+
+          mvn -B clean package -DskipTests=true ${EXTRA_NO_AM} "-Dliquibase.version=main-SNAPSHOT" -nsu
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}
@@ -444,8 +464,13 @@ jobs:
           # up front with bounded retries to let a transient miss settle; the test step
           # then runs with --no-snapshot-updates to consume what we just fetched without
           # re-racing. Gated to nightly so the common per-PR test path is unaffected.
+          # -U (--update-snapshots) on each retry forces a fresh registry check, defeating
+          # Maven's negative-resolution cache (default daily updatePolicy for SNAPSHOTs)
+          # so a transient miss on attempt N can actually recover on attempt N+1 (without
+          # -U, the second mvn invocation may serve from the cached miss without re-hitting
+          # GitHub Packages, making the retry loop a no-op).
           for attempt in 1 2 3 4 5; do
-            if mvn -B -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=main-SNAPSHOT" dependency:resolve; then
+            if mvn -B -U -P "$MAVEN_PROFILES" $EXTRA_MAVEN_ARGS "-Dliquibase.version=main-SNAPSHOT" dependency:resolve; then
               echo "main-SNAPSHOT dependencies resolved on attempt ${attempt}."
               exit 0
             fi


### PR DESCRIPTION
## Problem

The nightly `unit-test` job in `pro-extension-test.yml` re-resolves `com.liquibase:liquibase-commercial:main-SNAPSHOT` and `liquibase-extension-testing:main-SNAPSHOT` from GitHub Packages **independently of the `build` job**, and can land in a publish/cleanup race window: a concurrent `liquibase-pro` `main` build is re-publishing/cleaning SNAPSHOTs, so the SNAPSHOT metadata briefly points at a timestamp whose `.jar` is absent. Maven does **not** retry a 404-absent artifact, so the nightly fails intermittently.

Forensics (Vault nightly, SECURE-140): `.pom` for `liquibase-commercial-main-20260520.144115-1` downloaded at 14:47:54, then the `.jar` for that **same** timestamp failed at 14:48:08; a sibling `liquibase-extension-testing-...jar` downloaded fine in the same invocation — so it is not a network outage, only that one artifact was momentarily missing.

## Fix (nightly-only — common per-PR path unchanged)

1. New step **"Pre-resolve main-SNAPSHOT dependencies"** (`if: inputs.nightly`): `mvn dependency:resolve -Dliquibase.version=main-SNAPSHOT` with bounded retries (5 × 20s) so a transient miss settles before tests run.
2. Nightly **Run Tests** now passes `-nsu` (`--no-snapshot-updates`) so it consumes the artifacts the pre-resolve step just fetched into `~/.m2` instead of re-checking the registry and re-racing.

Both changes are gated on `inputs.nightly`, so the non-nightly path used by every other consumer of this reusable workflow is untouched (zero blast radius for normal per-PR CI).

## Validation

This reusable workflow can't be exercised in isolation, so correctness is validated via a **pinned DRAFT PR in `liquibase-pro`** that repoints `azure-extension-tests.yml` + `vault-extension-tests.yml` at this branch and runs the Azure + Vault nightlies. Evidence (green run links) will be added below before this leaves DRAFT.

> DRAFT until the pinned liquibase-pro nightlies are green. Companion: SECURE-139 (Azure), SECURE-140 (Vault). Related publisher-side mitigation: liquibase-pro DAT-22979 (#3886).