### PR TITLE
ci: fail extension builds when integration tests fail

### DIFF
--- a/.github/workflows/os-extension-test.yml
+++ b/.github/workflows/os-extension-test.yml
@@ -249,14 +249,14 @@ jobs:
         shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
-        run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS}
+        run: mvn -B test-compile failsafe:integration-test failsafe:verify -P 'coverage' ${EXTRA_MAVEN_ARGS}
 
       - name: Run Integration Tests
         if: ${{ inputs.nightly && inputs.runIntegrationTests }}
         shell: bash
         env:
           EXTRA_MAVEN_ARGS: ${{ inputs.extraMavenArgs }}
-        run: mvn -B integration-test -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
+        run: mvn -B test-compile failsafe:integration-test failsafe:verify -P 'coverage' ${EXTRA_MAVEN_ARGS} "-Dliquibase.version=main-SNAPSHOT"
 
       - name: Notify Slack on Build Failure
         if: ${{ failure() && inputs.nightly }}


### PR DESCRIPTION
## Problem

The `Run Integration Tests` steps in `os-extension-test.yml` invoke the `integration-test` Maven **lifecycle phase**. That phase runs failsafe's `integration-test` goal but never the `verify` goal — and failsafe is designed to record failures during `integration-test` and only fail the build during `verify`. The result: integration test errors are silently swallowed and the job is reported as **success**.

This is not theoretical. The most recent `Build and Test` run in liquibase-opensearch-spring-boot-starter shows all three Spring IT classes erroring on Windows (`Tests run: 3, ..., Errors: 3`) immediately followed by `BUILD SUCCESS`. Because this is the shared OS-extension workflow, every extension using it is exposed — including auto-merged dependabot PRs.

## Fix

Bind the failsafe goals directly instead of relying on the lifecycle phase:

```
mvn -B test-compile failsafe:integration-test failsafe:verify -P 'coverage' ...
```

- `test-compile` ensures the IT sources are compiled
- `failsafe:integration-test` runs the integration tests
- `failsafe:verify` checks the results and **fails the build** on any failure or error

Unit tests are not re-run, since they execute in a separate `Run Unit Tests` step.

Applied to both the PR step and the nightly step (the latter keeps `-Dliquibase.version=main-SNAPSHOT`).

Fixes liquibase/liquibase-opensearch-spring-boot-starter#99