### PR TITLE
fix: cap fossa test --timeout to 20m to fail fast on FOSSA backend stalls

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -101,7 +101,11 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           # https://github.com/fossas/fossa-cli/tree/master/docs/references/subcommands/test
-          fossa test -p "$REPO_NAME" 2>&1 | tee test.out
+          # --timeout caps how long we poll FOSSA's backend for issue-scan results.
+          # Default is 3600s (1h); when FOSSA's scan service stalls, that wastes a full
+          # hour of runner time per PR before failing. A healthy scan returns in minutes,
+          # so 1200s (20m) leaves ample headroom while failing fast on a backend stall.
+          fossa test -p "$REPO_NAME" --timeout 1200 2>&1 | tee test.out
           FILE="test.out"
           if [ -f "$FILE" ]; then
               if grep -q "Test passed" "$FILE"; then


### PR DESCRIPTION
## What

Add `--timeout 1200` (20 minutes) to the `fossa test` invocation in the reusable `fossa_ai.yml` workflow.

```diff
- fossa test -p "$REPO_NAME" 2>&1 | tee test.out
+ fossa test -p "$REPO_NAME" --timeout 1200 2>&1 | tee test.out
```

## Why

`fossa test` does not scan locally — it uploads, then **polls FOSSA's cloud backend** for issue-scan results (the repeating `Waiting for issue scan completion...` log line). Per the [official `fossa test` docs](https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/test.md), the CLI **defaults to waiting a maximum of 3600s (1 hour)** for those results before timing out.

When FOSSA's scan service stalls, that default means every PR check burns a **full hour** of runner time before failing, instead of failing fast.

**Observed 2026-06-08:** across `liquibase-pro` PRs, FOSSA's backend stopped returning issue-scan results around ~13:10 UTC. The *same commit* that passed in ~10 min at 13:08 then failed at ~1h08m at 13:13 — identical CLI version (`3.17.10`), branch, and workflow. The only variable was FOSSA's server-side scan stage hanging.

## Why this fixes the symptom

A healthy issue scan returns in **minutes**. Capping the wait at **1200s (20m)** keeps generous headroom for normal scans while failing **~3x faster** when the backend is unresponsive — so a FOSSA-side stall no longer costs an hour of runner time per PR.

> Note: this does **not** make the check pass during a FOSSA outage (the scan results still aren't available) — it makes the failure fast and cheap instead of slow and expensive. The underlying availability is on FOSSA's side.

## Reference

- Official flag + default: https://github.com/fossas/fossa-cli/blob/master/docs/references/subcommands/test.md — *"By default, `fossa test` waits a maximum of 3600 seconds (1 hour) for issue scan results."*

## Blast radius

This reusable workflow is consumed by multiple Liquibase repos. The change only **shortens an upper bound** on a wait that healthy scans never approach, so it is safe for all consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)