### PR TITLE
[TECHOPS-523] Polish ephemeral infra-destroy retry loop

### DIFF
--- a/.github/workflows/ephemeral-cloud-infra.yml
+++ b/.github/workflows/ephemeral-cloud-infra.yml
@@ -256,16 +256,24 @@ jobs:
           # retry. Deleting the stack after a failed destroy is what strands the
           # surviving RDS instances as untracked orphans (TECHOPS-523).
           attempts=3
+          # Cap each attempt so a hung `spacectl stack task --tail` (a stalled
+          # log stream) can't burn the whole job without ever retrying. 30m is
+          # well above a normal RDS teardown, so it only trips on a real hang.
+          attempt_timeout=30m
           for i in $(seq 1 "$attempts"); do
             echo "::group::terraform destroy attempt $i/$attempts"
-            if spacectl stack task --id "${STACK_ID}" --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve"; then
+            if timeout "$attempt_timeout" spacectl stack task --id "${STACK_ID}" --tail "terraform destroy -refresh=false -parallelism=10 -auto-approve"; then
               echo "::endgroup::"
               echo "Ephemeral infra destroyed successfully on attempt $i"
               exit 0
             fi
             echo "::endgroup::"
-            echo "::warning::terraform destroy attempt $i/$attempts failed; retrying after backoff"
-            sleep 30
+            # Skip the wait after the final attempt: we're about to fail anyway.
+            if [ "$i" -lt "$attempts" ]; then
+              backoff=$((30 * i))
+              echo "::warning::terraform destroy attempt $i/$attempts failed; retrying in ${backoff}s"
+              sleep "$backoff"
+            fi
           done
           echo "::error::terraform destroy failed after $attempts attempts. Keeping Spacelift stack '${STACK_ID}' so its Terraform state is preserved for a retry. Investigate before the stack is removed to avoid orphaned RDS resources."
           exit 1


### PR DESCRIPTION
## What

Addresses the non-blocking review polish on #606 (https://github.com/liquibase/build-logic/pull/606#pullrequestreview-4387024411) for the `Destroy ephemeral infra` retry loop in `ephemeral-cloud-infra.yml`.

## Changes

- **Real backoff:** flat `sleep 30` replaced with linear `sleep $((30 * i))`, so the "backoff" wording in the comment is actually true (30s, 60s).
- **No wasted final sleep:** the retry wait is now guarded with `[ "$i" -lt "$attempts" ]`, so the loop doesn't sleep after the last attempt right before failing.
- **Hang protection:** each attempt is wrapped in `timeout 30m`, so a hung `spacectl stack task --tail` log stream can't consume the whole job without ever retrying. 30m is well above a normal RDS teardown, so it only trips on a genuine hang.

## Behavior preserved

The step still fails loudly after all attempts (no `|| true`, no `continue-on-error`), so a failed destroy keeps the Spacelift stack and its state, and the Slack alert still fires : the orphan-prevention guarantee from #606 is unchanged.

## Testing

- `bash -n` on the extracted retry script: passes.
- `actionlint`: no new findings in the edited block (pre-existing SC2086 / `inputs.action` warnings elsewhere are untouched).

## Links

- Jira: [TECHOPS-523](https://datical.atlassian.net/browse/TECHOPS-523)
- Builds on: #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-523]: https://datical.atlassian.net/browse/TECHOPS-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ