### PR TITLE
ci: SHA-pin step-level uses across workflows [TECHOPS-81]

### DIFF
--- a/.github/workflows/build-extension-jar.yml
+++ b/.github/workflows/build-extension-jar.yml
@@ -131,7 +131,7 @@ jobs:
 
         #look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
           extra-repository-id: extension-repo

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -127,7 +127,7 @@ jobs:
     # look for dependencies in maven
     - name: Set up Maven settings.xml
       if: matrix.language == 'java'
-      uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+      uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
       with:
         gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/extension-attach-artifact-release.yml
+++ b/.github/workflows/extension-attach-artifact-release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Normalize OS platform name
         id: normalize-os
-        uses: liquibase/build-logic/.github/actions/normalize-os@main
+        uses: liquibase/build-logic/.github/actions/normalize-os@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -119,7 +119,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
@@ -306,7 +306,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/extension-automated-release.yml
+++ b/.github/workflows/extension-automated-release.yml
@@ -202,7 +202,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/extension-release-prepare.yml
+++ b/.github/workflows/extension-release-prepare.yml
@@ -56,7 +56,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -85,7 +85,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
@@ -167,7 +167,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
           extra-repository-id: dry-run-sonatype-nexus-staging

--- a/.github/workflows/extension-release-rollback.yml
+++ b/.github/workflows/extension-release-rollback.yml
@@ -54,7 +54,7 @@ jobs:
           
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
@@ -214,7 +214,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
@@ -274,7 +274,7 @@ jobs:
       - name: Normalize OS platform name
         if: ${{ always() }}
         id: normalize-os
-        uses: liquibase/build-logic/.github/actions/normalize-os@main
+        uses: liquibase/build-logic/.github/actions/normalize-os@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
 
       - name: Archive Test Results - ${{ matrix.os }}
         if: ${{ always() }}

--- a/.github/workflows/owasp-scanner.yml
+++ b/.github/workflows/owasp-scanner.yml
@@ -64,7 +64,7 @@ jobs:
           cache: "maven"
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/pro-extension-build-for-liquibase.yml
+++ b/.github/workflows/pro-extension-build-for-liquibase.yml
@@ -127,7 +127,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/pro-extension-test.yml
+++ b/.github/workflows/pro-extension-test.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Normalize OS platform name
         id: normalize-os
-        uses: liquibase/build-logic/.github/actions/normalize-os@main
+        uses: liquibase/build-logic/.github/actions/normalize-os@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -158,7 +158,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
@@ -368,13 +368,13 @@ jobs:
 
       # look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 
       - name: Normalize OS platform name
         id: normalize-os
-        uses: liquibase/build-logic/.github/actions/normalize-os@main
+        uses: liquibase/build-logic/.github/actions/normalize-os@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/publish-for-liquibase.yml
+++ b/.github/workflows/publish-for-liquibase.yml
@@ -101,7 +101,7 @@ jobs:
 
         #look for dependencies in maven
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
           extra-repository-id: extension-repo

--- a/.github/workflows/release-notes-aggregate.yml
+++ b/.github/workflows/release-notes-aggregate.yml
@@ -68,14 +68,14 @@ jobs:
           fi
 
       - name: Check out build-logic (for the aggregator script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: liquibase/build-logic
           ref: ${{ inputs.build_logic_ref }}
           path: build-logic
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -83,13 +83,13 @@ jobs:
         run: pip install --quiet requests python-dotenv
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get Jira credentials from vault
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -123,7 +123,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-notes
           path: release-notes-output/

--- a/.github/workflows/sonar-coverage-merge.yml
+++ b/.github/workflows/sonar-coverage-merge.yml
@@ -50,7 +50,7 @@ jobs:
           cache: maven
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -51,7 +51,7 @@ jobs:
           cache: "maven"
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,7 +41,7 @@ jobs:
           cache: maven
 
       - name: Set up Maven settings.xml
-        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@2660ba32055efd3301bcf624a3d60ca8b11cc482 # main
         with:
           gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
 


### PR DESCRIPTION
## Summary

Unblocks the GitHub enterprise policy **Require actions to be pinned to a full-length commit SHA** (currently disabled, see [TECHOPS-81 comment 200213](https://datical.atlassian.net/browse/TECHOPS-81?focusedCommentId=200213)).

Testing in the parent ticket confirmed the policy only enforces on **step-level** `uses:`. Job-level reusable-workflow refs and local path refs (`./.github/actions/...`) are not affected and stay at `@main`.

### Pins applied (16 files, 28 lines)

**External actions** in `release-notes-aggregate.yml` (5 refs):
| Before | After |
| --- | --- |
| `actions/checkout@v4` | `@34e114876b...` (v4.3.1) |
| `actions/setup-python@v5` | `@a26af69be9...` (v5.6.0) |
| `actions/upload-artifact@v4` | `@ea165f8d65...` (v4.6.2) |
| `aws-actions/configure-aws-credentials@v4` | `@7474bc4690...` (v4) |
| `aws-actions/aws-secretsmanager-get-secrets@v2` | `@a9a7eb4e2f...` (v2.0.10) |

**Internal cross-repo refs** pinned to `main` HEAD `2660ba32055e...`:
- `liquibase/build-logic/.github/actions/setup-maven-settings@main`: 14 step-level call sites
- `liquibase/build-logic/.github/actions/normalize-os@main`: 4 step-level call sites

### Intentionally NOT pinned

- Job-level reusable-workflow refs: `liquibase/build-logic/.github/workflows/*.yml@main` (9 refs). Per testing, job-level SHA pinning is NOT enforced by the policy.
- Local path actions: `./.github/actions/...` and `./build-logic/.github/actions/...`. Not subject to the policy.

## :warning: Maintenance note: internal SHAs are now frozen

**Internal composite-action SHAs are now frozen at `2660ba3`.** Any future change to `setup-maven-settings` or `normalize-os` will require an explicit SHA bump in **every calling workflow in this repo**. This is the intentional immutability trade-off the enterprise SHA-pinning policy enforces.

### Will Dependabot catch these self-referential bumps?

**Probably yes, but worth verifying on the next scheduled run.** Evidence:

- This repo's `.github/dependabot.yml` already runs weekly for the `github-actions` ecosystem on `/`, grouping all updates.
- Dependabot is already bumping SHA-pinned step-level refs (e.g. `actions/setup-java@be666c2f...`, `actions/upload-artifact@bbbca2dd...`) and keeps the trailing `# vX.Y.Z` comment in sync. See recent batch PRs #588, #598.
- However, **the GitHub docs and dependabot-core do not explicitly confirm self-referential behavior** for `owner/repo[/path]@sha` where `owner/repo` IS the current repo. Syntactically Dependabot has no signal to skip self-refs, so the expectation is it will scan and propose updates the same way. Issues dependabot/dependabot-core#6936 and #6656 are adjacent (composite-action internals, cross-repo composite refs), both closed as not planned.

**Recommended after merge:** wait for the next weekly Dependabot batch and confirm it includes proposals for the two new self-referential pins (or open a follow-up if it doesn't). Fallbacks if it doesn't pick them up: a tiny periodic script, or a manual bump as part of any PR that touches those composite actions.

## Test plan

- [ ] Merge this PR.
- [ ] Re-enable **Require actions to be pinned to a full-length commit SHA** at the enterprise level: https://github.com/enterprises/liquibase/settings/actions
- [ ] Re-run the two workflows that previously revealed the issue:
  - `docker-scan.yml` in liquibase-pro (the :green_apple: case, expected to still pass: job-level `@main`)
  - `build.yml` in liquibase-pro (the :apple: case, previously failed on step-level `@main` in `sonar-coverage-merge.yml:53`, expected to now pass)
- [ ] Spot-check that os-extension-test and pro-extension-test still resolve the pinned `normalize-os` and `setup-maven-settings` actions in a downstream extension.
- [ ] After the next weekly Dependabot run, confirm it proposes (or skips) bumps for the two new self-referential pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)