### PR TITLE
feat(docker): route Docker build/scan + scheduled-scan failures to #docker-builds (TECHOPS-588)

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -417,22 +417,37 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Verify webhook env var is set
+      - name: Resolve Slack webhook
+        id: webhook
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          # The var name is caller-controlled: validate name and value shape, and pass the
+          # webhook as a step output (random-delimiter heredoc) — never into GITHUB_ENV.
+          if ! printf '%s' "$WEBHOOK_ENV_VAR" | grep -qE '^[A-Z][A-Z0-9_]{0,127}$'; then
+            echo "::error::Invalid slack_webhook_env_var name: $WEBHOOK_ENV_VAR"
+            exit 1
+          fi
           WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
           if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
-          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
+          if ! printf '%s' "$WEBHOOK_VALUE" | grep -qE '^https://hooks\.slack\.com/[A-Za-z0-9/_+-]+$'; then
+            echo "::error::$WEBHOOK_ENV_VAR does not look like a Slack webhook URL"
+            exit 1
+          fi
+          DELIM="WEBHOOK_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "url<<$DELIM"
+            echo "$WEBHOOK_VALUE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.webhook.outputs.url }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker build failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -133,6 +133,11 @@ on:
         required: false
         type: string
         default: 'main'
+      slack_webhook_env_var:
+        description: 'Vault env-var name holding the Slack webhook URL for failure alerts. Defaults to #docker-builds. Pass an empty string to disable notifications.'
+        required: false
+        type: string
+        default: 'DOCKER_SLACK_WEBHOOK_URL'
     outputs:
       digest:
         description: 'Image digest of the pushed image (sha256:...)'
@@ -387,3 +392,48 @@ jobs:
           echo "Signing dry-run ECR image with Cosign keyless signing..."
           cosign sign --yes "${DRY_RUN_REPO}@${IMAGE_DIGEST}"
           echo "Dry-run ECR image signed successfully"
+
+  # ============================================
+  # SLACK FAILURE NOTIFICATION
+  # ============================================
+  notify:
+    needs: [build]
+    if: failure() && inputs.slack_webhook_env_var != ''
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Verify webhook env var is set
+        env:
+          WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
+        run: |
+          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+            echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
+            exit 1
+          fi
+
+      - name: Notify Slack on failure
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_COLOR: failure
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker build failed on ${{ github.ref_name }} (${{ github.sha }})"
+          SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_USERNAME: liquibot
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }}"
+          SLACK_LINK_NAMES: true

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -421,15 +421,18 @@ jobs:
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
+          if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
+          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker build failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -359,22 +359,37 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Verify webhook env var is set
+      - name: Resolve Slack webhook
+        id: webhook
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          # The var name is caller-controlled: validate name and value shape, and pass the
+          # webhook as a step output (random-delimiter heredoc) — never into GITHUB_ENV.
+          if ! printf '%s' "$WEBHOOK_ENV_VAR" | grep -qE '^[A-Z][A-Z0-9_]{0,127}$'; then
+            echo "::error::Invalid slack_webhook_env_var name: $WEBHOOK_ENV_VAR"
+            exit 1
+          fi
           WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
           if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
-          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
+          if ! printf '%s' "$WEBHOOK_VALUE" | grep -qE '^https://hooks\.slack\.com/[A-Za-z0-9/_+-]+$'; then
+            echo "::error::$WEBHOOK_ENV_VAR does not look like a Slack webhook URL"
+            exit 1
+          fi
+          DELIM="WEBHOOK_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "url<<$DELIM"
+            echo "$WEBHOOK_VALUE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.webhook.outputs.url }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker scan failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -333,12 +333,13 @@ jobs:
   # ============================================
   # SLACK FAILURE NOTIFICATION
   # Outermost owner for scan alerts — covers build-ghcr, vulnerability-scan,
-  # and scout. Uses always() to fire even when scout is skipped (scout_enabled=false).
-  # The nested reusable-vulnerability-scan call passes nested:true above, so its
-  # scheduled auto-notify is suppressed and THIS job owns the alert (no double-post, D4).
+  # scout, and cleanup-ghcr. Uses always() to fire even when scout is skipped
+  # (scout_enabled=false). The nested reusable-vulnerability-scan call passes
+  # nested:true above, so its scheduled auto-notify is suppressed and THIS job
+  # owns the alert (no double-post, D4).
   # ============================================
   notify:
-    needs: [build-ghcr, vulnerability-scan, scout]
+    needs: [build-ghcr, vulnerability-scan, scout, cleanup-ghcr]
     if: ${{ always() && contains(needs.*.result, 'failure') && inputs.slack_webhook_env_var != '' }}
     runs-on: ubuntu-22.04
     permissions:
@@ -362,15 +363,18 @@ jobs:
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
+          if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
+          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker scan failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-docker-scan.yml
+++ b/.github/workflows/reusable-docker-scan.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: 'main'
+      slack_webhook_env_var:
+        description: 'Vault env-var name holding the Slack webhook URL for failure alerts. Defaults to #docker-builds. Pass an empty string to disable notifications.'
+        required: false
+        type: string
+        default: 'DOCKER_SLACK_WEBHOOK_URL'
     outputs:
       scan_status:
         description: 'pass or fail based on vulnerability thresholds'
@@ -136,6 +141,7 @@ jobs:
       vex_enabled: ${{ inputs.vex_enabled }}
       build_logic_ref: ${{ inputs.build_logic_ref }}
       dispatch_new_cves: ${{ inputs.dispatch_new_cves }}
+      nested: true  # suppress the nested scheduled auto-notify; this (outer) scan owns the alert (D4)
     secrets: inherit
 
   # ============================================
@@ -323,3 +329,52 @@ jobs:
           else
             echo "No version found for ${PACKAGE_NAME}:${TAG}, skipping"
           fi
+
+  # ============================================
+  # SLACK FAILURE NOTIFICATION
+  # Outermost owner for scan alerts — covers build-ghcr, vulnerability-scan,
+  # and scout. Uses always() to fire even when scout is skipped (scout_enabled=false).
+  # The nested reusable-vulnerability-scan call passes nested:true above, so its
+  # scheduled auto-notify is suppressed and THIS job owns the alert (no double-post, D4).
+  # ============================================
+  notify:
+    needs: [build-ghcr, vulnerability-scan, scout]
+    if: ${{ always() && contains(needs.*.result, 'failure') && inputs.slack_webhook_env_var != '' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Verify webhook env var is set
+        env:
+          WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
+        run: |
+          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+            echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
+            exit 1
+          fi
+
+      - name: Notify Slack on failure
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_COLOR: failure
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker scan failed on ${{ github.ref_name }} (${{ github.sha }})"
+          SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_USERNAME: liquibot
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }}"
+          SLACK_LINK_NAMES: true

--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -796,22 +796,37 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Verify webhook env var is set
+      - name: Resolve Slack webhook
+        id: webhook
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          # The var name is caller-controlled: validate name and value shape, and pass the
+          # webhook as a step output (random-delimiter heredoc) — never into GITHUB_ENV.
+          if ! printf '%s' "$WEBHOOK_ENV_VAR" | grep -qE '^[A-Z][A-Z0-9_]{0,127}$'; then
+            echo "::error::Invalid slack_webhook_env_var name: $WEBHOOK_ENV_VAR"
+            exit 1
+          fi
           WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
           if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
-          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
+          if ! printf '%s' "$WEBHOOK_VALUE" | grep -qE '^https://hooks\.slack\.com/[A-Za-z0-9/_+-]+$'; then
+            echo "::error::$WEBHOOK_ENV_VAR does not look like a Slack webhook URL"
+            exit 1
+          fi
+          DELIM="WEBHOOK_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "url<<$DELIM"
+            echo "$WEBHOOK_VALUE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.webhook.outputs.url }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Vulnerability scan failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -81,6 +81,21 @@ on:
         required: false
         type: string
         default: 'docker/.trivyignore'
+      notify:
+        description: 'Force a Slack alert from THIS workflow on failure regardless of event. Scheduled standalone runs auto-notify already; set true only to force it on a non-scheduled direct call.'
+        required: false
+        type: boolean
+        default: false
+      nested:
+        description: 'Set true when called nested inside reusable-docker-scan so the scheduled-event auto-notify is suppressed and the outer workflow owns the alert. Standalone callers leave this false.'
+        required: false
+        type: boolean
+        default: false
+      slack_webhook_env_var:
+        description: 'Vault env-var name holding the Slack webhook URL for failure alerts. Defaults to #docker-builds. Pass an empty string to disable notifications.'
+        required: false
+        type: string
+        default: 'DOCKER_SLACK_WEBHOOK_URL'
     outputs:
       total_vulnerabilities:
         description: 'Total HIGH/CRITICAL vulnerability count'
@@ -751,3 +766,53 @@ jobs:
           echo "**Total batches dispatched**: $BATCH_NUM ($FAILED failed)" >> "$GITHUB_STEP_SUMMARY"
           echo "Dispatch complete: $BATCH_NUM batch(es), $FAILED failure(s)"
           exit 0  # Never fail the parent scan
+
+  # ============================================
+  # SLACK FAILURE NOTIFICATION
+  # Fires on failure when EITHER notify=true OR this is a scheduled standalone run
+  # (github.event_name == 'schedule') — so scheduled scans (trivy-scan-published-images,
+  # build-secure-distribution) alert with zero caller config. When nested inside
+  # reusable-docker-scan.yml the caller passes nested=true, which suppresses the
+  # scheduled auto-notify so the outer workflow owns the alert (no double-post, D4).
+  # ============================================
+  notify:
+    needs: [vulnerability-scan]
+    if: failure() && (inputs.notify || (github.event_name == 'schedule' && !inputs.nested)) && inputs.slack_webhook_env_var != ''
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Verify webhook env var is set
+        env:
+          WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
+        run: |
+          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+            echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
+            exit 1
+          fi
+
+      - name: Notify Slack on failure
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_COLOR: failure
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Vulnerability scan failed on ${{ github.ref_name }} (${{ github.sha }})"
+          SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_USERNAME: liquibot
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }}"
+          SLACK_LINK_NAMES: true

--- a/.github/workflows/reusable-vulnerability-scan.yml
+++ b/.github/workflows/reusable-vulnerability-scan.yml
@@ -800,15 +800,18 @@ jobs:
         env:
           WEBHOOK_ENV_VAR: ${{ inputs.slack_webhook_env_var }}
         run: |
-          if [ -z "${{ env[inputs.slack_webhook_env_var] }}" ]; then
+          # Resolve via shell indirection — a dynamic env[...] template lookup is caller-controlled (CodeQL code-injection)
+          WEBHOOK_VALUE="${!WEBHOOK_ENV_VAR}"
+          if [ -z "$WEBHOOK_VALUE" ]; then
             echo "::error::Slack webhook env $WEBHOOK_ENV_VAR resolved empty — check /vault/liquibase contains this key"
             exit 1
           fi
+          echo "RESOLVED_SLACK_WEBHOOK=$WEBHOOK_VALUE" >> "$GITHUB_ENV"
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
-          SLACK_WEBHOOK: ${{ env[inputs.slack_webhook_env_var] }}
+          SLACK_WEBHOOK: ${{ env.RESOLVED_SLACK_WEBHOOK }}
           SLACK_COLOR: failure
           SLACK_TITLE: "❌ ${{ github.repository }} ❌ Vulnerability scan failed on ${{ github.ref_name }} (${{ github.sha }})"
           SLACK_MESSAGE: "View run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## The problem

`liquibase/docker` is being archived (TECHOPS-366). Its CI was what fed **#docker-builds** with Docker build failures and vulnerability-scan results. After the Dockerfile migration (TECHOPS-314), those workflows run in the product repos via these reusable workflows — and today they notify **no one**. A broken build or a failing scan would go silent.

## What this does

Adds Slack **notify** wiring to the reusable Docker workflows so failures post to **#docker-builds**, defined once here so every product repo (current and future) inherits it with **zero caller config**. Everything lives in `build-logic` — **single PR, no product-repo changes required.**

- `reusable-docker-build.yml` — notify on build/release failure.
- `reusable-docker-scan.yml` — notify on scan-pipeline failure (owns the alert for that path).
- `reusable-vulnerability-scan.yml` — notify on failure when **either** `notify: true` **or** the run is a **scheduled** standalone scan (`github.event_name == 'schedule'`). A new `nested` input (set `true` only by `reusable-docker-scan`'s nested call) suppresses the scheduled auto-notify on the nested path so a scan posts **exactly once**.

Implements **[TECHOPS-588](https://datical.atlassian.net/browse/TECHOPS-588)**.

### Routing outcome (zero caller config)

| Caller | Event | Posts to #docker-builds? |
|--------|-------|--------------------------|
| `docker-release.yml` → `reusable-docker-build` | release build failure | ✅ |
| `docker-scan.yml` → `reusable-docker-scan` | scan-pipeline failure | ✅ (outer owns it; nested vuln-scan suppressed → no double-post) |
| `trivy-scan-published-images.yml` (Community + Secure) | scheduled | ✅ auto (schedule-gated) |
| `build-secure-distribution.yml` | scheduled | ✅ auto (scheduled Secure build) |
| `build-qa-docker.yml` (Community + Secure) | workflow_dispatch | 🔇 mute (not scheduled) |

### Design notes

- **Routing rule = the input default + the schedule gate.** `slack_webhook_env_var` defaults to `DOCKER_SLACK_WEBHOOK_URL` (the existing #docker-builds webhook in `/vault/liquibase`); scheduled scans self-select via `github.event_name`. New repos inherit both with no config.
- **No new secret.** Reuses the existing AWS OIDC → `/vault/liquibase` plumbing and the same webhook `liquibase/docker` used. `id-token: write` scoped to the notify jobs only.
- **No double-post.** The nested `reusable-docker-scan` → `reusable-vulnerability-scan` call passes `nested: true`; the outer scan owns the alert.
- **rtCamp** pinned to `e31e87e0…` (v2.3.3) — the SHA already used in this repo. Notify replicates `liquibase/docker`'s `trivy.yml` `notify-failure` job.

### Validation

- [x] `actionlint` clean — no new findings (4 pre-existing shellcheck findings in `reusable-docker-scan.yml` are unchanged and predate this PR).
- [x] Fresh-context adversarial review — pass, 0 critical; call graph confirms single-post; vault/secret resolution + `id-token` scope verified.
- [ ] **Human gate:** live `workflow_dispatch`/scheduled dry-run posting a test message to #docker-builds (needs vault/OIDC).
- _No unit tests apply — gate is actionlint + the dry-run._

### Before merge

- Run the dry-run and confirm a message lands in #docker-builds.
- End-to-end proof of a *real* failure posting depends on TECHOPS-314 having migrated the Dockerfiles; routing validates independently via dry-run.


[TECHOPS-588]: https://datical.atlassian.net/browse/TECHOPS-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ