### PR TITLE
TECHOPS-606: poll for H2 startup log in docker test instead of fixed sleep

### DIFF
--- a/.github/workflows/reusable-docker-test.yml
+++ b/.github/workflows/reusable-docker-test.yml
@@ -96,17 +96,31 @@ jobs:
           docker run --env LIQUIBASE_LICENSE_KEY="$PRO_LICENSE_KEY" --name $CONTAINER_NAME -d \
             -v $(pwd)/build-logic/"$TEST_FIXTURES_PATH":/liquibase/changelog \
             "liquibase/liquibase:$IMAGE_TAG" init start-h2
-          sleep 30
-          if docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q "true"; then
-            if docker logs "$CONTAINER_NAME" 2>&1 | grep -q "$LOG_STRING"; then
-              echo "The log contains the string: $LOG_STRING"
-            else
-              echo "The log does not contain the string: $LOG_STRING"
-              exit 1
+          # Poll for the H2 startup log instead of a fixed `sleep 30`. The startup
+          # message can take longer than a hard-coded wait on slower/busier runners
+          # (notably macOS Colima), which caused intermittent failures where the
+          # container was running but the log line had not appeared yet.
+          # Wait up to 90s, checking every 3s; fail fast if the container exits.
+          TIMEOUT=90
+          INTERVAL=3
+          ELAPSED=0
+          while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+            if ! docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q "true"; then
+              echo "Error: Container $CONTAINER_NAME is not running."
+              docker logs "$CONTAINER_NAME" 2>&1 || true
+              exit 2
             fi
-          else
-            echo "Error: Container $CONTAINER_NAME is not running."
-            exit 2
+            if docker logs "$CONTAINER_NAME" 2>&1 | grep -q "$LOG_STRING"; then
+              echo "The log contains the string: $LOG_STRING (after ${ELAPSED}s)"
+              break
+            fi
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+            echo "The log does not contain the string after ${TIMEOUT}s: $LOG_STRING"
+            docker logs "$CONTAINER_NAME" 2>&1 || true
+            exit 1
           fi
 
       - name: Test liquibase version


### PR DESCRIPTION
Jira: TECHOPS-606

## Problem

The reusable `reusable-docker-test.yml` "Test liquibase init start-h2" step does:

```bash
docker run -d ... init start-h2
sleep 30
# then checks the log exactly once for "The database does not persist data"
```

On slower/busier runners (notably **macos-15-intel** with Colima) the H2 startup line isn't always emitted within the hard-coded 30s, so the container is running but the one-shot `grep` fails and the step `exit 1`s. This is an intermittent, timing-dependent failure: the **same image/commit passes on one run and fails on another**.

Observed in liquibase-pro:
- PASS (push): https://github.com/liquibase/liquibase-pro/actions/runs/27147150163
- FAIL (PR): https://github.com/liquibase/liquibase-pro/actions/runs/27147263766

Both ran the same workflow (`workflow_id 264049622`), same commit `b3c6f7e`, same jobs — only runtime timing differed.

## Fix

Replace the fixed `sleep 30` + one-shot check with a **poll loop**: wait up to 90s, checking every 3s, break as soon as the log string appears, and fail fast (`exit 2`) if the container exits early.

```diff
- sleep 30
- if docker inspect ... Running == true; then
-   if docker logs ... | grep -q "$LOG_STRING"; then ... else exit 1; fi
- else exit 2; fi
+ TIMEOUT=90; INTERVAL=3; ELAPSED=0
+ while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+   <fail fast if not running>
+   <break as soon as log string appears>
+   sleep "$INTERVAL"; ELAPSED=$((ELAPSED + INTERVAL))
+ done
+ <exit 1 only if string never appeared within 90s>
```

## Why this works

The original failure was purely a race against H2 startup time. Polling removes the race: fast runs still finish in a few seconds (break early), and slow runners get up to 90s instead of a fixed 30s. The container-exited case fails fast with `exit 2` and dumps `docker logs` for diagnosis.

## Blast radius

This reusable workflow is consumed by multiple Liquibase repos' docker-test workflows. The change only makes the wait adaptive (same success criteria), so it's safe for all consumers and removes a common flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)