### PR TITLE
[TECHOPS-523] Prevent orphaned RDS by gating Spacelift stack deletion on infra-destroy success

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -286,3 +286,18 @@ jobs:
         working-directory: test-automation-ephemeral/stack
         run: |
           terraform destroy -auto-approve -var "run_id=$GH_RUN_ID" -var "run_repo=$GH_REPOSITORY"
+
+      - name: Notify Slack on teardown failure
+        # Alert the team the moment a teardown fails, instead of waiting for
+        # GuardDuty to flag the surviving publicly-accessible RDS. The Spacelift
+        # stack is kept (state preserved) so the destroy can be retried (TECHOPS-523).
+        if: ${{ inputs.destroy && failure() && steps.destroy_infra.outcome == 'failure' }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ env.NIGHTLY_BUILDS_SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
+          SLACK_TITLE: "Ephemeral teardown failed — possible orphaned RDS"
+          SLACK_MESSAGE: |
+            terraform destroy failed for stack `${{ inputs.stack_id }}` (${{ github.repository }}).
+            The Spacelift stack was kept so its state survives for a retry — please investigate and clean up to avoid orphaned, publicly-accessible RDS (TECHOPS-523).
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -237,7 +237,7 @@ jobs:
           spacectl stack deploy --id $EPHEMERAL_STACK_ID --auto-confirm
 
       - name: Destroy ephemeral infra
-        continue-on-error: true
+        id: destroy_infra
         env:
           STACK_ID: ${{ inputs.stack_id }}
           TF_VAR_stack_id: ${{ inputs.stack_id }}
@@ -247,7 +247,28 @@ jobs:
         if: ${{ inputs.destroy }}
         working-directory: test-automation-ephemeral/infra
         run: |
-          spacectl stack task --id "${STACK_ID}" --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve" || true
+          # Retry the infra destroy to absorb transient AWS API throttling and
+          # SG dependency-ordering races (a security group can't be deleted
+          # until the RDS instance referencing it is fully gone). We intentionally
+          # do NOT swallow a final failure (no `|| true`, no continue-on-error):
+          # if the AWS resources are not actually destroyed we must let this step
+          # fail so the Spacelift stack is kept and its state survives for a
+          # retry. Deleting the stack after a failed destroy is what strands the
+          # surviving RDS instances as untracked orphans (TECHOPS-523).
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::terraform destroy attempt $i/$attempts"
+            if spacectl stack task --id "${STACK_ID}" --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve"; then
+              echo "::endgroup::"
+              echo "Ephemeral infra destroyed successfully on attempt $i"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::terraform destroy attempt $i/$attempts failed; retrying after backoff"
+            sleep 30
+          done
+          echo "::error::terraform destroy failed after $attempts attempts. Keeping Spacelift stack '${STACK_ID}' so its Terraform state is preserved for a retry. Investigate before the stack is removed to avoid orphaned RDS resources."
+          exit 1
 
       - name: Download Terraform state
         if: ${{ inputs.destroy && always()}}
@@ -257,7 +278,11 @@ jobs:
           path: test-automation-ephemeral/stack
 
       - name: Destroy ephemeral stack
-        if: ${{ inputs.destroy && always()}}
+        # Only delete the Spacelift stack object when the AWS resource destroy
+        # actually succeeded. If the infra destroy failed we keep the stack (and
+        # its Terraform state) so the destroy can be retried; deleting it here
+        # would strand the surviving RDS resources as orphans (TECHOPS-523).
+        if: ${{ inputs.destroy && steps.destroy_infra.outcome == 'success' }}
         working-directory: test-automation-ephemeral/stack
         run: |
           terraform destroy -auto-approve -var "run_id=$GH_RUN_ID" -var "run_repo=$GH_REPOSITORY"

--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -294,7 +294,7 @@ jobs:
         if: ${{ inputs.destroy && failure() && steps.destroy_infra.outcome == 'failure' }}
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env.NIGHTLY_BUILDS_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ env.EPHEMERAL_DANGLING_RESOURCES_SLACK_WEBHOOK }}
           SLACK_COLOR: danger
           SLACK_TITLE: "Ephemeral teardown failed — possible orphaned RDS"
           SLACK_MESSAGE: |


### PR DESCRIPTION
## Issue

The ephemeral teardown deleted the Spacelift stack (and its Terraform state) even when the AWS `terraform destroy` had failed, because the destroy step swallowed all errors ([`continue-on-error: true`](https://github.com/liquibase/build-logic/blob/2660ba32055efd3301bcf624a3d60ca8b11cc482/.github/workflows/ephemeral-cloud-infra.yml#L240) + [`|| true`](https://github.com/liquibase/build-logic/blob/2660ba32055efd3301bcf624a3d60ca8b11cc482/.github/workflows/ephemeral-cloud-infra.yml#L250)) and the stack-deletion step ran with [`if: always()`](https://github.com/liquibase/build-logic/blob/2660ba32055efd3301bcf624a3d60ca8b11cc482/.github/workflows/ephemeral-cloud-infra.yml#L260). This stranded publicly-accessible RDS instances as orphans that accumulated GuardDuty findings (cleaned up manually in [TECHOPS-461](https://datical.atlassian.net/browse/TECHOPS-461)).

## Solution

The infra-destroy step now retries transient failures and fails loudly instead of swallowing errors, and the Spacelift stack is only deleted when that destroy actually succeeded (`steps.destroy_infra.outcome == 'success'`). On failure the stack and its state are preserved so the teardown can be safely retried, leaving zero orphans.

---
Resolves [TECHOPS-523](https://datical.atlassian.net/browse/TECHOPS-523)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-461]: https://datical.atlassian.net/browse/TECHOPS-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-523]: https://datical.atlassian.net/browse/TECHOPS-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ