### PR TITLE
fix(release): grant actions:read so extension release can resolve build-logic ref

### DIFF
--- a/.github/workflows/extension-release-published.yml
+++ b/.github/workflows/extension-release-published.yml
@@ -46,6 +46,7 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
+  actions: read # required by "Get build-logic ref" to read referenced_workflows via the Actions API
 
 jobs:
   maven-release:
@@ -111,8 +112,10 @@ jobs:
         run: |
           # In reusable workflows, github.workflow_sha resolves to the caller's SHA.
           # Query the API to find the actual ref/SHA of this reusable workflow.
+          # `|| true` so a transient API failure falls back to main instead of
+          # aborting the step (run: uses `bash -eo pipefail`).
           REF=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --jq '.referenced_workflows[] | select(.path | startswith("liquibase/build-logic/.github/workflows/extension-release-published")) | .ref')
+            --jq '.referenced_workflows[] | select(.path | startswith("liquibase/build-logic/.github/workflows/extension-release-published")) | .ref' || true)
           echo "ref=${REF:-refs/heads/main}" >> $GITHUB_OUTPUT
 
       - name: Checkout build-logic


### PR DESCRIPTION
## 🎯 Problem

Extension releases via `extension-release-published.yml` fail at the **Get build-logic ref** step with:

```
gh: Resource not accessible by integration (HTTP 403)
##[error]Process completed with exit code 1.
```

Surfaced while publishing `liquibase-mcp-changelog-server` v1.0.0 ([failing run](https://github.com/liquibase/liquibase-mcp-changelog-server/actions/runs/27161179978/job/80176875427)).

## 🔍 Root cause

The **Get build-logic ref** step calls `GET /repos/{repo}/actions/runs/{id}` (via `gh api`) to resolve `referenced_workflows`. That endpoint requires the **`actions: read`** permission, but the workflow's `permissions:` block only granted `contents`/`pull-requests`/`packages`/`id-token` — so `GITHUB_TOKEN` was denied (403).

Compounding it: the step was meant to fall back to `refs/heads/main` (`${REF:-refs/heads/main}`), but `run:` blocks execute under `bash -eo pipefail`, so the failing `gh api` aborted the step before the fallback could apply.

## 🔧 Fix

- Add `actions: read` to the `permissions:` block (root-cause fix)
- Add `|| true` to the `gh api` call so a transient API failure falls back to `main` instead of failing the release

## 💥 Impact

This affects **every extension** that releases through this reusable workflow — it's likely been failing for others on releases that exercise this step. Low-risk change: read-only scope addition + defensive fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)