### PR TITLE
ci: make branch_name optional in reusable-docker-build-qa

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -26,9 +26,10 @@ on:
         required: true
         type: string
       branch_name:
-        description: 'Liquibase branch to build from (workflow_dispatch input)'
-        required: true
+        description: 'Liquibase branch to build from, for Community branch-based QA builds. Optional: Secure callers download a pre-built artifact via secure_version and leave this unset.'
+        required: false
         type: string
+        default: ''
       secure_version:
         description: 'Explicit Secure version for RC/production S3 downloads, e.g. 5.0.0-RC10'
         required: false


### PR DESCRIPTION
## Problem

The Secure QA Docker workflow in `liquibase-pro` builds only from a pre-built Secure artifact in S3 (selected by `secure-version`) — it has no branch-based build, so it needs to stop passing a branch. But this reusable workflow declares `branch_name` as `required: true`, so any caller that omits it fails validation.

## What changed

`branch_name` → `required: false` with `default: ''`. Backward-compatible: Community branch-based QA builds keep passing it; Secure callers can now leave it unset.

## Result

Unblocks the `liquibase-pro` PR that removes the redundant `liquibaseBranch` input. No behavior change for existing callers.

## Context

- Surfaced in [TECHOPS-366](https://datical.atlassian.net/browse/TECHOPS-366) RFT review (Ruslan Berezenskyi).
- Paired with the `liquibase-pro` removal PR — **merge this one first.**


[TECHOPS-366]: https://datical.atlassian.net/browse/TECHOPS-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ