### PR TITLE
feat(release-notes): add reusable workflow + aggregator script [TECHOPS-498]

### DIFF
--- a/.github/workflows/release-notes-aggregate.yml
+++ b/.github/workflows/release-notes-aggregate.yml
@@ -1,0 +1,148 @@
+name: "Release notes: aggregate from Jira"
+
+# Reusable workflow that aggregates `## Release note` H2 blocks from every
+# Done Jira ticket in a Fix Version, renders a markdown report with a
+# seven-bucket completeness summary, and optionally appends it to the
+# GitHub Release body in the calling repository.
+#
+# Logic lives at scripts/release-notes/aggregate_release_notes.py in this
+# repo. Stdlib only, no requirements.txt. Callers in liquibase/liquibase,
+# liquibase/liquibase-pro, etc. invoke this workflow via `uses:` and pass
+# the Jira Fix Version name. This workflow checks out build-logic, runs
+# the script, and renders results.
+#
+# Operating modes:
+#   workflow_dispatch (manual)        Caller defaults dry_run to true,
+#                                     preview-only in step summary.
+#   release: [published]              Caller passes release_tag and
+#                                     dry_run=false, the release body
+#                                     gets aggregated notes appended.
+#
+# Per TECHOPS-498. Extracted from liquibase-infrastructure PR #3751.
+#
+# Security: every user-controllable input (inputs.version, inputs.release_tag)
+# is consumed via env vars in run: blocks, never interpolated directly into
+# shell. See the workflow-injection guide:
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Jira Fix Version name (e.g. 'Community 5.0.4', 'Secure 5.2.0', 'Platform 1.0.0', 'MCP Changelog 1.0.0')"
+        required: true
+        type: string
+      dry_run:
+        description: "If true: preview only in step summary + artifact, GitHub Release body untouched. If false: also append notes to the release body (requires release_tag)."
+        required: false
+        type: boolean
+        default: true
+      release_tag:
+        description: "GitHub Release tag to update when dry_run=false. Required when dry_run=false. Ignored when dry_run=true."
+        required: false
+        type: string
+        default: ""
+      build_logic_ref:
+        description: "Ref of liquibase/build-logic to check out for the script (default: main). Pin to a tag in production callers."
+        required: false
+        type: string
+        default: "main"
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Validate inputs
+        run: |
+          if [[ "$DRY_RUN" == "false" && -z "$RELEASE_TAG" ]]; then
+            echo "::error::dry_run=false requires release_tag to be provided"
+            exit 1
+          fi
+
+      - name: Check out build-logic (for the aggregator script)
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/build-logic
+          ref: ${{ inputs.build_logic_ref }}
+          path: build-logic
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get Jira credentials from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Run aggregator
+        env:
+          JIRA_BASE_URL: https://datical.atlassian.net
+          JIRA_EMAIL: ${{ env.JIRA_USER }}
+          JIRA_API_TOKEN: ${{ env.JIRA_API_TOKEN }}
+        run: |
+          mkdir -p release-notes-output
+          python build-logic/scripts/release-notes/aggregate_release_notes.py \
+            --version "$VERSION" \
+            > release-notes-output/release-notes.md
+
+      - name: Render preview in step summary
+        run: |
+          {
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "# Release notes preview — $VERSION"
+              echo ""
+              echo "> _Dry run. The GitHub Release body was NOT updated. Uncheck \`dry_run\` to publish._"
+            else
+              echo "# Release notes published — $VERSION"
+              echo ""
+              echo "> Appended to release \`$RELEASE_TAG\` in \`$GITHUB_REPOSITORY\`."
+            fi
+            echo ""
+            cat release-notes-output/release-notes.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes-output/
+          retention-days: 30
+
+      - name: Append to GitHub Release body
+        if: inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh release view "$RELEASE_TAG" --json body --jq '.body' 2>/dev/null || echo "")
+          generated=$(cat release-notes-output/release-notes.md)
+
+          if [[ -n "$existing" ]]; then
+            new_body="${existing}"$'\n\n---\n\n'"${generated}"
+          else
+            new_body="${generated}"
+          fi
+
+          tmp=$(mktemp)
+          printf '%s' "$new_body" > "$tmp"
+          gh release edit "$RELEASE_TAG" --notes-file "$tmp"
+          rm -f "$tmp"
+
+          echo "::notice::Release $RELEASE_TAG body updated with aggregated Jira release notes."

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Please review the below table of reusable workflows and their descriptions:
 | `pro-extension-build-for-liquibase.yml` | Builds and tests Pro extensions specifically for Liquibase                                                              |
 | `pro-extension-test.yml`                | Same as OS job, but with additional Pro-only vars such as License Key                                                   |
 | `publish-for-liquibase.yml`             | Publishes extensions for Liquibase consumption                                                                          |
+| `release-notes-aggregate.yml`           | Aggregates `## Release note` H2 blocks from Done Jira tickets in a Fix Version and renders the release notes (preview-only on dry-run, or appends to the GitHub Release body on publish) |
 | `slack-notification.yml`                | Sends notifications to Slack when tests fail                                                                            |
 | `sonar-scan.yml`                        | Sonar code coverage scan for PRs and pushes (auto-detects context)                                                      |
 | `sonar-coverage-merge.yml`              | Merges unit/integration test coverage (JaCoCo) and runs Sonar scan for liquibase/liquibase-pro                          |
@@ -266,6 +267,90 @@ build-logic/scripts/vulnerability-scanning/extract-nested-deps.sh \
   --source="./path/to/tarball.tar.gz" \
   --scope=python-only
 ```
+
+## Release Notes Aggregation
+
+The `release-notes-aggregate.yml` workflow walks every Done Jira ticket in a Fix Version, extracts the `## Release note` H2 block from each ticket's description, and renders a paste-ready markdown release notes block plus a seven-bucket completeness report. Logic lives in `scripts/release-notes/` (Python CLI, stdlib only, 70 pytest tests). Per [TECHOPS-498](https://datical.atlassian.net/browse/TECHOPS-498).
+
+Today's callers: [`liquibase/liquibase`](https://github.com/liquibase/liquibase/blob/main/.github/workflows/release-notes-aggregate.yml) (Community), [`liquibase/liquibase-pro`](https://github.com/liquibase/liquibase-pro/blob/main/.github/workflows/release-notes-aggregate.yml) (Secure). Future repos (NTT, Platform, MCP) adopt by pasting the ~85-line caller and swapping the product prefix.
+
+### Operating modes
+
+| Mode | Trigger | Output | Use case |
+|------|---------|--------|----------|
+| **Dry-run preview** | `workflow_dispatch` with `dry_run=true` (default) | Step summary + downloadable `release-notes` artifact | Release manager previews before publishing. GitHub Release body untouched. |
+| **Publish** | `release: [published]` auto-trigger, **or** manual dispatch with `dry_run=false` + `release_tag` | Step summary + artifact + appended to the GitHub Release body | Production. Existing Release Drafter content is preserved with a `---` separator. |
+
+### Usage
+
+**Manual preview (recommended starting point):**
+
+```yaml
+jobs:
+  aggregate:
+    uses: liquibase/build-logic/.github/workflows/release-notes-aggregate.yml@main
+    with:
+      version: "Community 5.0.4"   # or Secure / Platform / MCP X.Y.Z
+      dry_run: true
+    secrets: inherit
+```
+
+**Auto-fire on release publish (publishes to release body):**
+
+```yaml
+on:
+  release:
+    types: [published]
+
+jobs:
+  derive:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - id: compute
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          stripped="${EVENT_TAG#v}"
+          echo "version=Community ${stripped}" >> "$GITHUB_OUTPUT"
+
+  aggregate:
+    needs: derive
+    uses: liquibase/build-logic/.github/workflows/release-notes-aggregate.yml@main
+    with:
+      version: ${{ needs.derive.outputs.version }}
+      dry_run: false
+      release_tag: ${{ github.event.release.tag_name }}
+    secrets: inherit
+```
+
+Swap `Community` for `Secure`, `Platform`, or `MCP Changelog` when adopting in another product repo.
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `version` | string | yes | - | Jira Fix Version name (e.g. `Community 5.0.4`, `Secure 5.2.0`, `Platform 1.0.0`, `MCP Changelog 1.0.0`) |
+| `dry_run` | boolean | no | `true` | If `true`: preview only in step summary + artifact, GitHub Release body untouched. If `false`: also append notes to the release body (requires `release_tag`). |
+| `release_tag` | string | no | `""` | GitHub Release tag to update when `dry_run=false` (e.g. `v5.0.4`). Required when publishing, ignored on dry runs. |
+| `build_logic_ref` | string | no | `main` | Ref of `liquibase/build-logic` to check out for the script. Pin to a tag in production callers for stable behaviour. |
+
+### Auth
+
+Same OIDC pattern as every other `jira-*` workflow in this repo: GitHub OIDC token → assumes org-level role `LIQUIBASE_VAULT_OIDC_ROLE_ARN` → pulls `,/vault/liquibase` from AWS Secrets Manager → sets `JIRA_USER` + `JIRA_API_TOKEN`. Callers just say `secrets: inherit`.
+
+### Convention dependency
+
+The aggregator reads `## Release note` H2 blocks from each ticket's description. Engineers fill that in per the convention from [TECHOPS-479](https://datical.atlassian.net/browse/TECHOPS-479). Tickets without an H2 are flagged in the completeness report (not silently dropped). The `skipReleaseNotes` label from [TECHOPS-478](https://datical.atlassian.net/browse/TECHOPS-478) is honoured as an opt-out.
+
+### Completeness invariant
+
+Every run prints a seven-bucket report; the three mutually-exclusive count buckets satisfy `with_note + skipped + flagged == total_done`. The script asserts this in code and the report renderer fails loudly if it doesn't hold.
+
+### Security
+
+Every user-controllable input (`inputs.version`, `inputs.release_tag`, event payload fields) is consumed via env vars in `run:` blocks. Never interpolated directly into shell. Follows the [GitHub workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).
 
 ## Requirements
 

--- a/scripts/release-notes/.gitignore
+++ b/scripts/release-notes/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/release-notes/README.md
+++ b/scripts/release-notes/README.md
@@ -1,0 +1,184 @@
+# Release Notes Aggregator
+
+`jira/scripts/aggregate_release_notes.py` — TECHOPS-498
+
+Extracts `## Release note` H2 blocks from every Done ticket in a Jira Fix
+Version and emits a markdown report with a seven-bucket completeness summary.
+Output goes to stdout so you can redirect it to a file or pipe it directly.
+
+---
+
+## Prerequisites
+
+- Python 3.11+
+- `JIRA_BASE_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` in your environment
+  (or in `jira/.env` — see `jira/docs/env.example`)
+- The `Unknown` Fix Version must exist in all 9 federated projects
+  (TECHOPS, SECURE, NTT, PD, INT, LSI, CSOL, LAI, DAT).  The script checks
+  this at startup and prints a remediation command if any are missing.
+
+---
+
+## Usage
+
+Run from the `jira/` directory:
+
+```bash
+python3 scripts/aggregate_release_notes.py --version "Community 5.0.4"
+```
+
+To save to a file:
+
+```bash
+python3 scripts/aggregate_release_notes.py --version "Community 5.0.4" > notes.md
+```
+
+**Exit codes**
+
+| Code | Meaning |
+|---:|---|
+| 0 | Success (even if some tickets are flagged) |
+| 1 | Jira / auth / unexpected runtime failure |
+| 2 | Pre-flight failure — `Unknown` Fix Version missing or empty `--version` |
+
+---
+
+## Example Output
+
+```markdown
+# Release Notes — Community 5.0.4
+
+**Total Done tickets:** 47
+**Generated:** 2026-05-22 10:00:00 UTC
+
+---
+
+### Storys
+
+#### SECURE-1234: Improve snapshot performance
+
+Snapshot performance is improved by 40% on schemas with 500+ tables.
+
+### Bugs
+
+[FLAG: empty Affects Version]
+#### DAT-9999: Fix NPE on empty changelog
+
+Null pointer exception on empty changelogs is resolved.
+
+---
+
+## Release Notes Completeness — Community 5.0.4
+
+| Bucket | Count |
+|---|---:|
+| Total Done tickets in Fix Version | 47 |
+| With release note (customer-facing) | 42 |
+| With release note (internal-only) | 0 |
+| Skipped via `skipReleaseNotes` | 3 |
+| Flagged: no H2 + no skip label | 2 |
+
+**Completeness check:** 42 (with note) + 3 (skipped) + 2 (no H2) = 47 / 47 total
+
+### Overlay flags
+
+These counts are subsets of the _With release note_ row above.
+They flag tickets that need a closer look — they do **not** add to the sum.
+
+| Overlay flag | Count |
+|---|---:|
+| Bugs: empty Affects Version (needs follow-up) | 1 |
+| Bugs: Affects Version = Unknown (needs investigation) | 0 |
+
+**Projects encountered:** DAT (12), INT (2), NTT (4), PD (1), SECURE (28)
+```
+
+---
+
+## Completeness Report — Bucket Guide
+
+The completeness report is designed to account for every Done ticket with no
+silent drops. The main table's three non-total buckets are **mutually exclusive**
+and always sum to `total_done`:
+
+| Bucket | What it means | Action |
+|---|---|---|
+| **Total Done** | All Done tickets in the Fix Version | Denominator — nothing to do |
+| **With release note (customer-facing)** | Ticket had a valid `## Release note` H2 and appears in the notes body | Paste into release artifact |
+| **With release note (internal-only)** | Tickets with `release-notes-internal` label — always 0 in v1 | Reserved for v2 |
+| **Skipped via `skipReleaseNotes`** | Engineer applied the `skipReleaseNotes` label — intentional opt-out | No action |
+| **Flagged: no H2 + no skip label** | Ticket has neither a release note nor an opt-out — likely a convention gap | Chase the engineer to add `## Release note` or `skipReleaseNotes` |
+
+**Overlay flags** (shown in the sub-section below the main table) are additional
+attributes on tickets already counted in "With release note (customer-facing)".
+They do NOT add to the sum — they tell you which of those customer-facing tickets
+need a closer look at Affects Version:
+
+| Overlay flag | What it means | Action |
+|---|---|---|
+| **Bugs: empty Affects Version** | Bug has a release note but `Affects Version` is empty and no skip label | Release manager should confirm which version(s) are actually affected |
+| **Bugs: Affects Version = Unknown** | Bug has a release note and `Affects Version = Unknown` sentinel | Engineer set `Unknown` intentionally — investigate and update before publishing |
+
+---
+
+## Troubleshooting
+
+### Pre-flight failure: `Unknown` Fix Version missing
+
+```
+ERROR: 'Unknown' Fix Version is missing in: CSOL
+  Run: python3 jira/scripts/create_fix_versions.py --project CSOL --versions Unknown
+```
+
+Run the printed command for each missing project, then re-run the aggregator.
+This check exists to guarantee the four-state Affects Version classifier works
+correctly once TECHOPS-482 merges.
+
+### Empty output / zero tickets
+
+```
+WARNING: No Done tickets found for Fix Version "Community 5.0.4".
+```
+
+Verify the Fix Version name is spelled exactly as it appears in Jira
+(case-sensitive). If the version exists but has no Done tickets, the script
+exits 0 with an empty notes body and zeroed completeness table — that is
+correct behaviour.
+
+### `[unsupported ADF: <type>]` in the output
+
+The ADF visitor does not yet render every node type. When it encounters an
+unsupported type (e.g. `table`, `mediaSingle`, `panel`), it emits a visible
+placeholder rather than silently dropping content:
+
+```
+[unsupported ADF: table]
+```
+
+If you see this in a published release note:
+
+1. Note the ADF type name from the placeholder.
+2. Open the source Jira ticket and simplify the release note section
+   (remove the table/media and replace with plain text/list), **or**
+3. File a TECHOPS ticket to add support for that node type in the script.
+
+### Auth failure
+
+```
+ERROR: Missing required environment variable: 'JIRA_BASE_URL'
+```
+
+Ensure `JIRA_BASE_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` are set.
+See `jira/docs/env.example` for the `.env` format.
+
+---
+
+## Related
+
+- `jira/scripts/create_fix_versions.py` — pre-create Fix Versions (including `Unknown`)
+- `jira/docs/release-runbook.md` — where this script fits in the release process
+- `jira/docs/description-conventions.md` — `## Release note` H2 convention (TECHOPS-479)
+- TECHOPS-498 — implementation ticket
+- TECHOPS-479 — `## Release note` heading convention
+- TECHOPS-478 — `skipReleaseNotes` label
+- TECHOPS-482 — Affects Version four-state convention (in-flight)

--- a/scripts/release-notes/aggregate_release_notes.py
+++ b/scripts/release-notes/aggregate_release_notes.py
@@ -1,0 +1,704 @@
+"""Aggregate release notes from Done Jira tickets in a Fix Version.
+
+Extracts ``## Release note`` H2 blocks from Done tickets, applies the
+four-state Affects Version rule for Bug issuetypes, and emits a structured
+markdown report plus seven-bucket completeness summary to stdout.
+
+Usage:
+    python scripts/aggregate_release_notes.py --version "Community 5.0.4"
+
+Exit codes:
+    0  success (even if some tickets are flagged)
+    1  Jira / auth / unexpected runtime failure
+    2  pre-flight failure / user input error
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Exit-code constants
+# ---------------------------------------------------------------------------
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_PREFLIGHT = 2
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FEDERATED_PROJECTS: list[str] = [
+    "TECHOPS",
+    "SECURE",
+    "NTT",
+    "PD",
+    "INT",
+    "LSI",
+    "CSOL",
+    "LAI",
+    "DAT",
+]
+
+# Board filter 24722 covers all federated projects — DO NOT enumerate project keys.
+_JQL_TEMPLATE = 'filter = 24722 AND fixVersion = "{version}" AND status = Done'
+
+# Heading aliases that signal the start of a release-note block (post-normalization).
+_RELEASE_NOTE_ALIASES: frozenset[str] = frozenset(
+    [
+        "release note",
+        "user benefit (release note)",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# ADF → Markdown visitor (T-007)
+# ---------------------------------------------------------------------------
+
+
+def _adf_nodes_to_markdown(nodes: list[dict], depth: int = 0) -> str:
+    """Render a list of ADF nodes to markdown.
+
+    Supported node types: paragraph, text (with marks), bulletList, orderedList,
+    listItem, codeBlock, heading, hardBreak, inlineCard, blockCard.
+    Unknown types emit ``[unsupported ADF: <type>]`` — they never raise.
+    """
+    parts: list[str] = []
+    indent = "  " * depth
+
+    for node in nodes:
+        ntype = node.get("type", "")
+        content = node.get("content", [])
+
+        if ntype == "paragraph":
+            inner = _adf_nodes_to_markdown(content, depth)
+            parts.append(inner + "\n")
+
+        elif ntype == "text":
+            text = node.get("text", "")
+            marks = node.get("marks", [])
+            text = _apply_marks(text, marks)
+            parts.append(text)
+
+        elif ntype == "bulletList":
+            parts.append(_render_list(content, depth, ordered=False))
+
+        elif ntype == "orderedList":
+            parts.append(_render_list(content, depth, ordered=True))
+
+        elif ntype == "listItem":
+            # listItem is rendered by the parent list renderer; reaching here
+            # means an orphaned listItem — render its children inline.
+            parts.append(_adf_nodes_to_markdown(content, depth))
+
+        elif ntype == "codeBlock":
+            lang = node.get("attrs", {}).get("language", "") or ""
+            code_text = "".join(
+                n.get("text", "") for n in content if n.get("type") == "text"
+            )
+            parts.append(f"```{lang}\n{code_text}\n```\n")
+
+        elif ntype == "heading":
+            level = node.get("attrs", {}).get("level", 2)
+            # Never emit H2 (would collide with the section heading); shift down.
+            effective_level = max(level, 3)
+            hashes = "#" * effective_level
+            heading_text = _adf_nodes_to_markdown(content, depth).strip()
+            parts.append(f"{hashes} {heading_text}\n")
+
+        elif ntype == "hardBreak":
+            parts.append("  \n")
+
+        elif ntype in ("inlineCard", "blockCard"):
+            url = node.get("attrs", {}).get("url", "")
+            parts.append(f"[{url}]({url})")
+
+        else:
+            parts.append(f"[unsupported ADF: {ntype}]")
+
+    return "".join(parts)
+
+
+def _apply_marks(text: str, marks: list[dict]) -> str:
+    """Apply inline ADF marks to a text string, returning decorated markdown."""
+    for mark in marks:
+        mtype = mark.get("type", "")
+        if mtype == "strong":
+            text = f"**{text}**"
+        elif mtype == "em":
+            text = f"_{text}_"
+        elif mtype == "code":
+            text = f"`{text}`"
+        elif mtype == "link":
+            href = mark.get("attrs", {}).get("href", "")
+            text = f"[{text}]({href})"
+        # Other mark types (underline, strike, etc.) are silently dropped.
+    return text
+
+
+def _render_list(
+    items: list[dict], depth: int, ordered: bool
+) -> str:
+    """Render a bulletList or orderedList ADF node to markdown."""
+    lines: list[str] = []
+    indent = "  " * depth
+    for idx, item in enumerate(items):
+        if item.get("type") != "listItem":
+            continue
+        prefix = f"{idx + 1}." if ordered else "-"
+        # A listItem may contain paragraphs (inline text) and nested lists.
+        # Inline text goes on the same line as the prefix; nested lists go
+        # on subsequent lines (indented) so they render correctly in markdown.
+        inline_parts: list[str] = []
+        nested_parts: list[str] = []
+        for child in item.get("content", []):
+            if child.get("type") in ("bulletList", "orderedList"):
+                nested = _render_list(
+                    child.get("content", []),
+                    depth + 1,
+                    ordered=(child.get("type") == "orderedList"),
+                )
+                nested_parts.append(nested.rstrip("\n"))
+            else:
+                inline_parts.append(
+                    _adf_nodes_to_markdown([child], depth).rstrip("\n")
+                )
+        item_text = " ".join(p.strip() for p in inline_parts if p.strip())
+        lines.append(f"{indent}{prefix} {item_text}")
+        for nested in nested_parts:
+            lines.append(nested)
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# ADF H2 extractor (T-006)
+# ---------------------------------------------------------------------------
+
+
+def _normalize(s: str) -> str:
+    """Normalize a heading string for alias matching."""
+    return s.strip().lower().rstrip(":").strip()
+
+
+def _heading_text(node: dict) -> str:
+    """Extract plain text from a heading ADF node (ignores inline marks)."""
+    return "".join(
+        n.get("text", "")
+        for n in node.get("content", [])
+        if n.get("type") == "text"
+    )
+
+
+def _find_release_note_heading(content: list[dict]) -> int:
+    """Return the index of the matching H2 release-note heading, or -1."""
+    for i, node in enumerate(content):
+        if node.get("type") == "heading" and node.get("attrs", {}).get("level") == 2:
+            if _normalize(_heading_text(node)) in _RELEASE_NOTE_ALIASES:
+                return i
+    return -1
+
+
+def _collect_section_nodes(content: list[dict], idx: int) -> list[dict]:
+    """Return nodes from idx+1 up to (not including) the next heading of any level."""
+    result: list[dict] = []
+    for node in content[idx + 1 :]:
+        if node.get("type") == "heading":
+            break
+        result.append(node)
+    return result
+
+
+def extract_release_note(issue: dict) -> str | None:
+    """Extract the release note markdown block from an issue's ADF description.
+
+    Returns None if the issue has no matching H2 (bucket: no_h2_no_skip).
+    """
+    description = (issue.get("fields") or {}).get("description")
+    if not description:
+        return None
+
+    content = description.get("content", [])
+    idx = _find_release_note_heading(content)
+    if idx == -1:
+        return None
+
+    section_nodes = _collect_section_nodes(content, idx)
+    if not section_nodes:
+        return ""
+
+    return _adf_nodes_to_markdown(section_nodes).strip()
+
+
+# ---------------------------------------------------------------------------
+# Bug Affects-Version four-state classifier (T-008)
+# ---------------------------------------------------------------------------
+
+
+def classify_affects_version(issue: dict) -> str:
+    """Classify the Affects Version state of an issue.
+
+    Returns one of: ``"populated"``, ``"unknown"``, ``"empty_with_skip"``,
+    ``"empty_alone"``.
+
+    Story and Task issuetypes short-circuit to ``"populated"`` — Affects
+    Version logic is Bug-only.
+    """
+    fields = issue.get("fields") or {}
+    issuetype = (fields.get("issuetype") or {}).get("name", "")
+
+    if issuetype not in ("Bug",):
+        return "populated"
+
+    labels: set[str] = set(fields.get("labels") or [])
+    versions = fields.get("versions")  # may be None (field absent) or list
+
+    if versions is None:
+        # Field absent — graceful degradation (TECHOPS-482 unmerged)
+        return "empty_alone"
+
+    if not versions:
+        # Empty array
+        if "skipReleaseNotes" in labels:
+            return "empty_with_skip"
+        return "empty_alone"
+
+    names = {v.get("name") for v in versions}
+    if names == {"Unknown"}:
+        return "unknown"
+
+    # Mixed Unknown + real versions → treat as populated
+    return "populated"
+
+
+# ---------------------------------------------------------------------------
+# JQL fetcher (T-005)
+# ---------------------------------------------------------------------------
+
+
+def fetch_issues(client: Any, version: str) -> list[dict]:
+    """Fetch all Done issues in a Fix Version via paginated JQL.
+
+    Uses board filter 24722 — does NOT enumerate project keys.
+    Returns a flat list of issue dicts.  Exits non-zero on unrecoverable errors.
+    """
+    jql = _JQL_TEMPLATE.format(version=version)
+    fields = [
+        "summary",
+        "description",
+        "issuetype",
+        "labels",
+        "versions",
+        "project",
+        "status",
+    ]
+
+    issues: list[dict] = []
+    next_page_token: str | None = None
+
+    while True:
+        payload: dict[str, Any] = {
+            "jql": jql,
+            "fields": fields,
+            "maxResults": 50,
+        }
+        if next_page_token:
+            payload["nextPageToken"] = next_page_token
+
+        try:
+            resp = client.request("POST", "/rest/api/3/search/jql", json=payload)
+        except RuntimeError as exc:
+            error_text = str(exc)
+            # Distinguish 4xx from other errors; 429 is already retried by JiraClient.
+            if "-> 4" in error_text:
+                print(
+                    f"ERROR: Jira returned a client error fetching Fix Version "
+                    f'"{version}": {error_text}',
+                    file=sys.stderr,
+                )
+                sys.exit(EXIT_ERROR)
+            raise
+
+        if resp is None:
+            break
+
+        batch = resp.get("issues") or []
+        issues.extend(batch)
+
+        next_page_token = resp.get("nextPageToken")
+        if not next_page_token:
+            break
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight check (T-004)
+# ---------------------------------------------------------------------------
+
+
+def preflight_unknown_fix_version(client: Any) -> None:
+    """Verify that Fix Version ``Unknown`` exists in all 9 federated projects.
+
+    Exits with EXIT_PREFLIGHT (2) and an actionable error if any are missing.
+    Exits with EXIT_ERROR (1) on Jira network / auth failures.
+    """
+    missing: list[str] = []
+
+    for key in FEDERATED_PROJECTS:
+        try:
+            versions = client.request("GET", f"/rest/api/3/project/{key}/versions")
+        except RuntimeError as exc:
+            print(
+                f"ERROR: Could not reach Jira to check Fix Versions for project "
+                f"{key}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(EXIT_ERROR)
+
+        if not any(v.get("name") == "Unknown" for v in (versions or [])):
+            missing.append(key)
+
+    if missing:
+        missing_str = ", ".join(missing)
+        print(
+            f"ERROR: 'Unknown' Fix Version is missing in: {missing_str}",
+            file=sys.stderr,
+        )
+        for key in missing:
+            print(
+                f"  Run: python3 jira/scripts/create_fix_versions.py "
+                f"--project {key} --versions Unknown",
+                file=sys.stderr,
+            )
+        sys.exit(EXIT_PREFLIGHT)
+
+
+# ---------------------------------------------------------------------------
+# Bucket counter + accumulator (T-009)
+# ---------------------------------------------------------------------------
+
+
+def _issue_key(issue: dict) -> str:
+    return issue.get("key", "")
+
+
+def _project_key(issue: dict) -> str:
+    """Return the Jira project key for an issue (e.g. 'SECURE' from 'SECURE-1234')."""
+    key = _issue_key(issue)
+    return key.split("-")[0] if "-" in key else "UNKNOWN"
+
+
+def accumulate_issues(
+    issues: list[dict],
+) -> tuple[list[dict], dict[str, int], dict[str, int]]:
+    """Walk issues and compute buckets + entries + project counts for rendering.
+
+    Returns:
+        entries: list of dicts ready for render_notes_section()
+        buckets: dict with seven bucket counts
+        project_counts: dict mapping project key → total Done ticket count
+
+    The invariant (per spec clarification) is:
+        with_note_customer + skipped + no_h2_no_skip == total_done
+
+    AV flag buckets (affects_version_empty_alone, affects_version_unknown) are
+    OVERLAY counts on with_note_customer — they do NOT add to the sum.
+
+    project_counts covers ALL Done tickets (not just those with notes) so the
+    footer surfaces federated-project drift even when no ticket has a release note.
+    """
+    buckets: dict[str, int] = {
+        "total_done": len(issues),
+        "with_note_customer": 0,
+        "with_note_internal": 0,  # always 0 in v1
+        "skipped": 0,
+        "no_h2_no_skip": 0,
+        "affects_version_empty_alone": 0,
+        "affects_version_unknown": 0,
+    }
+
+    entries: list[dict] = []
+    project_counts: dict[str, int] = {}
+
+    for issue in issues:
+        fields = issue.get("fields") or {}
+        labels: set[str] = set(fields.get("labels") or [])
+
+        # Count every issue toward project totals (even skipped / no-H2).
+        proj = _project_key(issue)
+        project_counts[proj] = project_counts.get(proj, 0) + 1
+
+        # skipReleaseNotes wins over everything else.
+        if "skipReleaseNotes" in labels:
+            buckets["skipped"] += 1
+            continue
+
+        # Attempt H2 extraction.
+        note_md = extract_release_note(issue)
+
+        if note_md is None:
+            # No H2, no skip — flagged but not included in body.
+            buckets["no_h2_no_skip"] += 1
+            continue
+
+        # Ticket has a release note; it goes into the customer-facing body.
+        buckets["with_note_customer"] += 1
+
+        # Determine AV overlay flags (Bugs only).
+        av_state = classify_affects_version(issue)
+        flags: list[str] = []
+
+        if av_state == "empty_alone":
+            buckets["affects_version_empty_alone"] += 1
+            flags.append("empty Affects Version")
+        elif av_state == "unknown":
+            buckets["affects_version_unknown"] += 1
+            flags.append("Unknown Affects Version")
+
+        issuetype = (fields.get("issuetype") or {}).get("name", "")
+        summary = fields.get("summary", "")
+
+        entries.append(
+            {
+                "key": _issue_key(issue),
+                "project": proj,
+                "issuetype": issuetype,
+                "summary": summary,
+                "note_md": note_md,
+                "flags": flags,
+            }
+        )
+
+    return entries, buckets, project_counts
+
+
+# ---------------------------------------------------------------------------
+# Output renderer (T-010)
+# ---------------------------------------------------------------------------
+
+_ISSUETYPE_ORDER = {"Story": 0, "Task": 1, "Bug": 2}
+
+
+def _sort_key(entry: dict) -> tuple[int, str]:
+    """Sort key: issuetype group first, then issue key ascending."""
+    order = _ISSUETYPE_ORDER.get(entry["issuetype"], 99)
+    # Sort by project key + numeric part of issue key for stable natural sort.
+    key = entry["key"]
+    match = re.match(r"([A-Z]+)-(\d+)", key)
+    if match:
+        return (order, match.group(1), int(match.group(2)))
+    return (order, key, 0)
+
+
+def render_notes_section(entries: list[dict]) -> str:
+    """Render the notes body: Stories/Tasks first, then Bugs, sorted by key."""
+    if not entries:
+        return "_No release notes found for this Fix Version._\n"
+
+    sorted_entries = sorted(entries, key=_sort_key)
+    parts: list[str] = []
+
+    current_group: str | None = None
+    for entry in sorted_entries:
+        group = entry["issuetype"]
+        if group != current_group:
+            current_group = group
+            parts.append(f"\n### {group}s\n")
+
+        for flag in entry["flags"]:
+            parts.append(f"[FLAG: {flag}]\n")
+
+        parts.append(f"#### {entry['key']}: {entry['summary']}\n\n")
+        if entry["note_md"]:
+            parts.append(entry["note_md"] + "\n\n")
+
+    return "".join(parts).lstrip("\n")
+
+
+def render_completeness_report(buckets: dict[str, int], version_name: str) -> str:
+    """Render the seven-bucket completeness table.
+
+    The main table covers the three exclusive buckets that sum to total_done:
+        with_note_customer + skipped + no_h2_no_skip == total_done
+
+    A separate "Overlay flags" sub-section shows the AV flag counts, which
+    are additional attributes ON with_note_customer tickets — they do NOT
+    add to the sum.
+    """
+    total = buckets["total_done"]
+    with_note = buckets["with_note_customer"]
+    with_note_internal = buckets["with_note_internal"]
+    skipped = buckets["skipped"]
+    no_h2 = buckets["no_h2_no_skip"]
+    av_empty = buckets["affects_version_empty_alone"]
+    av_unknown = buckets["affects_version_unknown"]
+
+    lines: list[str] = [
+        f"## Release Notes Completeness — {version_name}",
+        "",
+        "| Bucket | Count |",
+        "|---|---:|",
+        f"| Total Done tickets in Fix Version | {total} |",
+        f"| With release note (customer-facing) | {with_note} |",
+        f"| With release note (internal-only) | {with_note_internal} |",
+        f"| Skipped via `skipReleaseNotes` | {skipped} |",
+        f"| Flagged: no H2 + no skip label | {no_h2} |",
+        "",
+        "**Completeness check:** "
+        f"{with_note} (with note) + {skipped} (skipped) + {no_h2} (no H2) = "
+        f"{with_note + skipped + no_h2} / {total} total",
+        "",
+        "### Overlay flags",
+        "",
+        "These counts are subsets of the _With release note_ row above.",
+        "They flag tickets that need a closer look — they do **not** add to the sum.",
+        "",
+        "| Overlay flag | Count |",
+        "|---|---:|",
+        f"| Bugs: empty Affects Version (needs follow-up) | {av_empty} |",
+        f"| Bugs: Affects Version = Unknown (needs investigation) | {av_unknown} |",
+    ]
+
+    return "\n".join(lines)
+
+
+def render_output(
+    version_name: str,
+    entries: list[dict],
+    buckets: dict[str, int],
+    timestamp: str,
+    project_counts: dict[str, int] | None = None,
+) -> str:
+    """Stitch all output sections into the final markdown string.
+
+    project_counts covers ALL Done tickets (including skipped / no-H2) so the
+    footer surfaces federated-project drift even when no ticket has a release note.
+    If omitted, falls back to counting from entries only (backward-compatible).
+    """
+    total = buckets["total_done"]
+
+    # Build project contribution footer.
+    if project_counts is None:
+        # Fallback: count from entries (used only in legacy / test callers that
+        # haven't been updated to pass project_counts).
+        project_counts = {}
+        for entry in entries:
+            proj = entry["project"]
+            project_counts[proj] = project_counts.get(proj, 0) + 1
+
+    footer_parts = [f"{k} ({v})" for k, v in sorted(project_counts.items())]
+    footer = ", ".join(footer_parts) if footer_parts else "none"
+
+    title_block = (
+        f"# Release Notes — {version_name}\n\n"
+        f"**Total Done tickets:** {total}  \n"
+        f"**Generated:** {timestamp} UTC\n"
+    )
+
+    notes_body = render_notes_section(entries)
+    completeness = render_completeness_report(buckets, version_name)
+
+    return (
+        title_block
+        + "\n---\n\n"
+        + notes_body
+        + "\n---\n\n"
+        + completeness
+        + "\n\n"
+        + f"**Projects encountered:** {footer}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (T-003)
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """CLI entry point for aggregate_release_notes.
+
+    Exit codes:
+        0  success
+        1  Jira / auth / unexpected runtime failure
+        2  pre-flight failure / user input error
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate release notes from Done Jira tickets in a Fix Version.\n"
+            "Output is markdown emitted to stdout."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        metavar="NAME",
+        help='Jira Fix Version name, e.g. "Community 5.0.4", "Secure 5.2.0", "Platform 1.0.0", "MCP Changelog 1.0.0"',
+    )
+
+    args = parser.parse_args()
+    version_name: str = args.version.strip()
+
+    if not version_name:
+        parser.error("--version cannot be empty")
+
+    # Import here so tests can mock JiraClient before main() is called.
+    try:
+        from jira_client import JiraClient  # type: ignore[import]
+    except ImportError:
+        # Support running from the repo root (python jira/scripts/...)
+        import importlib.util
+        import os
+
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        spec = importlib.util.spec_from_file_location(
+            "jira_client", os.path.join(script_dir, "jira_client.py")
+        )
+        module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        JiraClient = module.JiraClient
+
+    try:
+        client = JiraClient()
+    except KeyError as exc:
+        print(
+            f"ERROR: Missing required environment variable: {exc}\n"
+            "Set JIRA_BASE_URL, JIRA_EMAIL, and JIRA_API_TOKEN.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    # Pre-flight: Unknown Fix Version must exist in all federated projects.
+    preflight_unknown_fix_version(client)
+
+    # Fetch issues.
+    try:
+        issues = fetch_issues(client, version_name)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if not issues:
+        print(
+            f'WARNING: No Done tickets found for Fix Version "{version_name}".',
+            file=sys.stderr,
+        )
+
+    # Accumulate buckets, entries, and project counts.
+    entries, buckets, project_counts = accumulate_issues(issues)
+
+    # Render output.
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    output = render_output(version_name, entries, buckets, timestamp, project_counts)
+
+    print(output)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release-notes/tests/conftest.py
+++ b/scripts/release-notes/tests/conftest.py
@@ -1,0 +1,6 @@
+"""Add the parent directory (scripts/release-notes/) to sys.path so
+`import aggregate_release_notes` works when pytest is invoked from any cwd."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/scripts/release-notes/tests/fixtures/adf/canonical_h2.json
+++ b/scripts/release-notes/tests/fixtures/adf/canonical_h2.json
@@ -1,0 +1,15 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "This fix prevents a crash when upgrading from 5.0."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/capital_n_alias.json
+++ b/scripts/release-notes/tests/fixtures/adf/capital_n_alias.json
@@ -1,0 +1,15 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release Note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Capital N alias body text."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/code_block.json
+++ b/scripts/release-notes/tests/fixtures/adf/code_block.json
@@ -1,0 +1,25 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Example usage:"}]
+    },
+    {
+      "type": "codeBlock",
+      "attrs": {"language": "sql"},
+      "content": [
+        {
+          "type": "text",
+          "text": "SELECT * FROM changelog WHERE executed = true;"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/legacy_alias.json
+++ b/scripts/release-notes/tests/fixtures/adf/legacy_alias.json
@@ -1,0 +1,15 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "User benefit (release note)"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Legacy alias body text."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/marks_variety.json
+++ b/scripts/release-notes/tests/fixtures/adf/marks_variety.json
@@ -1,0 +1,45 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [
+        {
+          "type": "text",
+          "text": "bold",
+          "marks": [{"type": "strong"}]
+        },
+        {"type": "text", "text": " "},
+        {
+          "type": "text",
+          "text": "italic",
+          "marks": [{"type": "em"}]
+        },
+        {"type": "text", "text": " "},
+        {
+          "type": "text",
+          "text": "code",
+          "marks": [{"type": "code"}]
+        },
+        {"type": "text", "text": " "},
+        {
+          "type": "text",
+          "text": "link text",
+          "marks": [{"type": "link", "attrs": {"href": "https://example.com"}}]
+        },
+        {"type": "text", "text": " "},
+        {
+          "type": "text",
+          "text": "bold-italic",
+          "marks": [{"type": "strong"}, {"type": "em"}]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/multi_paragraph.json
+++ b/scripts/release-notes/tests/fixtures/adf/multi_paragraph.json
@@ -1,0 +1,23 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "First paragraph of the release note."}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Second paragraph with more detail."}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Third paragraph wrapping up."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/nested_bullets.json
+++ b/scripts/release-notes/tests/fixtures/adf/nested_bullets.json
@@ -1,0 +1,39 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "bulletList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{"type": "text", "text": "Top-level item"}]
+            },
+            {
+              "type": "bulletList",
+              "content": [
+                {
+                  "type": "listItem",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [{"type": "text", "text": "Nested item"}]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/no_h2.json
+++ b/scripts/release-notes/tests/fixtures/adf/no_h2.json
@@ -1,0 +1,19 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "This ticket has no release-note H2 heading."}]
+    },
+    {
+      "type": "heading",
+      "attrs": {"level": 3},
+      "content": [{"type": "text", "text": "Implementation details"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Some impl detail."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/ordered_list.json
+++ b/scripts/release-notes/tests/fixtures/adf/ordered_list.json
@@ -1,0 +1,34 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "orderedList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{"type": "text", "text": "First step"}]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{"type": "text", "text": "Second step"}]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/trailing_colon_alias.json
+++ b/scripts/release-notes/tests/fixtures/adf/trailing_colon_alias.json
@@ -1,0 +1,15 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note:"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Trailing colon alias body text."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/adf/unsupported_node.json
+++ b/scripts/release-notes/tests/fixtures/adf/unsupported_node.json
@@ -1,0 +1,33 @@
+{
+  "type": "doc",
+  "version": 1,
+  "content": [
+    {
+      "type": "heading",
+      "attrs": {"level": 2},
+      "content": [{"type": "text", "text": "Release note"}]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "Before the table."}]
+    },
+    {
+      "type": "table",
+      "content": [
+        {
+          "type": "tableRow",
+          "content": [
+            {
+              "type": "tableCell",
+              "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Cell"}]}]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "content": [{"type": "text", "text": "After the table."}]
+    }
+  ]
+}

--- a/scripts/release-notes/tests/fixtures/golden/output_mixed.md
+++ b/scripts/release-notes/tests/fixtures/golden/output_mixed.md
@@ -1,0 +1,55 @@
+# Release Notes — Community 5.0.4
+
+**Total Done tickets:** 6  
+**Generated:** 2026-05-22 10:00:00 UTC
+
+---
+
+### Storys
+#### DAT-100: Story fix
+
+This fix prevents a crash when upgrading from 5.0.
+
+
+### Tasks
+#### DAT-101: Task improvement
+
+This fix prevents a crash when upgrading from 5.0.
+
+
+### Bugs
+#### DAT-102: Bug fix A
+
+This fix prevents a crash when upgrading from 5.0.
+
+[FLAG: empty Affects Version]
+#### DAT-103: Bug fix B
+
+This fix prevents a crash when upgrading from 5.0.
+
+
+---
+
+## Release Notes Completeness — Community 5.0.4
+
+| Bucket | Count |
+|---|---:|
+| Total Done tickets in Fix Version | 6 |
+| With release note (customer-facing) | 4 |
+| With release note (internal-only) | 0 |
+| Skipped via `skipReleaseNotes` | 1 |
+| Flagged: no H2 + no skip label | 1 |
+
+**Completeness check:** 4 (with note) + 1 (skipped) + 1 (no H2) = 6 / 6 total
+
+### Overlay flags
+
+These counts are subsets of the _With release note_ row above.
+They flag tickets that need a closer look — they do **not** add to the sum.
+
+| Overlay flag | Count |
+|---|---:|
+| Bugs: empty Affects Version (needs follow-up) | 1 |
+| Bugs: Affects Version = Unknown (needs investigation) | 0 |
+
+**Projects encountered:** DAT (6)

--- a/scripts/release-notes/tests/test_aggregate_release_notes.py
+++ b/scripts/release-notes/tests/test_aggregate_release_notes.py
@@ -1,0 +1,873 @@
+"""Tests for aggregate_release_notes.py.
+
+Covers T-012 (H2 extractor), T-013 (ADF → markdown visitor), T-014 (classifier),
+T-015 (bucket counter), T-016 (output renderer golden), T-017 (pre-flight), T-018
+(JQL pagination).
+
+All Jira calls are mocked — no real network access.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Environment stubs — must be set BEFORE importing the module under test.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("JIRA_BASE_URL", "https://example.atlassian.net")
+os.environ.setdefault("JIRA_EMAIL", "test@example.com")
+os.environ.setdefault("JIRA_API_TOKEN", "test-token")
+
+# Support running from repo root (python jira/...) or from jira/ directory.
+from aggregate_release_notes import (  # noqa: E402
+    EXIT_ERROR,
+    EXIT_PREFLIGHT,
+    FEDERATED_PROJECTS,
+    _adf_nodes_to_markdown,
+    _find_release_note_heading,
+    _normalize,
+    accumulate_issues,
+    classify_affects_version,
+    extract_release_note,
+    fetch_issues,
+    preflight_unknown_fix_version,
+    render_completeness_report,
+    render_notes_section,
+    render_output,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "adf"
+
+
+def _load_adf(name: str) -> dict:
+    """Load an ADF doc fixture by filename (without .json)."""
+    return json.loads((FIXTURES_DIR / f"{name}.json").read_text())
+
+
+def _make_issue(
+    key: str,
+    *,
+    issuetype: str = "Story",
+    summary: str = "A summary",
+    description: dict | None = None,
+    labels: list[str] | None = None,
+    versions: list[dict] | None = None,
+    include_versions_key: bool = True,
+) -> dict:
+    """Build a minimal Jira issue dict for testing."""
+    fields: dict[str, Any] = {
+        "summary": summary,
+        "issuetype": {"name": issuetype},
+        "labels": labels or [],
+        "project": {"key": key.split("-")[0]},
+        "description": description,
+    }
+    if include_versions_key:
+        fields["versions"] = versions if versions is not None else []
+    return {"key": key, "fields": fields}
+
+
+# ---------------------------------------------------------------------------
+# T-012 — ADF H2 extractor tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractReleaseNote:
+    def test_extract_canonical_h2(self) -> None:
+        adf = _load_adf("canonical_h2")
+        issue = _make_issue("DAT-1", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "crash" in result
+
+    def test_extract_capital_n_alias(self) -> None:
+        adf = _load_adf("capital_n_alias")
+        issue = _make_issue("DAT-2", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "Capital N" in result
+
+    def test_extract_trailing_colon_alias(self) -> None:
+        adf = _load_adf("trailing_colon_alias")
+        issue = _make_issue("DAT-3", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "colon" in result
+
+    def test_extract_legacy_user_benefit_alias(self) -> None:
+        adf = _load_adf("legacy_alias")
+        issue = _make_issue("DAT-4", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "Legacy alias" in result
+
+    def test_extract_no_h2_returns_none(self) -> None:
+        adf = _load_adf("no_h2")
+        issue = _make_issue("DAT-5", description=adf)
+        assert extract_release_note(issue) is None
+
+    def test_extract_stops_at_next_h2(self) -> None:
+        """Content after a second H2 must not be captured."""
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Release note"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "In scope."}]},
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Implementation"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "Out of scope."}]},
+            ],
+        }
+        issue = _make_issue("DAT-6", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "In scope" in result
+        assert "Out of scope" not in result
+
+    def test_extract_stops_at_h3(self) -> None:
+        """An H3 heading after the release note H2 must stop capture (any-level rule)."""
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Release note"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "Captured."}]},
+                {"type": "heading", "attrs": {"level": 3}, "content": [{"type": "text", "text": "Sub-section"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "Not captured."}]},
+            ],
+        }
+        issue = _make_issue("DAT-7", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "Captured" in result
+        assert "Not captured" not in result
+
+    def test_extract_h3_alone_not_matched(self) -> None:
+        """An H3 release-note heading must NOT match (strict H2 only)."""
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "heading", "attrs": {"level": 3}, "content": [{"type": "text", "text": "Release note"}]},
+                {"type": "paragraph", "content": [{"type": "text", "text": "Body text."}]},
+            ],
+        }
+        issue = _make_issue("DAT-8", description=adf)
+        assert extract_release_note(issue) is None
+
+    def test_extract_null_description_returns_none(self) -> None:
+        issue = _make_issue("DAT-9", description=None)
+        assert extract_release_note(issue) is None
+
+    def test_extract_multi_paragraph(self) -> None:
+        adf = _load_adf("multi_paragraph")
+        issue = _make_issue("DAT-10", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "First paragraph" in result
+        assert "Second paragraph" in result
+        assert "Third paragraph" in result
+
+
+# ---------------------------------------------------------------------------
+# T-013 — ADF → markdown visitor tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdfNodesToMarkdown:
+    def test_paragraph_renders_text(self) -> None:
+        nodes = [{"type": "paragraph", "content": [{"type": "text", "text": "Hello world."}]}]
+        result = _adf_nodes_to_markdown(nodes)
+        assert "Hello world." in result
+
+    def test_bold_mark(self) -> None:
+        nodes = [{"type": "text", "text": "bold", "marks": [{"type": "strong"}]}]
+        assert "**bold**" in _adf_nodes_to_markdown(nodes)
+
+    def test_italic_mark(self) -> None:
+        nodes = [{"type": "text", "text": "italic", "marks": [{"type": "em"}]}]
+        assert "_italic_" in _adf_nodes_to_markdown(nodes)
+
+    def test_code_mark(self) -> None:
+        nodes = [{"type": "text", "text": "code", "marks": [{"type": "code"}]}]
+        assert "`code`" in _adf_nodes_to_markdown(nodes)
+
+    def test_link_mark(self) -> None:
+        nodes = [
+            {
+                "type": "text",
+                "text": "link text",
+                "marks": [{"type": "link", "attrs": {"href": "https://example.com"}}],
+            }
+        ]
+        result = _adf_nodes_to_markdown(nodes)
+        assert "[link text](https://example.com)" in result
+
+    def test_extract_preserves_bold_italic_code(self) -> None:
+        adf = _load_adf("marks_variety")
+        issue = _make_issue("DAT-20", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "**bold**" in result
+        assert "_italic_" in result
+        assert "`code`" in result
+        assert "[link text](https://example.com)" in result
+
+    def test_bold_italic_combined(self) -> None:
+        """Bold + italic marks on the same text node."""
+        nodes = [{"type": "text", "text": "bold-italic", "marks": [{"type": "strong"}, {"type": "em"}]}]
+        result = _adf_nodes_to_markdown(nodes)
+        assert "bold-italic" in result
+        assert "**" in result
+        assert "_" in result
+
+    def test_extract_preserves_bullet_list(self) -> None:
+        adf = _load_adf("nested_bullets")
+        issue = _make_issue("DAT-21", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "- Top-level item" in result
+        # Nested item should be indented
+        assert "  - Nested item" in result
+
+    def test_extract_preserves_ordered_list(self) -> None:
+        adf = _load_adf("ordered_list")
+        issue = _make_issue("DAT-22", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "1. First step" in result
+        assert "2. Second step" in result
+
+    def test_extract_preserves_hyperlink(self) -> None:
+        adf = _load_adf("marks_variety")
+        issue = _make_issue("DAT-23", description=adf)
+        result = extract_release_note(issue)
+        assert "[link text](https://example.com)" in result
+
+    def test_code_block_with_language(self) -> None:
+        adf = _load_adf("code_block")
+        issue = _make_issue("DAT-24", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "```sql" in result
+        assert "SELECT" in result
+        assert "```" in result
+
+    def test_extract_unsupported_node_placeholder(self) -> None:
+        adf = _load_adf("unsupported_node")
+        issue = _make_issue("DAT-25", description=adf)
+        result = extract_release_note(issue)
+        assert result is not None
+        assert "[unsupported ADF: table]" in result
+
+    def test_hardbreak_renders(self) -> None:
+        nodes = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "line one"},
+                    {"type": "hardBreak"},
+                    {"type": "text", "text": "line two"},
+                ],
+            }
+        ]
+        result = _adf_nodes_to_markdown(nodes)
+        assert "line one" in result
+        assert "line two" in result
+        assert "  \n" in result
+
+    def test_inline_card_renders_url(self) -> None:
+        nodes = [
+            {
+                "type": "inlineCard",
+                "attrs": {"url": "https://example.com/page"},
+            }
+        ]
+        result = _adf_nodes_to_markdown(nodes)
+        assert "https://example.com/page" in result
+
+    def test_heading_in_section_shifts_level(self) -> None:
+        """A heading inside a release-note section must never emit H2."""
+        nodes = [
+            {
+                "type": "heading",
+                "attrs": {"level": 2},
+                "content": [{"type": "text", "text": "Sub"}],
+            }
+        ]
+        result = _adf_nodes_to_markdown(nodes)
+        assert result.startswith("###")
+
+
+# ---------------------------------------------------------------------------
+# T-014 — Affects-Version classifier tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAffectsVersion:
+    def test_classify_story_skips_affects_version(self) -> None:
+        issue = _make_issue("DAT-30", issuetype="Story", versions=[])
+        assert classify_affects_version(issue) == "populated"
+
+    def test_classify_task_skips_affects_version(self) -> None:
+        issue = _make_issue("DAT-31", issuetype="Task", versions=[])
+        assert classify_affects_version(issue) == "populated"
+
+    def test_classify_bug_populated(self) -> None:
+        issue = _make_issue("DAT-32", issuetype="Bug", versions=[{"name": "5.0.3"}])
+        assert classify_affects_version(issue) == "populated"
+
+    def test_classify_bug_unknown_alone(self) -> None:
+        issue = _make_issue("DAT-33", issuetype="Bug", versions=[{"name": "Unknown"}])
+        assert classify_affects_version(issue) == "unknown"
+
+    def test_classify_bug_empty_with_skip(self) -> None:
+        issue = _make_issue(
+            "DAT-34", issuetype="Bug", versions=[], labels=["skipReleaseNotes"]
+        )
+        assert classify_affects_version(issue) == "empty_with_skip"
+
+    def test_classify_bug_empty_alone(self) -> None:
+        issue = _make_issue("DAT-35", issuetype="Bug", versions=[])
+        assert classify_affects_version(issue) == "empty_alone"
+
+    def test_classify_bug_missing_field_graceful(self) -> None:
+        """When versions key is absent (TECHOPS-482 unmerged), returns empty_alone."""
+        issue = _make_issue("DAT-36", issuetype="Bug", include_versions_key=False)
+        assert classify_affects_version(issue) == "empty_alone"
+
+    def test_classify_bug_unknown_mixed_with_real(self) -> None:
+        """Unknown + real version = populated (mixed rule D-DSGN-4)."""
+        issue = _make_issue(
+            "DAT-37",
+            issuetype="Bug",
+            versions=[{"name": "Unknown"}, {"name": "5.0.3"}],
+        )
+        assert classify_affects_version(issue) == "populated"
+
+
+# ---------------------------------------------------------------------------
+# T-015 — Bucket counter + tie-breaker tests
+# ---------------------------------------------------------------------------
+
+
+def _make_issue_with_adf(key: str, adf_name: str, **kwargs: Any) -> dict:
+    adf = _load_adf(adf_name)
+    return _make_issue(key, description=adf, **kwargs)
+
+
+class TestAccumulateIssues:
+    def test_bucket_skip_wins_over_h2(self) -> None:
+        """skipReleaseNotes must beat H2 presence — lands in skipped only."""
+        issue = _make_issue_with_adf(
+            "DAT-40", "canonical_h2", issuetype="Story", labels=["skipReleaseNotes"]
+        )
+        entries, buckets, _ = accumulate_issues([issue])
+        assert buckets["skipped"] == 1
+        assert buckets["with_note_customer"] == 0
+        assert len(entries) == 0
+
+    def test_bucket_no_h2_no_skip_exclusive_from_av_flags(self) -> None:
+        """Bug with no H2 and empty AV → no_h2_no_skip only (no AV flag applied)."""
+        issue = _make_issue_with_adf("DAT-41", "no_h2", issuetype="Bug", versions=[])
+        entries, buckets, _ = accumulate_issues([issue])
+        assert buckets["no_h2_no_skip"] == 1
+        assert buckets["affects_version_empty_alone"] == 0
+        assert buckets["with_note_customer"] == 0
+
+    def test_bucket_av_empty_overlay(self) -> None:
+        """Bug with H2 + empty AV + no skip → with_note_customer AND affects_version_empty_alone."""
+        issue = _make_issue_with_adf(
+            "DAT-42", "canonical_h2", issuetype="Bug", versions=[]
+        )
+        entries, buckets, _ = accumulate_issues([issue])
+        assert buckets["with_note_customer"] == 1
+        assert buckets["affects_version_empty_alone"] == 1
+        assert len(entries) == 1
+        assert "empty Affects Version" in entries[0]["flags"]
+
+    def test_bucket_av_unknown_overlay(self) -> None:
+        """Bug with H2 + Unknown AV → with_note_customer AND affects_version_unknown."""
+        issue = _make_issue_with_adf(
+            "DAT-43", "canonical_h2", issuetype="Bug", versions=[{"name": "Unknown"}]
+        )
+        entries, buckets, _ = accumulate_issues([issue])
+        assert buckets["with_note_customer"] == 1
+        assert buckets["affects_version_unknown"] == 1
+        assert "Unknown Affects Version" in entries[0]["flags"]
+
+    def test_bucket_sum_invariant(self) -> None:
+        """Core invariant: with_note_customer + skipped + no_h2_no_skip == total_done."""
+        issues = [
+            # with_note_customer (Story with H2)
+            _make_issue_with_adf("DAT-50", "canonical_h2", issuetype="Story"),
+            # with_note_customer + av_empty overlay (Bug with H2, empty AV)
+            _make_issue_with_adf("DAT-51", "canonical_h2", issuetype="Bug", versions=[]),
+            # with_note_customer + av_unknown overlay (Bug with H2, Unknown AV)
+            _make_issue_with_adf(
+                "DAT-52", "canonical_h2", issuetype="Bug", versions=[{"name": "Unknown"}]
+            ),
+            # skipped
+            _make_issue_with_adf(
+                "DAT-53", "canonical_h2", issuetype="Story", labels=["skipReleaseNotes"]
+            ),
+            # no_h2_no_skip
+            _make_issue_with_adf("DAT-54", "no_h2", issuetype="Story"),
+        ]
+        entries, buckets, project_counts = accumulate_issues(issues)
+        assert buckets["total_done"] == 5
+        core_sum = (
+            buckets["with_note_customer"]
+            + buckets["skipped"]
+            + buckets["no_h2_no_skip"]
+        )
+        assert core_sum == buckets["total_done"], (
+            f"Invariant broken: {buckets['with_note_customer']} + "
+            f"{buckets['skipped']} + {buckets['no_h2_no_skip']} != "
+            f"{buckets['total_done']}"
+        )
+
+    def test_bucket_with_note_internal_always_zero(self) -> None:
+        """v1 invariant: with_note_internal is always 0."""
+        issues = [_make_issue_with_adf("DAT-60", "canonical_h2", issuetype="Story")]
+        _, buckets, __ = accumulate_issues(issues)
+        assert buckets["with_note_internal"] == 0
+
+    def test_empty_input_all_zeros(self) -> None:
+        entries, buckets, _ = accumulate_issues([])
+        assert buckets["total_done"] == 0
+        assert all(v == 0 for k, v in buckets.items() if k != "total_done")
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# T-016 — Output renderer golden-file + determinism tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderOutput:
+    def _build_mixed_entries_and_buckets(self) -> tuple[list[dict], dict]:
+        """Build a fixture set covering all bucket states for golden-file testing."""
+        issues = [
+            # Story with H2 → with_note_customer
+            _make_issue_with_adf("DAT-100", "canonical_h2", issuetype="Story", summary="Story fix"),
+            # Task with H2 → with_note_customer
+            _make_issue_with_adf("DAT-101", "canonical_h2", issuetype="Task", summary="Task improvement"),
+            # Bug with H2 + populated AV → with_note_customer, no flag
+            _make_issue_with_adf(
+                "DAT-102", "canonical_h2", issuetype="Bug", summary="Bug fix A",
+                versions=[{"name": "5.0.3"}],
+            ),
+            # Bug with H2 + empty AV → with_note_customer + av_empty overlay
+            _make_issue_with_adf(
+                "DAT-103", "canonical_h2", issuetype="Bug", summary="Bug fix B", versions=[]
+            ),
+            # Bug with H2 + Unknown AV → with_note_customer + av_unknown overlay
+            _make_issue_with_adf(
+                "DAT-104", "canonical_h2", issuetype="Bug", summary="Bug fix C",
+                versions=[{"name": "Unknown"}],
+            ),
+            # Skipped
+            _make_issue_with_adf(
+                "DAT-105", "canonical_h2", issuetype="Story", summary="Internal",
+                labels=["skipReleaseNotes"],
+            ),
+            # No H2, no skip
+            _make_issue_with_adf("DAT-106", "no_h2", issuetype="Bug", summary="No note bug"),
+        ]
+        return accumulate_issues(issues)
+
+    def test_render_notes_grouped_by_issuetype(self) -> None:
+        entries, buckets, _proj_counts = self._build_mixed_entries_and_buckets()
+        output = render_notes_section(entries)
+        story_pos = output.find("### Storys")
+        task_pos = output.find("### Tasks")
+        bug_pos = output.find("### Bugs")
+        assert story_pos != -1, "Story group heading missing"
+        assert task_pos != -1, "Task group heading missing"
+        assert bug_pos != -1, "Bug group heading missing"
+        assert story_pos < bug_pos, "Stories must appear before Bugs"
+        assert task_pos < bug_pos, "Tasks must appear before Bugs"
+
+    def test_render_notes_sub_sorted_by_key(self) -> None:
+        """Keys within each group must be ascending."""
+        # Add two bugs in reverse key order to force a sort.
+        issues = [
+            _make_issue_with_adf(
+                "DAT-200", "canonical_h2", issuetype="Bug", summary="Bug Z",
+                versions=[{"name": "5.0.3"}],
+            ),
+            _make_issue_with_adf(
+                "DAT-100", "canonical_h2", issuetype="Bug", summary="Bug A",
+                versions=[{"name": "5.0.3"}],
+            ),
+        ]
+        entries, _, __ = accumulate_issues(issues)
+        output = render_notes_section(entries)
+        pos_100 = output.find("DAT-100")
+        pos_200 = output.find("DAT-200")
+        assert pos_100 < pos_200, "DAT-100 should appear before DAT-200"
+
+    def test_render_flag_empty_affects_version(self) -> None:
+        issue = _make_issue_with_adf(
+            "DAT-110", "canonical_h2", issuetype="Bug", versions=[]
+        )
+        entries, _, __ = accumulate_issues([issue])
+        output = render_notes_section(entries)
+        assert "[FLAG: empty Affects Version]" in output
+
+    def test_render_flag_unknown_affects_version(self) -> None:
+        issue = _make_issue_with_adf(
+            "DAT-111", "canonical_h2", issuetype="Bug", versions=[{"name": "Unknown"}]
+        )
+        entries, _, __ = accumulate_issues([issue])
+        output = render_notes_section(entries)
+        assert "[FLAG: Unknown Affects Version]" in output
+
+    def test_render_no_flag_when_populated(self) -> None:
+        issue = _make_issue_with_adf(
+            "DAT-112", "canonical_h2", issuetype="Bug", versions=[{"name": "5.0.3"}]
+        )
+        entries, _, __ = accumulate_issues([issue])
+        output = render_notes_section(entries)
+        assert "[FLAG:" not in output
+
+    def test_render_completeness_report_table_shape(self) -> None:
+        buckets = {
+            "total_done": 7,
+            "with_note_customer": 3,
+            "with_note_internal": 0,
+            "skipped": 2,
+            "no_h2_no_skip": 2,
+            "affects_version_empty_alone": 1,
+            "affects_version_unknown": 1,
+        }
+        report = render_completeness_report(buckets, "Community 5.0.4")
+        lines = report.split("\n")
+        table_rows = [l for l in lines if l.strip().startswith("|") and "---" not in l]
+        assert len(table_rows) >= 7, f"Expected at least 7 table rows, got {len(table_rows)}: {table_rows}"
+
+    def test_render_completeness_buckets_sum_to_total(self) -> None:
+        buckets = {
+            "total_done": 10,
+            "with_note_customer": 6,
+            "with_note_internal": 0,
+            "skipped": 2,
+            "no_h2_no_skip": 2,
+            "affects_version_empty_alone": 1,
+            "affects_version_unknown": 0,
+        }
+        report = render_completeness_report(buckets, "Community 5.0.4")
+        assert "6 (with note) + 2 (skipped) + 2 (no H2) = 10 / 10 total" in report
+
+    def test_render_projects_encountered_footer(self) -> None:
+        issues = [
+            _make_issue_with_adf("SECURE-1", "canonical_h2", issuetype="Story", summary="S1"),
+            _make_issue_with_adf("DAT-1", "canonical_h2", issuetype="Bug", versions=[{"name": "5.0.3"}], summary="D1"),
+        ]
+        entries, buckets, project_counts = accumulate_issues(issues)
+        output = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00", project_counts)
+        assert "SECURE (1)" in output
+        assert "DAT (1)" in output
+
+    def test_render_deterministic(self) -> None:
+        """Two calls with same inputs (modulo timestamp) produce identical notes + table."""
+        entries, buckets, _proj_counts = self._build_mixed_entries_and_buckets()
+        out1 = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00")
+        out2 = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00")
+        assert out1 == out2
+
+    def test_render_heading_present(self) -> None:
+        entries, buckets, _proj_counts = self._build_mixed_entries_and_buckets()
+        output = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00")
+        assert "# Release Notes — Community 5.0.4" in output
+
+    def test_render_completeness_heading_present(self) -> None:
+        entries, buckets, _proj_counts = self._build_mixed_entries_and_buckets()
+        output = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00")
+        assert "## Release Notes Completeness — Community 5.0.4" in output
+
+    def test_render_overlay_section_present(self) -> None:
+        entries, buckets, _proj_counts = self._build_mixed_entries_and_buckets()
+        output = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00")
+        assert "### Overlay flags" in output
+
+    def test_render_empty_version_zero_buckets(self) -> None:
+        buckets = {
+            "total_done": 0,
+            "with_note_customer": 0,
+            "with_note_internal": 0,
+            "skipped": 0,
+            "no_h2_no_skip": 0,
+            "affects_version_empty_alone": 0,
+            "affects_version_unknown": 0,
+        }
+        report = render_completeness_report(buckets, "Community 5.0.4")
+        assert "0" in report
+
+
+# ---------------------------------------------------------------------------
+# T-016 — Golden-file test
+# ---------------------------------------------------------------------------
+
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "golden"
+
+
+class TestGoldenFile:
+    def test_render_golden_file(self) -> None:
+        """Compare full render output against committed golden file."""
+        issues = [
+            _make_issue_with_adf("DAT-100", "canonical_h2", issuetype="Story", summary="Story fix"),
+            _make_issue_with_adf("DAT-101", "canonical_h2", issuetype="Task", summary="Task improvement"),
+            _make_issue_with_adf(
+                "DAT-102", "canonical_h2", issuetype="Bug", summary="Bug fix A",
+                versions=[{"name": "5.0.3"}],
+            ),
+            _make_issue_with_adf(
+                "DAT-103", "canonical_h2", issuetype="Bug", summary="Bug fix B", versions=[]
+            ),
+            _make_issue_with_adf(
+                "DAT-105", "canonical_h2", issuetype="Story", summary="Internal",
+                labels=["skipReleaseNotes"],
+            ),
+            _make_issue_with_adf("DAT-106", "no_h2", issuetype="Bug", summary="No note bug"),
+        ]
+        entries, buckets, project_counts = accumulate_issues(issues)
+        actual = render_output("Community 5.0.4", entries, buckets, "2026-05-22 10:00:00", project_counts)
+
+        golden_path = GOLDEN_DIR / "output_mixed.md"
+        if not golden_path.exists():
+            # First run: write the golden file.
+            GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+            golden_path.write_text(actual)
+            pytest.skip("Golden file written on first run — re-run to compare")
+
+        expected = golden_path.read_text()
+        assert actual == expected, (
+            "Output does not match golden file. "
+            "If the change is intentional, delete "
+            f"{golden_path} and re-run to regenerate."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-017 — Pre-flight check tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightUnknownFixVersion:
+    def _make_client(self, present_projects: list[str]) -> MagicMock:
+        """Return a mock client where the listed projects have Unknown Fix Version."""
+        client = MagicMock()
+
+        def _get(path: str) -> list:
+            key = path.split("/project/")[1].split("/")[0]
+            if key in present_projects:
+                return [{"name": "Unknown", "id": "99"}]
+            return []
+
+        client.request.side_effect = lambda method, path: _get(path)
+        return client
+
+    def test_preflight_unknown_present_in_all(self) -> None:
+        client = self._make_client(FEDERATED_PROJECTS)
+        # Must return without calling sys.exit.
+        preflight_unknown_fix_version(client)
+
+    def test_preflight_unknown_missing_in_some(self, capsys: pytest.CaptureFixture) -> None:
+        present = [p for p in FEDERATED_PROJECTS if p != "CSOL"]
+        client = self._make_client(present)
+        with pytest.raises(SystemExit) as exc_info:
+            preflight_unknown_fix_version(client)
+        assert exc_info.value.code == EXIT_PREFLIGHT
+        captured = capsys.readouterr()
+        assert "CSOL" in captured.err
+        assert "create_fix_versions.py" in captured.err
+
+    def test_preflight_missing_multiple(self, capsys: pytest.CaptureFixture) -> None:
+        present = [p for p in FEDERATED_PROJECTS if p not in ("CSOL", "LAI")]
+        client = self._make_client(present)
+        with pytest.raises(SystemExit) as exc_info:
+            preflight_unknown_fix_version(client)
+        assert exc_info.value.code == EXIT_PREFLIGHT
+        captured = capsys.readouterr()
+        assert "CSOL" in captured.err
+        assert "LAI" in captured.err
+
+    def test_preflight_jira_error_exit_1(self, capsys: pytest.CaptureFixture) -> None:
+        """Network/auth failure → sys.exit(1), distinct from pre-flight exit 2."""
+        client = MagicMock()
+        client.request.side_effect = RuntimeError("Connection refused")
+        with pytest.raises(SystemExit) as exc_info:
+            preflight_unknown_fix_version(client)
+        assert exc_info.value.code == EXIT_ERROR
+
+
+# ---------------------------------------------------------------------------
+# T-018 — JQL pagination + error-handling tests
+# ---------------------------------------------------------------------------
+
+
+def _make_jira_page(issues: list, next_token: str | None = None) -> dict:
+    resp: dict[str, Any] = {"issues": issues}
+    if next_token:
+        resp["nextPageToken"] = next_token
+    return resp
+
+
+class TestFetchIssues:
+    def _issue_stubs(self, count: int, prefix: str = "DAT") -> list[dict]:
+        return [{"key": f"{prefix}-{i}", "fields": {}} for i in range(1, count + 1)]
+
+    def test_fetch_paginates_all_pages(self) -> None:
+        """3 pages × 50 issues each → flat list of 150."""
+        page1 = _make_jira_page(self._issue_stubs(50), next_token="tok-2")
+        page2 = _make_jira_page(self._issue_stubs(50, "NTT"), next_token="tok-3")
+        page3 = _make_jira_page(self._issue_stubs(50, "INT"))
+
+        client = MagicMock()
+        client.request.side_effect = [page1, page2, page3]
+        result = fetch_issues(client, "Community 5.0.4")
+        assert len(result) == 150
+        assert client.request.call_count == 3
+
+    def test_fetch_empty_version(self) -> None:
+        """0 issues → empty list, no exception, no exit."""
+        client = MagicMock()
+        client.request.return_value = _make_jira_page([])
+        result = fetch_issues(client, "Secure 99.0.0")
+        assert result == []
+
+    def test_fetch_single_page(self) -> None:
+        issues = self._issue_stubs(5)
+        client = MagicMock()
+        client.request.return_value = _make_jira_page(issues)
+        result = fetch_issues(client, "Community 5.0.4")
+        assert len(result) == 5
+        assert client.request.call_count == 1
+
+    def test_fetch_raises_on_unrecoverable_4xx(self, capsys: pytest.CaptureFixture) -> None:
+        """A 403 response should print an error and exit 1."""
+        client = MagicMock()
+        client.request.side_effect = RuntimeError(
+            "POST https://example.atlassian.net/rest/api/3/search/jql -> 403: Forbidden"
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fetch_issues(client, "Community 5.0.4")
+        assert exc_info.value.code == EXIT_ERROR
+        captured = capsys.readouterr()
+        assert "Jira returned a client error" in captured.err
+
+    def test_fetch_non_4xx_runtime_error_propagates(self) -> None:
+        """Errors without '-> 4' in message should propagate as RuntimeError."""
+        client = MagicMock()
+        client.request.side_effect = RuntimeError("Connection refused")
+        with pytest.raises(RuntimeError, match="Connection refused"):
+            fetch_issues(client, "Community 5.0.4")
+
+    def test_fetch_includes_correct_fields(self) -> None:
+        """The JQL payload must request the required fields and use filter 24722."""
+        client = MagicMock()
+        client.request.return_value = _make_jira_page([])
+        fetch_issues(client, "Community 5.0.4")
+        call_kwargs = client.request.call_args
+        payload = call_kwargs[1]["json"] if call_kwargs[1] else call_kwargs[0][2]
+        assert "filter = 24722" in payload["jql"]
+        assert 'fixVersion = "Community 5.0.4"' in payload["jql"]
+        # Must NOT enumerate project keys
+        for proj in FEDERATED_PROJECTS:
+            assert f"project = {proj}" not in payload["jql"]
+
+    def test_fetch_none_response_terminates(self) -> None:
+        """If client returns None, loop terminates without error."""
+        client = MagicMock()
+        client.request.return_value = None
+        result = fetch_issues(client, "Community 5.0.4")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Normalize helper
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def test_strip_whitespace(self) -> None:
+        assert _normalize("  Release note  ") == "release note"
+
+    def test_lowercase(self) -> None:
+        assert _normalize("Release Note") == "release note"
+
+    def test_strip_trailing_colon(self) -> None:
+        assert _normalize("Release note:") == "release note"
+
+    def test_combined(self) -> None:
+        assert _normalize("  Release Note:  ") == "release note"
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke — end-to-end with mocked client
+# ---------------------------------------------------------------------------
+
+
+class TestMainHappyPath:
+    def test_main_stdout_contains_notes_and_report(self, capsys: pytest.CaptureFixture) -> None:
+        """End-to-end: mocked client returns one issue; output has notes + report.
+
+        JiraClient is imported inside main() via importlib (to support running from
+        any cwd), so we inject a mock module into sys.modules before calling main().
+        """
+        adf = _load_adf("canonical_h2")
+        mock_issues = [
+            {
+                "key": "DAT-1",
+                "fields": {
+                    "summary": "Fix the thing",
+                    "description": adf,
+                    "issuetype": {"name": "Story"},
+                    "labels": [],
+                    "versions": [],
+                    "project": {"key": "DAT"},
+                },
+            }
+        ]
+        mock_client = MagicMock()
+        # pre-flight: all projects have Unknown; search returns issues
+        mock_client.request.side_effect = lambda method, path, **kw: (
+            [{"name": "Unknown"}]
+            if method == "GET" and "/versions" in path
+            else _make_jira_page(mock_issues)
+        )
+
+        mock_jira_module = MagicMock()
+        mock_jira_module.JiraClient.return_value = mock_client
+
+        sys.argv = ["aggregate_release_notes.py", "--version", "Community 5.0.4"]
+        # Inject mock into sys.modules so the dynamic import inside main() picks it up.
+        old_module = sys.modules.get("jira_client")
+        sys.modules["jira_client"] = mock_jira_module
+        try:
+            from aggregate_release_notes import main
+            exit_code = main()
+        finally:
+            if old_module is None:
+                sys.modules.pop("jira_client", None)
+            else:
+                sys.modules["jira_client"] = old_module
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Release Notes — Community 5.0.4" in captured.out
+        assert "Release Notes Completeness" in captured.out


### PR DESCRIPTION
## The problem

Every Liquibase release forces a manual H2-extraction pass across dozens of Jira tickets. Tickets without the heading or an opt-out label get silently dropped — no visibility for the release manager, no fix path for the engineer. Originally being shipped via [liquibase-infrastructure PR #3751](https://github.com/liquibase/liquibase-infrastructure/pull/3751), but that bound the pipeline to the infra repo. Wrong home: this is reusable across every product repo that cuts releases (today: `liquibase`, `liquibase-pro`; future: NTT, Platform, MCP).

## What we did

Lifted the aggregator into `build-logic` as a **reusable workflow** alongside the existing `jira-*` reusable workflows. Three inputs, two operating modes, drop-in adoption from any caller repo.

**Inputs**
- `version` (required) — Jira Fix Version name (e.g. `Community 5.0.4`, `Secure 5.2.0`, `Platform 1.0.0`, `MCP Changelog 1.0.0`)
- `dry_run` (default `true`) — preview only in step summary + artifact, GitHub Release body untouched
- `release_tag` (required when `dry_run=false`) — the release whose body to append notes to
- `build_logic_ref` (default `main`) — pinnable for production callers

**Operating modes**
- `workflow_dispatch` (manual): caller defaults `dry_run=true`. Release manager sees the preview before publishing.
- `release: [published]` auto-trigger: caller passes `dry_run=false` + `release_tag`. Aggregator output gets appended to the GH Release body (existing Release Drafter content preserved with a `---` separator).

## The result

Companion caller PRs in `liquibase/liquibase` and `liquibase/liquibase-pro` ship ~15-line workflows that delegate everything to this reusable. NTT / Platform / MCP repos can adopt by pasting the same 15 lines.

```yaml
# Caller pattern (liquibase, liquibase-pro, future repos)
jobs:
  aggregate:
    uses: liquibase/build-logic/.github/workflows/release-notes-aggregate.yml@main
    with:
      version: "Community 5.0.4"
      dry_run: true
      release_tag: ""
    secrets: inherit
```

## What's in scope

| File | Purpose |
|---|---|
| `.github/workflows/release-notes-aggregate.yml` (+139) | The reusable workflow (`workflow_call`) — OIDC + vault auth, validates inputs, runs the script, preview to summary + artifact, conditional `gh release edit --notes-file` for the publish path |
| `scripts/release-notes/aggregate_release_notes.py` (+704) | The CLI — stdlib only, board-filter JQL, ADF visitor, four-state Affects Version classifier, seven-bucket completeness report. Name-agnostic — accepts any Jira Fix Version name. |
| `scripts/release-notes/tests/test_aggregate_release_notes.py` (+873) | 70 pytest tests covering all 9 spec requirements × 24 BDD scenarios |
| `scripts/release-notes/tests/fixtures/...` (+333) | ADF fixtures (canonical / capital-N / colon / legacy aliases, multi-paragraph, nested lists, marks variety, code block, unsupported node fallback) + golden-file output |
| `scripts/release-notes/tests/conftest.py` (+5) | Path-setup so pytest imports `aggregate_release_notes` from anywhere |
| `scripts/release-notes/README.md` (+184) | Runbook: invocation, completeness-report interpretation, troubleshooting |
| `scripts/release-notes/.gitignore` | `__pycache__/`, `*.pyc` |

Total: ~2,250 lines added.

## Smoke tests (post-TECHOPS-547)

Naming convention rolled out 2026-05-28 in [TECHOPS-547](https://datical.atlassian.net/browse/TECHOPS-547) (4-tier `Secure` / `Community` / `Platform` / `MCP` + 475-ticket Target-Version → fixVersion migration). Script smoke verified against the new naming:

- **Secure 5.2.0** — 328 Done · invariant `0 (with-note) + 1 (skipped) + 327 (no-H2) = 328` ✓ · DAT 150 / INT 99 / PD 35 / SECURE 44
- **Secure 6.0.0** — 22 Done · invariant `0 + 0 + 22 = 22` ✓
- **Platform 0.2.0** — 14 Done · invariant `0 + 0 + 14 = 14` ✓
- **Platform 1.0.0** — 0 Done (release not started) · invariant `0 + 0 + 0 = 0` ✓ (empty release handled cleanly)

All 70 pytest cases green.

## Security

Every user-controllable input (`inputs.version`, `inputs.release_tag`) is consumed via env vars in `run:` blocks — never interpolated directly into shell. Follows [GitHub's workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Companion PRs

- **`liquibase/liquibase`** — caller workflow (coming next)
- **`liquibase/liquibase-pro`** — caller workflow (coming next)
- **`liquibase/liquibase-infrastructure#3751`** — will be closed without merging (work has migrated here)

## SDD trail

Original four-phase SDD in `liquibase-internal-security-hub` engram:
- `sdd/techops-498-release-notes-aggregator/explore` → `apply-progress`

Future engram artifacts will be saved under the same key namespace.

[TECHOPS-547]: https://datical.atlassian.net/browse/TECHOPS-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ