### PR TITLE
ci: reference dispatch-and-wait by repo path, not ./ (TECHOPS-366)

### DIFF
--- a/.github/workflows/reusable-docker-build-qa.yml
+++ b/.github/workflows/reusable-docker-build-qa.yml
@@ -323,7 +323,13 @@ jobs:
         if: ${{ inputs.build_type == 'secure' && steps.download-artifact.outputs.trigger_liquibase_secure_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: trigger-liquibase-secure-release
         continue-on-error: true
-        uses: ./.github/actions/dispatch-and-wait
+        # Full repo path, not ./ — this reusable workflow runs in the CALLER's
+        # checkout (actions/checkout above pulls the caller repo into the
+        # workspace), so a ./ local-action reference resolves against the caller
+        # and the dispatch-and-wait action (which lives here in build-logic) is
+        # not found. Reference it by owner/repo path so it resolves regardless
+        # of which repo called the workflow.
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
         with:
           workflow: secure-release-to-s3.yml
           repo: liquibase/liquibase-pro


### PR DESCRIPTION
## What's the problem?

The Secure QA Docker fallback fails the moment it runs:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/liquibase-pro/liquibase-pro/.github/actions/dispatch-and-wait'.
Did you forget to run actions/checkout before running your local action?
```

`reusable-docker-build-qa.yml` runs `actions/checkout` of the **caller** repo (e.g. `liquibase-pro`) into the workspace. So the step `uses: ./.github/actions/dispatch-and-wait` resolves `./` against the **caller's** tree — which has no such action. The action lives **here**, in build-logic.

It was latent until now: the Secure QA build only reaches this dispatch step when the requested S3 artifact is missing. liquibase-pro just switched its QA default from `master` to `main` ([TECHOPS-366](https://datical.atlassian.net/browse/TECHOPS-366?focusedCommentId=201560)); `releases/secure/main/` doesn't exist yet, so the fallback fires and trips over this.

## What changed?

One reference: `./.github/actions/dispatch-and-wait` → `liquibase/build-logic/.github/actions/dispatch-and-wait@main`.

Step-level `uses:` can't take expressions, and this reusable workflow is consumed `@main`, so pinning the action `@main` is consistent. The full repo path resolves regardless of which repo called the workflow.

| File | Change |
|------|--------|
| `.github/workflows/reusable-docker-build-qa.yml` | Reference `dispatch-and-wait` by repo path instead of `./` |

## Why it's safe

The `./` reference is broken **whenever this step runs** — it can only fix, never regress. Repairs the fallback for **both** Community and Secure QA Docker builds across all callers.

## Test plan

- [x] Confirmed `.github/actions/dispatch-and-wait/action.yml` exists in build-logic
- [x] Confirmed it's the only `./` local-action reference in the workflow
- [ ] Post-merge: re-run **Build QA Docker Images** in liquibase-pro (blank `secure-version`) and confirm the dispatch step resolves and a `liquibase-secure-qa:main` tag lands in Nexus

[TECHOPS-366]: https://datical.atlassian.net/browse/TECHOPS-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ