### PR TITLE
Add liquibase-databricks to automated extension release

### DIFF
--- a/.github/workflows/extension-automated-release.yml
+++ b/.github/workflows/extension-automated-release.yml
@@ -10,7 +10,7 @@ on:
       repositories:
         description: "Comma separated list of repositories to release"
         required: false
-        default: '["liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-parent-pom","liquibase-cdi","liquibase-cdi-jakarta"]'
+        default: '["liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-databricks","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-parent-pom","liquibase-cdi","liquibase-cdi-jakarta"]'
         type: string
 
 permissions:


### PR DESCRIPTION
`liquibase-databricks` now follows unified Liquibase-core versioning, so it should release alongside the other OSS extensions. Adds it to the `repositories` default list consumed by `release-extensions.yml`.

The repo currently has 0 open Dependabot security alerts, so it won't trip the `check-security-vulnerabilities` gate.